### PR TITLE
Try sharing the Travis cache between jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
+# Travis uses the environment variable to determine the cache: if two jobs
+# have different environment variables, they get different caches.
+# See https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
+#
+# We want to share the Scala/sbt cache between multiple jobs, so we don't
+# have any environment variables attached to the tasks.
+
 jobs:
   include:
     - stage: preflight
-      env: TASK=travis-format
+      script: TASK=travis-format              ./.travis/run_job.py
 
     - stage: libraries
-      env: SBT_PROJECT=common
-    - env: SBT_PROJECT=display
-    - env: SBT_PROJECT=ingests_common
+      script: SBT_PROJECT=common              ./.travis/run_job.py
+    - script: SBT_PROJECT=display             ./.travis/run_job.py
+    - script: SBT_PROJECT=ingests_common      ./.travis/run_job.py
 
     - stage: services
-      env: SBT_PROJECT=ingests
-    - env: SBT_PROJECT=ingests_api
-    - env: SBT_PROJECT=bags_api
-    - env: SBT_PROJECT=bag_register
-    - env: SBT_PROJECT=bag_replicator
-    - env: SBT_PROJECT=bag_root_finder
-    - env: SBT_PROJECT=bag_verifier
-    - env: SBT_PROJECT=bag_unpacker
-    - env: SBT_PROJECT=bag_versioner
-    - env: SBT_PROJECT=replica_aggregator
+      script: SBT_PROJECT=bags_api            ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_register        ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_replicator      ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_root_finder     ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_unpacker        ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_verifier        ./.travis/run_job.py
+    - script: SBT_PROJECT=bag_versioner       ./.travis/run_job.py
+    - script: SBT_PROJECT=ingests             ./.travis/run_job.py
+    - script: SBT_PROJECT=ingests_api         ./.travis/run_job.py
+    - script: SBT_PROJECT=replica_aggregator  ./.travis/run_job.py
 
-    - env: SBT_PROJECT=notifier
-
-    # - env: TASK=bagger-publish
-    # - env: TASK=python_client-test
-
-script:
-  - ./.travis/run_job.py
+    - script: SBT_PROJECT=notifier            ./.travis/run_job.py
 
 cache:
   directories:
@@ -49,8 +50,6 @@ cache:
     - ingests_common/target
     - notifier/target
     - replica_aggregator/target
-
-    - python_client/.tox
 
 stages:
   - preflight


### PR DESCRIPTION
Travis uses the environment variable to determine the cache: if two jobs have different environment variables, they get different caches. See https://docs.travis-ci.com/user/caching/#caches-and-build-matrices

This means every job is having to rebuild the common lib and download dependencies.  This is very inefficient!  Let's try sharing the cache among all Scala jobs and see if that improves build times.

h/t Jamie for spotting this originally