### PR TITLE
Remove unused code for writing a fetch.txt

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetch.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetch.scala
@@ -64,24 +64,8 @@ object BagFetch {
     BagFetch(entries)
   }
 
-  def write(entries: Seq[BagFetchEntry]): String =
-    entries
-      .map { e =>
-        s"${e.uri} ${encodeLength(e.length)} ${encodeFilepath(e.path.value)}"
-      }
-      .mkString("\n")
-
-  private def encodeLength(length: Option[Long]): String =
-    length match {
-      case Some(i) => i.toString
-      case None    => "-"
-    }
-
   private def decodeLength(ls: String): Option[Long] =
     if (ls == "-") None else Some(ls.toLong)
-
-  private def encodeFilepath(path: String): String =
-    path.replaceAll("\n", "%0A").replaceAll("\r", "%0D")
 
   private def decodeFilepath(path: String): String =
     path.replaceAll("%0A", "\n").replaceAll("%0D", "\r")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
@@ -7,64 +7,6 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.FetchEntryGenerators
 
 class BagFetchTest extends FunSpec with Matchers with FetchEntryGenerators {
-
-  describe("write") {
-    it("writes the lines of a fetch.txt") {
-      val entries = Seq(
-        createBagFetchEntryWith(
-          uri = "http://example.org/",
-          length = 25,
-          path = "example.txt"
-        ),
-        createBagFetchEntryWith(
-          uri = "https://wellcome.ac.uk/",
-          path = "logo.png"
-        )
-      )
-
-      val expected =
-        s"""
-           |http://example.org/ 25 example.txt
-           |https://wellcome.ac.uk/ - logo.png
-       """.stripMargin.trim
-
-      BagFetch.write(entries) shouldBe expected
-    }
-
-    it("percent-encodes a CR, LF or CRLF in the filename") {
-      val entries = Seq(
-        "example\rnumber\r1.txt",
-        "example\nnumber\n2.txt",
-        "example\r\nnumber\r\n3.txt"
-      ).map { path =>
-        createBagFetchEntryWith(
-          uri = "http://example.org/",
-          path = path
-        )
-      }
-
-      Seq(
-        createBagFetchEntryWith(
-          uri = "http://example.org/",
-          path = "example.txt"
-        ),
-        createBagFetchEntryWith(
-          uri = "https://wellcome.ac.uk/",
-          path = "logo.png"
-        )
-      )
-
-      val expected =
-        s"""
-           |http://example.org/ - example%0Dnumber%0D1.txt
-           |http://example.org/ - example%0Anumber%0A2.txt
-           |http://example.org/ - example%0D%0Anumber%0D%0A3.txt
-       """.stripMargin.trim
-
-      BagFetch.write(entries) shouldBe expected
-    }
-  }
-
   describe("read") {
     it("reads the contents of a fetch.txt") {
       val contents = toInputStream(s"""


### PR DESCRIPTION
This code was written when we thought the storage service might create its own fetch files for the replicas; we later decided not to do this, so we can remove these `write()` methods.

The storage service should only ever be reading BagIt metadata files, never creating its own.

An easy win spun out of https://github.com/wellcomecollection/storage-service/pull/461