### PR TITLE
Remove the full stop from the sentence "Callback fulfilled."

### DIFF
--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationService.scala
@@ -27,7 +27,7 @@ object PrepareNotificationService extends Logging {
           IngestCallbackStatusUpdate(
             id = id,
             callbackStatus = Succeeded,
-            description = "Callback fulfilled."
+            description = "Callback fulfilled"
           )
         } else {
           debug(s"Callback failed for: $id, got $status!")

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -245,7 +245,7 @@ class NotifierFeatureTest
                       List(ingestEvent)
                       ) =>
                     id shouldBe ingest.id
-                    ingestEvent.description shouldBe "Callback fulfilled."
+                    ingestEvent.description shouldBe "Callback fulfilled"
                     callbackStatus shouldBe Callback.Succeeded
                     assertRecent(ingestEvent.createdDate)
                 }

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
@@ -41,7 +41,7 @@ class PrepareNotificationServiceTest
       assertPreparedNotificationIsCorrect(
         httpResponse = Success(HttpResponse(responseStatus)),
         expectedCallbackStatus = Callback.Succeeded,
-        expectedDescription = "Callback fulfilled."
+        expectedDescription = "Callback fulfilled"
       )
     }
   }


### PR DESCRIPTION
It's the only message sent to the ingests monitor that has a full stop, and the inconsistency annoys me.

Closes https://github.com/wellcomecollection/platform/issues/4270