### PR TITLE
Produce a more helpful error message upon "Access Denied"

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -195,10 +195,23 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
     error: UnpackerError
   ): Option[String] =
     error match {
+
+      // An Access Denied error from S3 could be (at least) two scenarios:
+      //
+      //    - The object exists, but it's in a bucket we don't have Get* permissions.
+      //
+      //    - The object doesn't exist, and it's in a bucket where we have Get* but not
+      //      List* permissions.  In that case, S3 will give a generic error rather than give
+      //      away information about what's in the bucket.
+      //
+      // In practice, we've seen the latter case a couple of times, so we want the user
+      // to check the object really exists when they get this error, not chalk it up to
+      // an IAM error that devs need to fix.  It *might* be something they can fix themselves.
+      //
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
           if exc.getMessage.startsWith("Access Denied") =>
         Some(
-          s"Access denied while trying to read ${formatLocation(srcLocation)}"
+          s"Error reading ${formatLocation(srcLocation)}: either it doesn't exist, or the unpacker doesn't have permission to read it"
         )
 
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -141,7 +141,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
               )
 
             assertIsError(result) { maybeMessage =>
-              maybeMessage.get shouldBe s"Access denied while trying to read s3://${archiveLocation.namespace}/${archiveLocation.path}"
+              maybeMessage.get shouldBe s"Error reading s3://${archiveLocation.namespace}/${archiveLocation.path}: either it doesn't exist, or the unpacker doesn't have permission to read it"
             }
           }
         }


### PR DESCRIPTION
It might be that we have GetObject permission in that bucket, but it doesn't exist and S3 won't give us the more specific error.  This is an error that the user can fix themselves, but only if they know it might be permissions *or* a non-existent object.

The easy bit of https://github.com/wellcomecollection/platform/issues/4310