### PR TITLE
Use Fargate Spot for the storage service

### DIFF
--- a/terraform/modules/service/api/main.tf
+++ b/terraform/modules/service/api/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=125f1aaf90a1b2469ad129c95e76755b9e71ab76"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.4.0"
 
   service_name = var.namespace
 

--- a/terraform/modules/service/api/main.tf
+++ b/terraform/modules/service/api/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=125f1aaf90a1b2469ad129c95e76755b9e71ab76"
 
   service_name = var.namespace
 
@@ -20,6 +20,8 @@ module "service" {
   target_group_arn = aws_lb_target_group.tcp.arn
   container_name   = "nginx"
   container_port   = var.nginx_container_port
+
+  use_fargate_spot = var.use_fargate_spot_for_api
 }
 
 module "task_definition" {

--- a/terraform/modules/service/api/variables.tf
+++ b/terraform/modules/service/api/variables.tf
@@ -68,3 +68,7 @@ variable "desired_task_count" {
   default = 3
 }
 
+variable "use_fargate_spot_for_api" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/service/scaling_worker/main.tf
+++ b/terraform/modules/service/scaling_worker/main.tf
@@ -23,6 +23,8 @@ module "worker" {
 
   cpu    = var.cpu
   memory = var.memory
+
+  use_fargate_spot = var.use_fargate_spot
 }
 
 module "scaling" {

--- a/terraform/modules/service/scaling_worker/variables.tf
+++ b/terraform/modules/service/scaling_worker/variables.tf
@@ -55,3 +55,7 @@ variable "memory" {
   default = 1024
 }
 
+variable "use_fargate_spot" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=125f1aaf90a1b2469ad129c95e76755b9e71ab76"
 
   service_name = var.service_name
 
@@ -16,6 +16,8 @@ module "service" {
   launch_type = var.launch_type
 
   desired_task_count = var.desired_task_count
+
+  use_fargate_spot = var.use_fargate_spot
 }
 
 module "task_definition" {

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=125f1aaf90a1b2469ad129c95e76755b9e71ab76"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.4.0"
 
   service_name = var.service_name
 

--- a/terraform/modules/service/worker/variables.tf
+++ b/terraform/modules/service/worker/variables.tf
@@ -47,3 +47,7 @@ variable "memory" {
   default = 1024
 }
 
+variable "use_fargate_spot" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/stack/api/main.tf
+++ b/terraform/modules/stack/api/main.tf
@@ -34,5 +34,7 @@ module "services" {
   ingests_listener_port                        = local.ingests_listener_port
   interservice_security_group_id               = var.interservice_security_group_id
   allow_ingests_publish_to_unpacker_topic_json = data.aws_iam_policy_document.allow_ingests_publish_to_unpacker_topic.json
+
+  use_fargate_spot_for_api = var.use_fargate_spot_for_api
 }
 

--- a/terraform/modules/stack/api/services/bags.tf
+++ b/terraform/modules/stack/api/services/bags.tf
@@ -35,5 +35,7 @@ module "bags" {
   app_memory = 1792
 
   desired_task_count = var.desired_bags_api_count
+
+  use_fargate_spot_for_api = var.use_fargate_spot_for_api
 }
 

--- a/terraform/modules/stack/api/services/ingests.tf
+++ b/terraform/modules/stack/api/services/ingests.tf
@@ -35,6 +35,8 @@ module "ingests" {
   app_memory = 1792
 
   desired_task_count = var.desired_ingests_api_count
+
+  use_fargate_spot_for_api = var.use_fargate_spot_for_api
 }
 
 resource "aws_iam_role_policy" "allow_ingests_publish_to_unpacker_topic" {

--- a/terraform/modules/stack/api/services/variables.tf
+++ b/terraform/modules/stack/api/services/variables.tf
@@ -83,3 +83,6 @@ variable "interservice_security_group_id" {
 variable "allow_ingests_publish_to_unpacker_topic_json" {
 }
 
+variable "use_fargate_spot_for_api" {
+  type = bool
+}

--- a/terraform/modules/stack/api/variables.tf
+++ b/terraform/modules/stack/api/variables.tf
@@ -87,3 +87,7 @@ variable "desired_bags_api_count" {
 variable "desired_ingests_api_count" {
 }
 
+variable "use_fargate_spot_for_api" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -112,6 +112,8 @@ module "bag_root_finder" {
   max_capacity = var.max_capacity
 
   container_image = local.bag_root_finder_image
+
+  use_fargate_spot = true
 }
 
 # bag_verifier
@@ -185,6 +187,8 @@ module "bag_versioner" {
   max_capacity = var.max_capacity
 
   container_image = local.bag_versioner_image
+
+  use_fargate_spot = true
 }
 
 module "replicator_verifier_primary" {
@@ -310,6 +314,8 @@ module "replica_aggregator" {
   max_capacity = var.max_capacity
 
   container_image = local.replica_aggregator_image
+
+  use_fargate_spot = true
 }
 
 # bag_register
@@ -340,6 +346,8 @@ module "bag_register" {
   max_capacity = var.max_capacity
 
   container_image = local.bag_register_image
+
+  use_fargate_spot = true
 }
 
 # notifier
@@ -370,6 +378,8 @@ module "notifier" {
   max_capacity = var.max_capacity
 
   container_image = local.notifier_image
+
+  use_fargate_spot = true
 }
 
 # ingests
@@ -398,6 +408,8 @@ module "ingests" {
   max_capacity = var.max_capacity
 
   container_image = local.ingests_image
+
+  use_fargate_spot = true
 }
 
 # Storage API
@@ -464,5 +476,7 @@ module "api" {
   # NLBs that seem to increase latency significantly if number of tasks < number of AZs.
   desired_bags_api_count    = max(3, var.desired_bags_api_count)
   desired_ingests_api_count = max(3, var.desired_ingests_api_count)
+
+  use_fargate_spot_for_api = var.use_fargate_spot_for_api
 }
 

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -111,3 +111,8 @@ variable "max_capacity" {}
 variable "bag_register_output_subscribe_principals" {
   type = list(string)
 }
+
+variable "use_fargate_spot_for_api" {
+  type    = bool
+  default = false
+}

--- a/terraform/stack_prod/provider.tf
+++ b/terraform/stack_prod/provider.tf
@@ -4,6 +4,6 @@ provider "aws" {
   }
 
   region  = var.aws_region
-  version = "2.34.0"
+  version = "2.51.0"
 }
 

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -55,5 +55,10 @@ module "stack_staging" {
 
   archivematica_ingests_bucket             = local.archivematica_ingests_bucket
   bag_register_output_subscribe_principals = []
+
+  # This means the staging service might be interrupted (unlikely), but the
+  # staging service doesn't make the same guarantees of uptime and this
+  # saves us money.
+  use_fargate_spot_for_api = true
 }
 

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -5,6 +5,6 @@ provider "aws" {
   }
 
   region  = var.aws_region
-  version = "2.34.0"
+  version = "2.51.0"
 }
 


### PR DESCRIPTION
This patch uses https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/6 to use Fargate Spot in some of the storage service apps, specifically:

* the bag root finder
* the bag versioner
* the replica aggregator
* the bag register
* the notifier
* the ingests monitor

because all these tasks are SQS-backed and can be interrupted at short notice. The unpacker, verifier and replicator all stay as they are.

It also turns on spot for the APIs **in the staging service only**, on the basis that it's an easy cost win for something where we don't need 100% uptime.

Still needs to be rolled out to prod, which turns out to be a bit more delicate if we want to avoid downtime.