### PR TITLE
Fix OOM issues in the bag unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
@@ -39,10 +39,7 @@ trait S3StreamReader
   // the stream.
   //
 
-  // 1 KB = 1024 bytes
-  // 1 MB = 1 KB * 1024 = 1024 * 1024
-  // 128 MB = 128 MB * 1024 = 128 * 1024 * 1024
-  protected val bufferSize: Long = 128 * 1024 * 1024
+  protected val bufferSize: Long
 
   private class S3StreamEnumeration(
     location: ObjectLocation,

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
@@ -93,22 +93,20 @@ class S3StreamReader(bufferSize: Long)(implicit s3Client: AmazonS3)
       //
       // e.g. GetObject will return "The bucket name was invalid" rather than
       // "Bad Request".
-      val getRequest =
-        new GetObjectRequest(location.namespace, location.path)
-          .withRange(0, 0)
+      //
+      val getRequest = new GetObjectRequest(location.namespace, location.path)
 
       val s3Object = s3Client.getObject(getRequest)
       val metadata = s3Object.getObjectMetadata
       val contentLength = metadata.getContentLength
 
-      // Read the (empty) stream to avoid getting a warning:
+      // Abort the stream to avoid getting a warning:
       //
       //    Not all bytes were read from the S3ObjectInputStream, aborting
       //    HTTP connection. This is likely an error and may result in
       //    sub-optimal behavior.
       //
-      IOUtils.toByteArray(s3Object.getObjectContent)
-
+      s3Object.getObjectContent.abort()
       s3Object.getObjectContent.close()
 
       val streams = new S3StreamEnumeration(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReader.scala
@@ -35,7 +35,7 @@ import scala.util.{Failure, Success, Try}
   *
   */
 class S3StreamReader(bufferSize: Long)(implicit s3Client: AmazonS3)
-  extends Readable[ObjectLocation, InputStreamWithLengthAndMetadata]
+    extends Readable[ObjectLocation, InputStreamWithLengthAndMetadata]
     with Logging {
 
   private class S3StreamEnumeration(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -22,14 +22,7 @@ class S3Unpacker(
 )(implicit s3Client: AmazonS3) extends Unpacker {
   private val s3StreamStore = new S3StreamStore()
 
-  val readerClient: AmazonS3 = s3Client
-  val readerBufferSize: Long = bufferSize
-
-  val reader: S3StreamReader = new S3StreamReader {
-    override implicit val s3Client: AmazonS3 = readerClient
-
-    override protected val bufferSize: Long = readerBufferSize
-  }
+  val reader: S3StreamReader = new S3StreamReader(bufferSize = bufferSize)
 
   override def get(
     location: ObjectLocation

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
+import org.apache.commons.io.FileUtils
 import uk.ac.wellcome.platform.archive.bagunpacker.services.{
   Unpacker,
   UnpackerError,
@@ -16,13 +17,18 @@ import uk.ac.wellcome.storage.streaming.{
   InputStreamWithLengthAndMetadata
 }
 
-class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
+class S3Unpacker(
+  bufferSize: Long = 128 * FileUtils.ONE_MB
+)(implicit s3Client: AmazonS3) extends Unpacker {
   private val s3StreamStore = new S3StreamStore()
 
-  val readerClient = s3Client
+  val readerClient: AmazonS3 = s3Client
+  val readerBufferSize: Long = bufferSize
 
-  val reader = new S3StreamReader {
+  val reader: S3StreamReader = new S3StreamReader {
     override implicit val s3Client: AmazonS3 = readerClient
+
+    override protected val bufferSize: Long = readerBufferSize
   }
 
   override def get(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -19,7 +19,8 @@ import uk.ac.wellcome.storage.streaming.{
 
 class S3Unpacker(
   bufferSize: Long = 128 * FileUtils.ONE_MB
-)(implicit s3Client: AmazonS3) extends Unpacker {
+)(implicit s3Client: AmazonS3)
+    extends Unpacker {
   private val s3StreamStore = new S3StreamStore()
 
   val reader: S3StreamReader = new S3StreamReader(bufferSize = bufferSize)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
@@ -1,0 +1,49 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.services.s3
+
+import org.mockito.{Matchers => MockitoMatchers, Mockito}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.streaming.Codec._
+
+class S3StreamReaderTest extends FunSpec with Matchers with S3Fixtures with MockitoSugar with StorageRandomThings with EitherValues {
+  it("makes multiple GetObject requests") {
+    withLocalS3Bucket { bucket =>
+      val location = createObjectLocationWith(bucket)
+
+      s3Client.putObject(location.namespace, location.path, randomAlphanumericWithLength(length = 1000))
+
+      val spyClient = Mockito.spy(s3Client)
+      val reader = new S3StreamReader(bufferSize = 500)(s3Client = spyClient)
+
+      val result = reader.get(location)
+      result.right.value.identifiedT.read()
+
+      // We expect to see at least three calls to getObject:
+      //
+      //    - One to get the size of the object
+      //    - Two or more to read the object
+      //
+      Mockito
+        .verify(spyClient, Mockito.atLeast(3))
+        .getObject(MockitoMatchers.any())
+    }
+  }
+
+  it("joins multiple GetObject streams correctly") {
+    withLocalS3Bucket { bucket =>
+      val message = randomAlphanumericWithLength(length = 1000)
+      val location = createObjectLocationWith(bucket)
+
+      s3Client.putObject(location.namespace, location.path, message)
+
+      val reader = new S3StreamReader(bufferSize = 500)
+
+      val inputStream = reader.get(location).right.value.identifiedT
+      val s = stringCodec.fromStream(inputStream)
+      println(s)
+      stringCodec.fromStream(inputStream).right.value shouldBe message
+    }
+  }
+}

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
@@ -17,8 +17,9 @@ class S3StreamReaderTest extends FunSpec with Matchers with S3Fixtures with Mock
       val spyClient = Mockito.spy(s3Client)
       val reader = new S3StreamReader(bufferSize = 500)(s3Client = spyClient)
 
-      val result = reader.get(location)
-      result.right.value.identifiedT.read()
+      // Consume all the bytes from the stream, even if we don't look at them.
+      val inputStream = reader.get(location).right.value.identifiedT
+      stringCodec.fromStream(inputStream).right.value
 
       // We expect to see at least three calls to getObject:
       //
@@ -41,8 +42,6 @@ class S3StreamReaderTest extends FunSpec with Matchers with S3Fixtures with Mock
       val reader = new S3StreamReader(bufferSize = 500)
 
       val inputStream = reader.get(location).right.value.identifiedT
-      val s = stringCodec.fromStream(inputStream)
-      println(s)
       stringCodec.fromStream(inputStream).right.value shouldBe message
     }
   }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
@@ -7,12 +7,22 @@ import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.streaming.Codec._
 
-class S3StreamReaderTest extends FunSpec with Matchers with S3Fixtures with MockitoSugar with StorageRandomThings with EitherValues {
+class S3StreamReaderTest
+    extends FunSpec
+    with Matchers
+    with S3Fixtures
+    with MockitoSugar
+    with StorageRandomThings
+    with EitherValues {
   it("makes multiple GetObject requests") {
     withLocalS3Bucket { bucket =>
       val location = createObjectLocationWith(bucket)
 
-      s3Client.putObject(location.namespace, location.path, randomAlphanumericWithLength(length = 1000))
+      s3Client.putObject(
+        location.namespace,
+        location.path,
+        randomAlphanumericWithLength(length = 1000)
+      )
 
       val spyClient = Mockito.spy(s3Client)
       val reader = new S3StreamReader(bufferSize = 500)(s3Client = spyClient)

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,10 @@ lazy val bag_unpacker = setupProject(
   project,
   "bag_unpacker",
   localDependencies = Seq(common),
-  externalDependencies = ExternalDependencies.commonsCompressDependencies ++ ExternalDependencies.commonsIODependencies
+  externalDependencies =
+    ExternalDependencies.commonsCompressDependencies ++
+      ExternalDependencies.commonsIODependencies ++
+      ExternalDependencies.mockitoDependencies
 )
 
 lazy val ingests_common =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,6 +68,7 @@ object ExternalDependencies {
     val akkaStreamAlpakka = "0.20"
     val commonsCompress = "1.5"
     val commonsIO = "2.6"
+    val mockito = "1.9.5"
     val aws = "1.11.504"
     val circe = "0.9.0"
     val scalatest = "3.0.1"
@@ -108,6 +109,10 @@ object ExternalDependencies {
 
   val cloudwatchMetricsDependencies = Seq[ModuleID](
     "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % versions.aws
+  )
+
+  val mockitoDependencies: Seq[ModuleID] = Seq(
+    "org.mockito" % "mockito-core" % versions.mockito % "test"
   )
 
   val wiremockDependencies = Seq[ModuleID](


### PR DESCRIPTION
Because we were making a ranged GET request, S3 would report the content length of every file as 1.  That would cause the reader to read straight to the end, even if it was an enormous thing, and buffer the entire object in memory.

Using .abort() and not a ranged GET avoids this issue *and* means we don't get the warning about "not all bytes read from the stream".

Closes https://github.com/wellcomecollection/platform/issues/4326