### PR TITLE
When we read a stream, hash it with all four BagIt checksum algorithms

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/UnreferencedFiles.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/UnreferencedFiles.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.bagit.models
 
+import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA1, SHA256, SHA512}
+
 /** In a bag, we have objects.  Those objects are referred to by a manifest file,
   * which is in turn referred to by a tag manifest file.  But how do we know the
   * tag manifest file is there?
@@ -25,9 +27,9 @@ package uk.ac.wellcome.platform.archive.common.bagit.models
   */
 object UnreferencedFiles {
   val tagManifestFiles: Seq[String] = Seq(
-    "tagmanifest-md5.txt",
-    "tagmanifest-sha1.txt",
-    "tagmanifest-sha256.txt",
-    "tagmanifest-sha512.txt"
+    s"tagmanifest-${MD5.pathRepr}.txt",
+    s"tagmanifest-${SHA1.pathRepr}.txt",
+    s"tagmanifest-${SHA256.pathRepr}.txt",
+    s"tagmanifest-${SHA512.pathRepr}.txt"
   )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
@@ -58,7 +58,8 @@ class TagManifestFileFinder[IS <: InputStream with HasLength](
         // so it happens after the entire bag has been verified.  To verify the bag,
         // we've already had to read the tagmanifest-sha256.txt file, so an error
         // here would be unlikely (but probably not impossible).
-        val checksum = Hasher.hash(is.identifiedT)
+        val checksum = Hasher
+          .hash(is.identifiedT)
           .get
           .getChecksumValue(algorithm)
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
@@ -4,10 +4,7 @@ import java.io.InputStream
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
-import uk.ac.wellcome.platform.archive.common.verify.{
-  Hasher,
-  HashingAlgorithm
-}
+import uk.ac.wellcome.platform.archive.common.verify.{Hasher, HashingAlgorithm}
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming.HasLength
 import uk.ac.wellcome.storage.{
@@ -58,9 +55,10 @@ class TagManifestFileFinder[IS <: InputStream with HasLength](
         // here would be unlikely (but probably not impossible).
         val checksum = Hasher.hash(is.identifiedT) match {
           case Success(hashResult) => hashResult.getChecksumValue(algorithm)
-          case Failure(err)        => throw new RuntimeException(
-            s"Error reading tag manifest: $err"
-          )
+          case Failure(err) =>
+            throw new RuntimeException(
+              s"Error reading tag manifest: $err"
+            )
         }
 
         Some(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -32,22 +32,6 @@ case object Checksum extends Logging {
   }
 }
 
-sealed trait HashingAlgorithm {
-  val value: String
-  val pathRepr: String
-  override def toString: String = value
-}
-
-case object SHA256 extends HashingAlgorithm {
-  val value = MessageDigestAlgorithms.SHA_256
-  val pathRepr = "sha256"
-}
-
-case object MD5 extends HashingAlgorithm {
-  val value = MessageDigestAlgorithms.MD5
-  val pathRepr = "md5"
-}
-
 case class ChecksumValue(value: String) {
   override def toString: String = value
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -7,7 +7,6 @@ import grizzled.slf4j.Logging
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.codec.digest.DigestUtils.{getDigest, updateDigest}
-import org.apache.commons.codec.digest.MessageDigestAlgorithms
 
 import scala.util.Try
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -22,7 +22,8 @@ case object Checksum extends Logging {
     algorithm: HashingAlgorithm
   ): Try[Checksum] = {
     debug(s"Creating Checksum for $inputStream with  $algorithm")
-    val checksum = Hasher.hash(inputStream)
+    val checksum = Hasher
+      .hash(inputStream)
       .map { _.getChecksumValue(algorithm) }
       .map { Checksum(algorithm, _) }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
@@ -1,0 +1,56 @@
+package uk.ac.wellcome.platform.archive.common.verify
+
+import java.io.InputStream
+import java.security.MessageDigest
+
+import org.apache.commons.codec.binary.Hex
+
+import scala.util.Try
+
+case class HashingResult(
+  md5: ChecksumValue,
+  sha1: ChecksumValue,
+  sha256: ChecksumValue,
+  sha512: ChecksumValue
+)
+
+object Hasher {
+
+  /** Given an InputStream, read the complete contents and hash it using the four
+    * algorithms suggested by the BagIt spec.
+    *
+    */
+  def hash(inputStream: InputStream): Try[HashingResult] = Try {
+    val digest_MD5: MessageDigest = MessageDigest.getInstance(MD5.value)
+    val digest_SHA1 = MessageDigest.getInstance(SHA1.value)
+    val digest_SHA256 = MessageDigest.getInstance(SHA256.value)
+    val digest_SHA512 = MessageDigest.getInstance(SHA512.value)
+
+    // This implementation is based on MessageDigest.updateDigest(), but rather than
+    // updating a single digest, we update all four at once.
+    val STREAM_BUFFER_LENGTH = 1024
+
+    val buffer = new Array[Byte](STREAM_BUFFER_LENGTH)
+    var read = inputStream.read(buffer, 0, STREAM_BUFFER_LENGTH)
+
+    while (read > -1) {
+      digest_MD5.update(buffer, 0, read)
+      digest_SHA1.update(buffer, 0, read)
+      digest_SHA256.update(buffer, 0, read)
+      digest_SHA512.update(buffer, 0, read)
+
+      read = inputStream.read(buffer, 0, STREAM_BUFFER_LENGTH)
+    }
+    // == MessageDigest.updateDigest() ends ==
+
+    HashingResult(
+      md5 = asChecksumValue(digest_MD5),
+      sha1 = asChecksumValue(digest_SHA1),
+      sha256 = asChecksumValue(digest_SHA256),
+      sha512 = asChecksumValue(digest_SHA512),
+    )
+  }
+
+  private def asChecksumValue(digest: MessageDigest): ChecksumValue =
+    ChecksumValue(Hex.encodeHexString(digest.digest))
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
@@ -12,7 +12,15 @@ case class HashingResult(
   sha1: ChecksumValue,
   sha256: ChecksumValue,
   sha512: ChecksumValue
-)
+) {
+  def getChecksumValue(algorithm: HashingAlgorithm): ChecksumValue =
+    algorithm match {
+      case MD5    => md5
+      case SHA1   => sha1
+      case SHA256 => sha256
+      case SHA512 => sha512
+    }
+}
 
 object Hasher {
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Hasher.scala
@@ -55,7 +55,7 @@ object Hasher {
       md5 = asChecksumValue(digest_MD5),
       sha1 = asChecksumValue(digest_SHA1),
       sha256 = asChecksumValue(digest_SHA256),
-      sha512 = asChecksumValue(digest_SHA512),
+      sha512 = asChecksumValue(digest_SHA512)
     )
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/HashingAlgorithm.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/HashingAlgorithm.scala
@@ -15,7 +15,6 @@ sealed trait HashingAlgorithm {
   * See https://tools.ietf.org/html/rfc8493#section-2.4
   *
   */
-
 case object SHA512 extends HashingAlgorithm {
   val value: String = MessageDigestAlgorithms.SHA_512
   val pathRepr = "sha512"

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/HashingAlgorithm.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/HashingAlgorithm.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.archive.common.verify
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms
+
+sealed trait HashingAlgorithm {
+  val value: String
+  val pathRepr: String
+  override def toString: String = value
+}
+
+/** The BagIt spec requires that BagIt parsers support SHA-256 and SHA-512.
+  * It additionally mentions the MD5 and SHA-1 algorithms, but these should
+  * not be used for new bags.
+  *
+  * See https://tools.ietf.org/html/rfc8493#section-2.4
+  *
+  */
+
+case object SHA512 extends HashingAlgorithm {
+  val value: String = MessageDigestAlgorithms.SHA_512
+  val pathRepr = "sha512"
+}
+
+case object SHA256 extends HashingAlgorithm {
+  val value: String = MessageDigestAlgorithms.SHA_256
+  val pathRepr = "sha256"
+}
+
+case object SHA1 extends HashingAlgorithm {
+  val value: String = MessageDigestAlgorithms.SHA_1
+  val pathRepr = "sha1"
+}
+
+case object MD5 extends HashingAlgorithm {
+  val value: String = MessageDigestAlgorithms.MD5
+  val pathRepr = "md5"
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/HasherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/HasherTest.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.archive.common.verify
+
+import java.io.{FilterInputStream, InputStream}
+
+import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.storage.streaming.Codec._
+
+class HasherTest extends FunSpec with Matchers with EitherValues with TryValues {
+  it("correctly hashes a string") {
+    val input = "Hello world"
+    val inputStream = stringCodec.toStream(input).right.value
+
+    val result = Hasher.hash(inputStream)
+
+    // Expected values obtained by searching "md5 Hello World" in DuckDuckGo,
+    // and similar for other algorithms.
+    result.success.value shouldBe HashingResult(
+      md5 = ChecksumValue("3e25960a79dbc69b674cd4ec67a72c62"),
+      sha1 = ChecksumValue("7b502c3a1f48c8609ae212cdfb639dee39673f5e"),
+      sha256 = ChecksumValue("64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"),
+      sha512 = ChecksumValue("b7f783baed8297f0db917462184ff4f08e69c2d5e5f79a942600f9725f58ce1f29c18139bf80b06c0fff2bdd34738452ecf40c488c22a7e3d80cdf6f9c1c0d47")
+    )
+  }
+
+  // This test is ensuring we cross the STREAM_BUFFER_LENGTH boundary.
+  it("hashes a string that is more than 1024 bytes long") {
+    val input = "Hello world " * 1024
+    val inputStream = stringCodec.toStream(input).right.value
+
+    val result = Hasher.hash(inputStream)
+
+    // Expected values obtained by using the Python hashlib library.
+    result.success.value shouldBe HashingResult(
+      md5 = ChecksumValue("6a2d892099d210d049be9276c2659c17"),
+      sha1 = ChecksumValue("dc92fd07cfbfbb450eb0703fdea3ef9154e38db1"),
+      sha256 = ChecksumValue("54395c09aa8014ff92197da81f9d38d091d3674094c3c6890fafd0704670b34d"),
+      sha512 = ChecksumValue("0516df5e826b287ef848c2362c72796475ced84d6bf41eeea920c0c8f053848f16352bed4ef951a7c8af1e7fb2b2525833dcbb538075fdafbb72f9c4627893f2")
+    )
+  }
+
+  it("returns a failure if it can't read the input stream") {
+    val exception = new Throwable("BOOM!")
+
+    class BrokenStream(is: InputStream) extends FilterInputStream(is) {
+      override def read(b: Array[Byte], off: Int, len: Int): Int = throw exception
+    }
+
+    val inputStream = new BrokenStream(
+      is = stringCodec.toStream("Hello world").right.value
+    )
+
+    val result = Hasher.hash(inputStream)
+    result.failed.get shouldBe exception
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/HasherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/HasherTest.scala
@@ -5,7 +5,11 @@ import java.io.{FilterInputStream, InputStream}
 import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.storage.streaming.Codec._
 
-class HasherTest extends FunSpec with Matchers with EitherValues with TryValues {
+class HasherTest
+    extends FunSpec
+    with Matchers
+    with EitherValues
+    with TryValues {
   it("correctly hashes a string") {
     val input = "Hello world"
     val inputStream = stringCodec.toStream(input).right.value
@@ -17,8 +21,12 @@ class HasherTest extends FunSpec with Matchers with EitherValues with TryValues 
     result.success.value shouldBe HashingResult(
       md5 = ChecksumValue("3e25960a79dbc69b674cd4ec67a72c62"),
       sha1 = ChecksumValue("7b502c3a1f48c8609ae212cdfb639dee39673f5e"),
-      sha256 = ChecksumValue("64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"),
-      sha512 = ChecksumValue("b7f783baed8297f0db917462184ff4f08e69c2d5e5f79a942600f9725f58ce1f29c18139bf80b06c0fff2bdd34738452ecf40c488c22a7e3d80cdf6f9c1c0d47")
+      sha256 = ChecksumValue(
+        "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"
+      ),
+      sha512 = ChecksumValue(
+        "b7f783baed8297f0db917462184ff4f08e69c2d5e5f79a942600f9725f58ce1f29c18139bf80b06c0fff2bdd34738452ecf40c488c22a7e3d80cdf6f9c1c0d47"
+      )
     )
   }
 
@@ -33,8 +41,12 @@ class HasherTest extends FunSpec with Matchers with EitherValues with TryValues 
     result.success.value shouldBe HashingResult(
       md5 = ChecksumValue("6a2d892099d210d049be9276c2659c17"),
       sha1 = ChecksumValue("dc92fd07cfbfbb450eb0703fdea3ef9154e38db1"),
-      sha256 = ChecksumValue("54395c09aa8014ff92197da81f9d38d091d3674094c3c6890fafd0704670b34d"),
-      sha512 = ChecksumValue("0516df5e826b287ef848c2362c72796475ced84d6bf41eeea920c0c8f053848f16352bed4ef951a7c8af1e7fb2b2525833dcbb538075fdafbb72f9c4627893f2")
+      sha256 = ChecksumValue(
+        "54395c09aa8014ff92197da81f9d38d091d3674094c3c6890fafd0704670b34d"
+      ),
+      sha512 = ChecksumValue(
+        "0516df5e826b287ef848c2362c72796475ced84d6bf41eeea920c0c8f053848f16352bed4ef951a7c8af1e7fb2b2525833dcbb538075fdafbb72f9c4627893f2"
+      )
     )
   }
 
@@ -42,7 +54,8 @@ class HasherTest extends FunSpec with Matchers with EitherValues with TryValues 
     val exception = new Throwable("BOOM!")
 
     class BrokenStream(is: InputStream) extends FilterInputStream(is) {
-      override def read(b: Array[Byte], off: Int, len: Int): Int = throw exception
+      override def read(b: Array[Byte], off: Int, len: Int): Int =
+        throw exception
     }
 
     val inputStream = new BrokenStream(


### PR DESCRIPTION
This lays some early groundwork for https://github.com/wellcomecollection/platform/issues/4277, which I'd like to see done sooner rather than later

In particular, when we read a file out of S3, we create MD5/SHA1/SHA256/SHA512 checksums all in one go, rather than having to read it four times.

Right now we don't use the extra values anywhere, but later we can read the other manifests, and start comparing the checksums they contain from the values we get from S3.