### PR TITLE
Check the cache before returning a really large bag

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -52,8 +52,9 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
 
         get {
           parameter('version.as[String] ?) {
-            case None                => getLatestBag(bagId = bagId)
-            case Some(versionString) => getBag(bagId = bagId, versionString = versionString)
+            case None => getLatestBag(bagId = bagId)
+            case Some(versionString) =>
+              getBag(bagId = bagId, versionString = versionString)
           }
         }
       }
@@ -62,8 +63,9 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
 
   private def getLatestBag(bagId: BagId): Route =
     getLatestVersion(bagId) match {
-      case Left(route)          => route
-      case Right(latestVersion) => getBag(bagId, versionString = latestVersion.toString)
+      case Left(route) => route
+      case Right(latestVersion) =>
+        getBag(bagId, versionString = latestVersion.toString)
     }
 
   /** Some of the bags are very large (Chemist & Druggist is ~180MB for the manifest
@@ -94,7 +96,8 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
               redirectionType = StatusCodes.Found
             )
 
-          case Left(_) => lookupBag(bagId = bagId, versionString = versionString)
+          case Left(_) =>
+            lookupBag(bagId = bagId, versionString = versionString)
         }
 
       case _ => lookupBag(bagId = bagId, versionString = versionString)

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -1,16 +1,19 @@
 package uk.ac.wellcome.platform.storage.bags.api
 
-import java.net.URLDecoder
+import java.net.{URL, URLDecoder}
 import java.nio.charset.StandardCharsets
 
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.storage.LargeResponses
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.platform.archive.common.storage.services.S3ObjectExists
 import uk.ac.wellcome.platform.storage.bags.api.responses.{
   LookupBag,
   LookupBagVersions
@@ -48,12 +51,49 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
         )
 
         get {
-          parameter('version.as[String] ?) { maybeVersion =>
-            lookupBag(bagId = bagId, maybeVersion = maybeVersion)
+          parameter('version.as[String] ?) {
+            case None => lookupBag(bagId = bagId, maybeVersion = None)
+
+            case Some(versionString) => getBag(bagId = bagId, versionString = versionString)
           }
         }
       }
     )
+  }
+
+  /** Some of the bags are very large (Chemist & Druggist is ~180MB for the manifest
+    * alone).  If we've already cached a copy of this bag in S3, we know this bag
+    * is big and we won't be able to return it in time.  Return a pre-signed URL
+    * for the cached response.
+    *
+    * If the response hasn't been cached yet, fetch a response directly from VHS.
+    *
+    */
+  private def getBag(bagId: BagId, versionString: String): Route = {
+    val etag = createEtag(bagId = bagId, versionString = versionString)
+
+    val cacheLocation = prefix.asLocation(etag.value)
+
+    implicit val s3Client: AmazonS3 = s3Uploader.s3Client
+    import S3ObjectExists._
+
+    cacheLocation.exists match {
+      case Right(true) =>
+        s3Uploader.getPresignedGetURL(
+          location = cacheLocation,
+          expiryLength = cacheDuration
+        ) match {
+          case Right(url: URL) =>
+            redirect(
+              uri = Uri(url.toString),
+              redirectionType = StatusCodes.Found
+            )
+
+          case Left(_) => lookupBag(bagId = bagId, maybeVersion = Some(versionString))
+        }
+
+      case _ => lookupBag(bagId = bagId, maybeVersion = Some(versionString))
+    }
   }
 
   private def decodeExternalIdentifier(

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import uk.ac.wellcome.monitoring.typesafe.MetricsBuilder
 import uk.ac.wellcome.platform.archive.common.config.builders._
+import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.http.{
   HttpMetrics,
   WellcomeHttpApp
@@ -60,6 +61,8 @@ object Main extends WellcomeTypesafeApp {
     )
 
     val router: BagsApi = new BagsApi {
+      override val httpServerConfig: HTTPServerConfig =
+        HTTPServerBuilder.buildHTTPServerConfig(config)
       override implicit val ec: ExecutionContext = ecMain
       override val contextURL: URL = contextURLMain
       override val storageManifestDao: StorageManifestDao =

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
@@ -2,42 +2,91 @@ package uk.ac.wellcome.platform.storage.bags.api.responses
 
 import java.net.URL
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.ETag
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
+import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.http.models.{
   InternalServerErrorResponse,
   UserErrorResponse
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.storage.bags.api.models.ResponseDisplayBag
-import uk.ac.wellcome.storage.NoVersionExistsError
+import uk.ac.wellcome.storage.{NoMaximaValueError, NoVersionExistsError}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 trait LookupBag extends Logging with ResponseBase {
+  val httpServerConfig: HTTPServerConfig
   val contextURL: URL
+
   val storageManifestDao: StorageManifestDao
 
   implicit val ec: ExecutionContext
 
-  def lookupBag(bagId: BagId, maybeVersion: Option[String]): Route = {
-    val result = maybeVersion match {
-      case None => storageManifestDao.getLatest(bagId)
+  def createLookupBagUrl(bagId: BagId, version: BagVersion): Uri = {
+    val baseUri = Uri(httpServerConfig.externalBaseURL.toString)
 
-      case Some(versionString) =>
-        parseVersion(versionString) match {
-          case Success(version) =>
-            storageManifestDao.get(bagId, version = version)
-          case Failure(_) => Left(NoVersionExistsError())
-        }
+    val newPath = baseUri.path / "bags" / bagId.space.toString / bagId.externalIdentifier.toString
+
+    val newParams: Map[String, String] = baseUri.query().toMap ++ Map("version" -> version.toString)
+    val newQuery: Query = Query(newParams)
+
+    baseUri
+      .withPath(newPath)
+      .withQuery(newQuery)
+  }
+
+  def lookupBag(bagId: BagId, maybeVersion: Option[String]): Route =
+    maybeVersion match {
+      case None                => redirectToLatestVersion(bagId)
+      case Some(versionString) => lookupVersionOfBag(bagId, versionString = versionString)
+    }
+
+  private def redirectToLatestVersion(bagId: BagId): Route = {
+    storageManifestDao.getLatestVersion(bagId) match {
+      case Right(version) =>
+        redirect(
+          uri = createLookupBagUrl(bagId, version = version),
+          redirectionType = StatusCodes.Found
+        )
+
+      case Left(_: NoMaximaValueError) =>
+        complete(
+          NotFound -> UserErrorResponse(
+            context = contextURL,
+            statusCode = StatusCodes.NotFound,
+            description = s"Storage manifest $bagId not found"
+          )
+        )
+
+      case Left(readError) =>
+        error(
+          s"Error while trying to find the latest version of $bagId",
+          readError.e
+        )
+        complete(
+          InternalServerError -> InternalServerErrorResponse(
+            context = contextURL,
+            statusCode = StatusCodes.InternalServerError
+          )
+        )
+    }
+  }
+
+  private def lookupVersionOfBag(bagId: BagId, versionString: String): Route = {
+    val result = parseVersion(versionString) match {
+      case Success(version) =>
+        storageManifestDao.get(bagId, version = version)
+      case Failure(_) => Left(NoVersionExistsError())
     }
 
     result match {
@@ -54,22 +103,17 @@ trait LookupBag extends Logging with ResponseBase {
         }
 
       case Left(_: NoVersionExistsError) =>
-        val errorMessage = maybeVersion match {
-          case Some(version) =>
-            s"Storage manifest $bagId version $version not found"
-          case None => s"Storage manifest $bagId not found"
-        }
-
         complete(
           NotFound -> UserErrorResponse(
             context = contextURL,
             statusCode = StatusCodes.NotFound,
-            description = errorMessage
+            description = s"Storage manifest $bagId $versionString not found"
           )
         )
+
       case Left(storageError) =>
         error(
-          s"Error while trying to look up $bagId v = $maybeVersion",
+          s"Error while trying to look up bagId=$bagId version=$versionString",
           storageError.e
         )
         complete(

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
@@ -82,6 +82,9 @@ trait LookupBag extends Logging with ResponseBase {
     }
   }
 
+  def createEtag(bagId: BagId, versionString: String): ETag =
+    ETag(s"$bagId/$versionString")
+
   private def lookupVersionOfBag(bagId: BagId, versionString: String): Route = {
     val result = parseVersion(versionString) match {
       case Success(version) =>
@@ -89,10 +92,10 @@ trait LookupBag extends Logging with ResponseBase {
       case Failure(_) => Left(NoVersionExistsError())
     }
 
+    val etag = createEtag(bagId = bagId, versionString = versionString)
+
     result match {
       case Right(storageManifest) =>
-        val etag = ETag(storageManifest.idWithVersion)
-
         respondWithHeaders(etag) {
           complete(
             ResponseDisplayBag(

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -57,8 +57,7 @@ class LookupBagApiTest
           whenGetRequestReady(s"$baseUrl/bags/$bagId") { response =>
             assertIsUserErrorResponse(
               response,
-              description =
-                s"Storage manifest $bagId not found",
+              description = s"Storage manifest $bagId not found",
               statusCode = StatusCodes.NotFound,
               label = "Not Found"
             )
@@ -86,7 +85,8 @@ class LookupBagApiTest
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>
-          val url = s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
+          val url =
+            s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
 
           whenGetRequestReady(url) { response =>
             response.status shouldBe StatusCodes.OK
@@ -120,7 +120,8 @@ class LookupBagApiTest
           maxResponseByteLength = 1000
         ) {
           case (_, metrics, baseUrl) =>
-            val url = s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
+            val url =
+              s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
 
             whenGetRequestReady(url) { response =>
               response.status shouldBe StatusCodes.TemporaryRedirect
@@ -155,7 +156,8 @@ class LookupBagApiTest
           maxResponseByteLength = 1000
         ) {
           case (_, metrics, baseUrl) =>
-            val url = s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
+            val url =
+              s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
 
             (1 to 3).foreach { _ =>
               whenGetRequestReady(url) { response =>
@@ -284,14 +286,18 @@ class LookupBagApiTest
   describe("returns a 404 Not Found for missing bags") {
     it("if you ask for a bag ID in the wrong space") {
       val storageManifest = createStorageManifest
-      val badId = s"${storageManifest.space}123/${storageManifest.id.externalIdentifier}"
+      val badId =
+        s"${storageManifest.space}123/${storageManifest.id.externalIdentifier}"
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>
-          whenGetRequestReady(s"$baseUrl/bags/$badId?version=${storageManifest.version}") { response =>
+          whenGetRequestReady(
+            s"$baseUrl/bags/$badId?version=${storageManifest.version}"
+          ) { response =>
             assertIsUserErrorResponse(
               response,
-              description = s"Storage manifest $badId ${storageManifest.version} not found",
+              description =
+                s"Storage manifest $badId ${storageManifest.version} not found",
               statusCode = StatusCodes.NotFound,
               label = "Not Found"
             )
@@ -333,8 +339,7 @@ class LookupBagApiTest
             response =>
               assertIsUserErrorResponse(
                 response,
-                description =
-                  s"Storage manifest $bagId $badVersion not found",
+                description = s"Storage manifest $bagId $badVersion not found",
                 statusCode = StatusCodes.NotFound,
                 label = "Not Found"
               )

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.storage.bags.api
 
 import java.time.format.DateTimeFormatter
 
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.{ETag, Location}
 import io.circe.optics.JsonPath.root
 import io.circe.parser.parse
@@ -34,7 +34,7 @@ class LookupBagApiTest
     with BagsApiFixture {
 
   describe("finding the latest version of a bag") {
-    it("returns a 302 Redirect to the latest version") {
+    it("returns the latest version") {
       val storageManifest = createStorageManifest
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
@@ -42,15 +42,8 @@ class LookupBagApiTest
           val url = s"$baseUrl/bags/${storageManifest.id}"
 
           whenGetRequestReady(url) { response =>
-            response.status shouldBe StatusCodes.Found
-
-            val location: Location = response.header[Location].get
-            location.uri shouldBe Uri(s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}")
-
-            whenGetRequestReady(location.uri.toString) { redirectedResponse =>
-              withStringEntity(redirectedResponse.entity) {
-                assertJsonMatches(_, storageManifest)
-              }
+            withStringEntity(response.entity) {
+              assertJsonMatches(_, storageManifest)
             }
           }
       }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.storage.bags.api
 
 import java.time.format.DateTimeFormatter
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.model.headers.{ETag, Location}
 import io.circe.optics.JsonPath.root
 import io.circe.parser.parse
@@ -20,7 +20,6 @@ import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.display.fixtures.DisplayJsonHelpers
 import uk.ac.wellcome.platform.storage.bags.api.fixtures.BagsApiFixture
-import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 /** Tests for GET /bags/:space/:id.
   *
@@ -34,91 +33,67 @@ class LookupBagApiTest
     with StorageManifestGenerators
     with BagsApiFixture {
 
-  it("finds the latest version of a bag") {
-    val storageManifest = createStorageManifest
+  describe("finding the latest version of a bag") {
+    it("returns a 302 Redirect to the latest version") {
+      val storageManifest = createStorageManifest
 
-    withConfiguredApp(initialManifests = Seq(storageManifest)) {
-      case (_, metrics, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifest.id.space.underlying}/${storageManifest.id.externalIdentifier.underlying}"
-
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
-
-          withStringEntity(response.entity) {
-            assertJsonMatches(_, storageManifest)
-          }
-
-          val header: ETag = response.header[ETag].get
-          val etagValue = header.etag.value.replace("\"", "")
-
-          etagValue shouldBe storageManifest.idWithVersion
-
-          assertMetricSent(
-            metrics,
-            result = HttpMetricResults.Success
-          )
-        }
-    }
-  }
-
-  it("can return very large responses") {
-    // This is not an exact mechanism!
-    // We can experiment to identify a size which exceeds the maxResponseByteLength
-    val storageManifest = createStorageManifestWithFileCount(fileCount = 100)
-
-    withLocalS3Bucket { bucket =>
-      val prefix = ObjectLocationPrefix(bucket.name, randomAlphanumeric)
-
-      withConfiguredApp(
-        initialManifests = Seq(storageManifest),
-        locationPrefix = prefix,
-        maxResponseByteLength = 1000
-      ) {
-        case (_, metrics, baseUrl) =>
-          val url =
-            s"$baseUrl/bags/${storageManifest.id.space.underlying}/${storageManifest.id.externalIdentifier.underlying}"
+      withConfiguredApp(initialManifests = Seq(storageManifest)) {
+        case (_, _, baseUrl) =>
+          val url = s"$baseUrl/bags/${storageManifest.id}"
 
           whenGetRequestReady(url) { response =>
-            response.status shouldBe StatusCodes.TemporaryRedirect
+            response.status shouldBe StatusCodes.Found
 
-            assertMetricSent(
-              metrics,
-              result = HttpMetricResults.Success
-            )
+            val location: Location = response.header[Location].get
+            location.uri shouldBe Uri(s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}")
 
-            val redirectedUrl = response.header[Location].get.uri.toString()
-
-            whenGetRequestReady(redirectedUrl) { redirectedResponse =>
+            whenGetRequestReady(location.uri.toString) { redirectedResponse =>
               withStringEntity(redirectedResponse.entity) {
                 assertJsonMatches(_, storageManifest)
               }
             }
           }
+      }
+    }
 
+    it("returns a 404 if there are no versions of this bag") {
+      val bagId = createBagId
+
+      withConfiguredApp() {
+        case (_, metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/bags/$bagId") { response =>
+            assertIsUserErrorResponse(
+              response,
+              description =
+                s"Storage manifest $bagId not found",
+              statusCode = StatusCodes.NotFound,
+              label = "Not Found"
+            )
+
+            assertMetricSent(metrics, result = HttpMetricResults.UserError)
+          }
+      }
+    }
+
+    it("returns a 500 if looking up the latest version fails") {
+      withBrokenApp {
+        case (metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/bags/$createBagId") { response =>
+            assertIsInternalServerErrorResponse(response)
+
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+          }
       }
     }
   }
 
-  it("finds a specific version of a bag") {
-    val externalIdentifier = createExternalIdentifier
-    val storageSpace = createStorageSpace
+  describe("looking up an exact version of a bag") {
+    it("returns the bag") {
+      val storageManifest = createStorageManifest
 
-    val manifests = (1 to 5).map { version =>
-      createStorageManifestWith(
-        bagInfo = createBagInfoWith(
-          externalIdentifier = externalIdentifier
-        ),
-        space = storageSpace,
-        version = BagVersion(version)
-      )
-    }
-
-    withConfiguredApp(initialManifests = manifests) {
-      case (_, metrics, baseUrl) =>
-        manifests.foreach { storageManifest =>
-          val url =
-            s"$baseUrl/bags/${storageSpace.underlying}/${externalIdentifier.underlying}?version=${storageManifest.version}"
+      withConfiguredApp(initialManifests = Seq(storageManifest)) {
+        case (_, metrics, baseUrl) =>
+          val url = s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
 
           whenGetRequestReady(url) { response =>
             response.status shouldBe StatusCodes.OK
@@ -130,52 +105,126 @@ class LookupBagApiTest
             val header: ETag = response.header[ETag].get
             val etagValue = header.etag.value.replace("\"", "")
 
-            etagValue shouldBe s"${storageManifest.space}/${storageManifest.info.externalIdentifier}/${storageManifest.version}"
+            etagValue shouldBe storageManifest.idWithVersion
 
             assertMetricSent(
               metrics,
               result = HttpMetricResults.Success
             )
           }
+      }
+    }
+
+    it("returns large responses") {
+      // This is not an exact mechanism!
+      // We can experiment to identify a size which exceeds the maxResponseByteLength
+      val storageManifest = createStorageManifestWithFileCount(fileCount = 100)
+
+      withLocalS3Bucket { bucket =>
+        withConfiguredApp(
+          initialManifests = Seq(storageManifest),
+          locationPrefix = createObjectLocationPrefixWith(bucket.name),
+          maxResponseByteLength = 1000
+        ) {
+          case (_, metrics, baseUrl) =>
+            val url = s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
+
+            whenGetRequestReady(url) { response =>
+              response.status shouldBe StatusCodes.TemporaryRedirect
+
+              assertMetricSent(metrics, result = HttpMetricResults.Success)
+
+              val redirectedUrl = response.header[Location].get.uri.toString()
+
+              whenGetRequestReady(redirectedUrl) { redirectedResponse =>
+                withStringEntity(redirectedResponse.entity) {
+                  assertJsonMatches(_, storageManifest)
+                }
+              }
+            }
         }
+      }
+    }
+
+    it("finds specific versions") {
+      val externalIdentifier = createExternalIdentifier
+      val storageSpace = createStorageSpace
+
+      val manifests = (1 to 5).map { version =>
+        createStorageManifestWith(
+          bagInfo = createBagInfoWith(
+            externalIdentifier = externalIdentifier
+          ),
+          space = storageSpace,
+          version = BagVersion(version)
+        )
+      }
+
+      withConfiguredApp(initialManifests = manifests) {
+        case (_, metrics, baseUrl) =>
+          manifests.foreach { storageManifest =>
+            val url =
+              s"$baseUrl/bags/$storageSpace/$externalIdentifier?version=${storageManifest.version}"
+
+            whenGetRequestReady(url) { response =>
+              response.status shouldBe StatusCodes.OK
+
+              withStringEntity(response.entity) {
+                assertJsonMatches(_, storageManifest)
+              }
+
+              val header: ETag = response.header[ETag].get
+              val etagValue = header.etag.value.replace("\"", "")
+
+              etagValue shouldBe s"$storageSpace/$externalIdentifier/${storageManifest.version}"
+
+              assertMetricSent(
+                metrics,
+                result = HttpMetricResults.Success
+              )
+            }
+          }
+      }
     }
   }
 
-  val storageManifestWithSlash: StorageManifest = createStorageManifestWith(
-    bagInfo = createBagInfoWith(
-      externalIdentifier = ExternalIdentifier("alfa/bravo")
+  describe("looking up a bag with a slash in the external identifier") {
+    val storageManifestWithSlash: StorageManifest = createStorageManifestWith(
+      bagInfo = createBagInfoWith(
+        externalIdentifier = ExternalIdentifier("alfa/bravo")
+      )
     )
-  )
 
-  it("finds a bag with a slash in the external identifier (URL-encoded)") {
-    withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifestWithSlash.id.space.underlying}/alfa%2Fbravo"
+    it("when the identifier is URL encoded") {
+      withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
+        case (_, _, baseUrl) =>
+          val url =
+            s"$baseUrl/bags/${storageManifestWithSlash.id.space}/alfa%2Fbravo?version=${storageManifestWithSlash.version}"
 
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
+          whenGetRequestReady(url) { response =>
+            response.status shouldBe StatusCodes.OK
 
-          withStringEntity(response.entity) {
-            assertJsonMatches(_, storageManifestWithSlash)
+            withStringEntity(response.entity) {
+              assertJsonMatches(_, storageManifestWithSlash)
+            }
           }
-        }
+      }
     }
-  }
 
-  it("finds a bag with a slash in the external identifier (not URL-encoded)") {
-    withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifestWithSlash.id.space.underlying}/alfa/bravo"
+    it("when the identifier is not URL-encoded") {
+      withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
+        case (_, _, baseUrl) =>
+          val url =
+            s"$baseUrl/bags/${storageManifestWithSlash.id.space}/alfa/bravo?version=${storageManifestWithSlash.version}"
 
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
+          whenGetRequestReady(url) { response =>
+            response.status shouldBe StatusCodes.OK
 
-          withStringEntity(response.entity) {
-            assertJsonMatches(_, storageManifestWithSlash)
+            withStringEntity(response.entity) {
+              assertJsonMatches(_, storageManifestWithSlash)
+            }
           }
-        }
+      }
     }
   }
 
@@ -187,7 +236,7 @@ class LookupBagApiTest
     withConfiguredApp(initialManifests = Seq(storageManifest)) {
       case (_, _, baseUrl) =>
         whenGetRequestReady(
-          s"$baseUrl/bags/${storageManifest.id.space.underlying}/${storageManifest.id.externalIdentifier.underlying}"
+          s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version}"
         ) { response =>
           response.status shouldBe StatusCodes.OK
 
@@ -203,36 +252,16 @@ class LookupBagApiTest
   }
 
   describe("returns a 404 Not Found for missing bags") {
-    it("if there are no manifests for this bag ID") {
-      withConfiguredApp() {
-        case (_, metrics, baseUrl) =>
-          val bagId = createBagId
-          whenGetRequestReady(
-            s"$baseUrl/bags/${bagId.space}/${bagId.externalIdentifier}"
-          ) { response =>
-            assertIsUserErrorResponse(
-              response,
-              description = s"Storage manifest $bagId not found",
-              statusCode = StatusCodes.NotFound,
-              label = "Not Found"
-            )
-
-            assertMetricSent(metrics, result = HttpMetricResults.UserError)
-          }
-      }
-    }
-
     it("if you ask for a bag ID in the wrong space") {
       val storageManifest = createStorageManifest
+      val badId = s"${storageManifest.space}123/${storageManifest.id.externalIdentifier}"
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>
-          val badId =
-            s"${storageManifest.space}123/${storageManifest.id.externalIdentifier}"
-          whenGetRequestReady(s"$baseUrl/bags/$badId") { response =>
+          whenGetRequestReady(s"$baseUrl/bags/$badId?version=${storageManifest.version}") { response =>
             assertIsUserErrorResponse(
               response,
-              description = s"Storage manifest $badId not found",
+              description = s"Storage manifest $badId ${storageManifest.version} not found",
               statusCode = StatusCodes.NotFound,
               label = "Not Found"
             )
@@ -248,12 +277,12 @@ class LookupBagApiTest
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>
           whenGetRequestReady(
-            s"$baseUrl/bags/${storageManifest.space}/${storageManifest.id.externalIdentifier}?version=${storageManifest.version.increment}"
+            s"$baseUrl/bags/${storageManifest.id}?version=${storageManifest.version.increment}"
           ) { response =>
             assertIsUserErrorResponse(
               response,
               description =
-                s"Storage manifest ${storageManifest.id} version ${storageManifest.version.increment} not found",
+                s"Storage manifest ${storageManifest.id} ${storageManifest.version.increment} not found",
               statusCode = StatusCodes.NotFound,
               label = "Not Found"
             )
@@ -275,7 +304,7 @@ class LookupBagApiTest
               assertIsUserErrorResponse(
                 response,
                 description =
-                  s"Storage manifest $bagId version $badVersion not found",
+                  s"Storage manifest $bagId $badVersion not found",
                 statusCode = StatusCodes.NotFound,
                 label = "Not Found"
               )

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
+import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   HttpFixtures,
   StorageManifestVHSFixture,
@@ -64,6 +65,7 @@ trait BagsApiFixture
         )
 
         lazy val router: BagsApi = new BagsApi {
+          override val httpServerConfig: HTTPServerConfig = httpServerConfigTest
           override implicit val ec: ExecutionContext = global
           override val contextURL: URL = contextURLTest
           override val storageManifestDao: StorageManifestDao =
@@ -129,6 +131,9 @@ trait BagsApiFixture
     )
 
     val brokenDao = new MemoryStorageManifestDao(versionedStore) {
+      override def getLatestVersion(id: BagId): Either[ReadError, BagVersion] =
+        Left(StoreReadError(new Throwable("BOOM!")))
+
       override def getLatest(
         id: BagId
       ): scala.Either[ReadError, StorageManifest] =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExists.scala
@@ -30,6 +30,7 @@ object S3ObjectExists {
   ) {
     val s3ObjectExists = new S3ObjectExists(s3Client)
 
-    def exists: Either[StoreReadError, Boolean] = s3ObjectExists.exists(objectLocation)
+    def exists: Either[StoreReadError, Boolean] =
+      s3ObjectExists.exists(objectLocation)
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExists.scala
@@ -30,6 +30,6 @@ object S3ObjectExists {
   ) {
     val s3ObjectExists = new S3ObjectExists(s3Client)
 
-    def exists = s3ObjectExists.exists(objectLocation)
+    def exists: Either[StoreReadError, Boolean] = s3ObjectExists.exists(objectLocation)
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
   * It's based on an example from the AWS SDK for Java docs:
   * https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURLJavaSDK.html
   */
-class S3Uploader(implicit s3Client: AmazonS3) {
+class S3Uploader(implicit val s3Client: AmazonS3) {
   import S3ObjectExists._
 
   private val s3StreamStore: S3StreamStore = new S3StreamStore()
@@ -62,7 +62,7 @@ class S3Uploader(implicit s3Client: AmazonS3) {
       )
     } yield result
 
-  private def getPresignedGetURL(
+  def getPresignedGetURL(
     location: ObjectLocation,
     expiryLength: Duration
   ): Either[ReadError, URL] = {


### PR DESCRIPTION
Tentative fix for https://github.com/wellcometrust/platform/issues/4024

Not being able to get some bags out of the API (Chemist & Druggist in particular) has been a source of issues while cleaning up the DDS file shares (because I can't see what's inside the bag!). This patch is an attempt to fix that.

When you request a bag, we check the large response cache, and if a response has already been stored, we pull it straight from the cache. I've added a new "getLatestVersion" method to the storage manifest dao, so we can also do this if you look up the latest version of the bag.

I had to do some fairly major rewiring of the bags API internals to make this work – in particular, the LookupBag trait now assumes you know what the version is already, and working out what the latest version is gets handled by BagsApi instead.

This is probably easier to review if you go commit-by-commit.

---

I don't think this is the final version of this code – it’s an improvement, but still doesn't feel great. If/when we have more time, it'd be good to get more eyes on this code and come up with a better version.