### PR TITLE
Improve the variable naming in bag_register.Main

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -52,7 +52,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: AmazonSQSAsync =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    val storageManifestVHS = StorageManifestDaoBuilder.build(config)
+    val storageManifestDao = StorageManifestDaoBuilder.build(config)
 
     val operationName = OperationNameBuilder.getName(config)
 
@@ -61,7 +61,7 @@ object Main extends WellcomeTypesafeApp {
       operationName
     )
 
-    implicit val s3StreamStore = new S3StreamStore()
+    implicit val s3StreamStore: S3StreamStore = new S3StreamStore()
 
     val storageManifestService = new StorageManifestService(
       sizeFinder = new S3SizeFinder()
@@ -69,7 +69,7 @@ object Main extends WellcomeTypesafeApp {
 
     val register = new Register(
       bagReader = new S3BagReader(),
-      storageManifestDao = storageManifestVHS,
+      storageManifestDao = storageManifestDao,
       storageManifestService = storageManifestService
     )
 


### PR DESCRIPTION
Tiny fixup I spotted while staring at this code.