### PR TITLE
Allow getting the latest BagVersion from the storage manifest dao

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
@@ -14,6 +14,9 @@ trait StorageManifestDao {
     HybridStoreEntry[StorageManifest, EmptyMetadata]
   ]
 
+  def getLatestVersion(id: BagId): Either[ReadError, BagVersion] =
+    vhs.store.max(id).map { BagVersion(_) }
+
   def getLatest(id: BagId): Either[ReadError, StorageManifest] =
     vhs.getLatest(id).map { _.identifiedT.t }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTestCases.scala
@@ -203,7 +203,10 @@ trait StorageManifestDaoTestCases[Context]
             dao.put(manifest) shouldBe a[Right[_, _]]
           }
 
-          dao.getLatestVersion(storageManifest.id).right.value shouldBe BagVersion(5)
+          dao
+            .getLatestVersion(storageManifest.id)
+            .right
+            .value shouldBe BagVersion(5)
         }
       }
     }


### PR DESCRIPTION
This is a more efficient lookup than calling listVersions() or getLatest(), because it only has to look in the DynamoDB table, and it doesn't serialise the full storage manifest out of S3.

This is preliminary work for a change to the bags API to allow us to get cached responses from an S3 bucket, rather than fetching a complete response every time.

Another piece spun out of #436.