### PR TITLE
Write new bags as Standard, let S3 lifecycle applicable objects to Standard-IA

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -6,6 +6,17 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
+
+  // We write new objects as Standard, and then rely on bucket management policies
+  // to lifecycle objects to Standard-IA or Glacier Deep Archive as appropriate.
+  //
+  // We don't write straight as Standard-IA (although we used to) because that
+  // has a minimum 128KB size for objects.  If you store <128KB, it rounds up and
+  // charges you as if you were storing 128KB.
+  //
+  // Things like the bag-info.txt and tag manifest are tiny, and it's more expensive
+  // to store them as Standard-IA than Standard.
+  //
   implicit val prefixTransfer: S3PrefixTransfer =
-    S3PrefixTransfer(storageClass = StorageClass.StandardInfrequentAccess)
+    S3PrefixTransfer(storageClass = StorageClass.Standard)
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -56,38 +56,6 @@ class S3ReplicatorTest
     }
   }
 
-  it("stores the objects as Standard-IA") {
-    withLocalS3Bucket { bucket =>
-      val name = randomAlphanumeric
-      val location = createObjectLocationWith(bucket, key = s"src/$name")
-      val contents = randomAlphanumeric
-
-      s3Client.putObject(
-        location.namespace,
-        location.path,
-        contents
-      )
-
-      val srcPrefix =
-        ObjectLocationPrefix(namespace = bucket.name, path = "src/")
-      val dstPrefix =
-        ObjectLocationPrefix(namespace = bucket.name, path = "dst/")
-
-      val result = new S3Replicator().replicate(
-        ingestId = createIngestID,
-        request = ReplicationRequest(
-          srcPrefix = srcPrefix,
-          dstPrefix = dstPrefix
-        )
-      )
-
-      result shouldBe a[ReplicationSucceeded]
-
-      val metadata = s3Client.getObjectMetadata(bucket.name, s"dst/$name")
-      metadata.getStorageClass shouldBe "STANDARD_IA"
-    }
-  }
-
   it("fails if the underlying replication has an error") {
     val result = new S3Replicator().replicate(
       ingestId = createIngestID,

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -6,44 +6,6 @@ resource "aws_s3_bucket" "replica_primary" {
     enabled = var.enable_s3_versioning
   }
 
-  # This is a temporary lifecycle rule that will flush all the existing objects
-  # from Standard to Standard-IA.
-  #
-  # When we first set up the replicators, we were writing everything as the
-  # Standard storage class.  We should actually be writing the primary replica
-  # as Standard-IA, which is more appropriate and cheaper.
-  #
-  # The replicators now write all *new* objects as Standard-IA, but we have
-  # millions of existing objects that are all Standard.  Rather than moving
-  # them manually, we'll get S3 to lifecycle them for us (less risky).
-  #
-  # You can run this Python script to find out if any objects haven't been
-  # lifecycled to Standard-IA yet:
-  #
-  #     import boto3
-  #     import tqdm
-  #
-  #     s3 = boto3.client("s3")
-  #
-  #
-  #     def all_objects():
-  #         paginator = s3.get_paginator("list_objects_v2")
-  #
-  #         for page in paginator.paginate(Bucket="wellcomecollection-storage"):
-  #             yield from page["Contents"]
-  #
-  #
-  #     if any(
-  #         s3_obj["StorageClass"] == "STANDARD"
-  #         for s3_obj in tqdm.tqdm(all_objects())
-  #     ):
-  #         print("Some objects in the bucket are not Standard-IA!")
-  #     else:
-  #         print("Every objects in the bucket is Standard-IA!")
-  #
-  # When this rule is removed, you can close
-  # https://github.com/wellcometrust/platform/issues/4096
-  #
   lifecycle_rule {
     enabled = true
 


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4096

I realised this was an issue when trying to work out why we had objects that hadn't been lifecycled to Standard-IA, and it's because S3 won't lifecycle objects that are below the Standard-IA billing threshold (128KB). Small files like the tag manifest and bag-info.txt are cheaper to store as Standard than Standard-IA.

Rather than write everything as Standard-IA, we write everything as Standard and let S3 lifecycle rules choose what's appropriate to cycle away to Standard-IA.

Any bags written since I did this original patch will have some objects that are Standard-IA which would be cheaper as Standard, but it's a small enough number that I don't think it's worth going and moving those objects back to Standard – but while I'm looking at this code, I can stop it happening to new bags.