### PR TITLE
Slight rejigging of Ingest.Status types

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -108,7 +108,7 @@ trait BagRegisterFixtures
 
       val ingestCompleted =
         ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
-      ingestCompleted.status shouldBe Ingest.Completed
+      ingestCompleted.status shouldBe Ingest.Succeeded
       ingestCompleted.events.head.description shouldBe "Register succeeded (completed)"
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -32,6 +32,7 @@ case class Ingest(
 
 case object Ingest {
   sealed trait Status
+  sealed trait Completed extends Status
 
   case object Accepted extends Status {
     override def toString: String = "accepted"

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -33,24 +33,19 @@ case class Ingest(
 case object Ingest {
   sealed trait Status
 
-  private val acceptedString = "accepted"
-  private val processingString = "processing"
-  private val succeededString = "succeeded"
-  private val failedString = "failed"
-
   case object Accepted extends Status {
-    override def toString: String = acceptedString
+    override def toString: String = "accepted"
   }
 
   case object Processing extends Status {
-    override def toString: String = processingString
+    override def toString: String = "processing"
   }
 
-  case object Completed extends Status {
-    override def toString: String = succeededString
+  case object Succeeded extends Completed {
+    override def toString: String = "succeeded"
   }
 
-  case object Failed extends Status {
-    override def toString: String = failedString
+  case object Failed extends Completed {
+    override def toString: String = "failed"
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -28,7 +28,7 @@ class IngestUpdater[Destination](
       case IngestCompleted(_) =>
         IngestStatusUpdate(
           id = ingestId,
-          status = Ingest.Completed,
+          status = Ingest.Succeeded,
           events = List(
             IngestEvent(
               s"${stepName.capitalize} succeeded (completed)"

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
@@ -60,7 +60,7 @@ class IngestUpdaterTest
     assertTopicReceivesIngestStatus(
       ingestId = ingestId,
       ingests = messageSender,
-      status = Ingest.Completed
+      status = Ingest.Succeeded
     ) { events =>
       events should have size 1
       events.head.description shouldBe s"${stepName.capitalize} succeeded (completed)"

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
@@ -20,7 +20,7 @@ class CallbackNotificationService[Destination](
     ingest.callback match {
       case Some(Callback(callbackUri, Pending)) =>
         ingest.status match {
-          case Ingest.Completed | Ingest.Failed =>
+          case Ingest.Succeeded | Ingest.Failed =>
             sendSnsMessage(callbackUri, ingest = ingest)
           case _ => Success(())
         }

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
@@ -20,7 +20,7 @@ class CallbackNotificationService[Destination](
     ingest.callback match {
       case Some(Callback(callbackUri, Pending)) =>
         ingest.status match {
-          case Ingest.Succeeded | Ingest.Failed =>
+          case _: Ingest.Completed =>
             sendSnsMessage(callbackUri, ingest = ingest)
           case _ => Success(())
         }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Completed
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Succeeded
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   CallbackNotification,
   IngestUpdate
@@ -31,11 +31,11 @@ class IngestsFeatureTest
     val ingestStatusUpdate =
       createIngestStatusUpdateWith(
         id = ingest.id,
-        status = Completed
+        status = Succeeded
       )
 
     val expectedIngest = ingest.copy(
-      status = Completed,
+      status = Succeeded,
       events = ingestStatusUpdate.events
     )
 
@@ -73,7 +73,7 @@ class IngestsFeatureTest
 
     it("updates the ingest tracker") {
       val storedIngest = ingestTracker.get(ingest.id).right.value.identifiedT
-      storedIngest.status shouldBe Completed
+      storedIngest.status shouldBe Succeeded
     }
 
     it("records the events in the ingest tracker") {

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
@@ -21,7 +21,7 @@ class CallbackNotificationServiceTest
   it("sends a notification if the ingest is complete and the callback pending") {
     val completedIngestStatus = Table(
       "ingest-status",
-      Ingest.Completed,
+      Ingest.Succeeded,
       Ingest.Failed
     )
 
@@ -53,7 +53,7 @@ class CallbackNotificationServiceTest
       "ingest-status",
       Ingest.Processing,
       Ingest.Accepted,
-      Ingest.Completed,
+      Ingest.Succeeded,
       Ingest.Failed
     )
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
@@ -25,7 +25,7 @@ class CallbackNotificationServiceTest
       Ingest.Failed
     )
 
-    forAll(completedIngestStatus) { ingestStatus =>
+    forAll(completedIngestStatus) { ingestStatus: Ingest.Completed =>
       assertNotificationSent(
         ingestStatus = ingestStatus,
         callbackStatus = Callback.Pending

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -11,8 +11,8 @@ import uk.ac.wellcome.messaging.worker.models.{
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.{
-  Succeeded,
-  Processing
+  Processing,
+  Succeeded
 }
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures.IngestTrackerFixtures
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryIngestTracker

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.worker.models.{
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.{
-  Completed,
+  Succeeded,
   Processing
 }
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures.IngestTrackerFixtures
@@ -33,14 +33,14 @@ class IngestsWorkerServiceTest
     val ingestStatusUpdate =
       createIngestStatusUpdateWith(
         id = ingest.id,
-        status = Completed
+        status = Succeeded
       )
 
     val callbackNotification = CallbackNotification(
       ingestId = ingest.id,
       callbackUri = ingest.callback.get.uri,
       payload = ingest.copy(
-        status = Completed,
+        status = Succeeded,
         events = ingestStatusUpdate.events
       )
     )
@@ -141,7 +141,7 @@ class IngestsWorkerServiceTest
         withIngestWorker(queue, ingestTracker, messageSender) { service =>
           val ingestStatusUpdate =
             createIngestStatusUpdateWith(
-              status = Completed
+              status = Succeeded
             )
 
           val result = service.processMessage(ingestStatusUpdate)
@@ -174,7 +174,7 @@ class IngestsWorkerServiceTest
             val ingestStatusUpdate =
               createIngestStatusUpdateWith(
                 id = ingest.id,
-                status = Completed
+                status = Succeeded
               )
 
             val result = service.processMessage(ingestStatusUpdate)

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestStates.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestStates.scala
@@ -122,7 +122,7 @@ object IngestStates {
 
       case Ingest.Accepted   => true
       case Ingest.Processing => update != Ingest.Accepted
-      case Ingest.Completed  => false
+      case Ingest.Succeeded  => false
       case Ingest.Failed     => false
     }
 

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestStatesTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestStatesTest.scala
@@ -75,7 +75,7 @@ class IngestEventUpdateTest
     ("initial", "expected"),
     (Ingest.Accepted, Ingest.Processing),
     (Ingest.Processing, Ingest.Processing),
-    (Ingest.Completed, Ingest.Completed),
+    (Ingest.Succeeded, Ingest.Succeeded),
     (Ingest.Failed, Ingest.Failed)
   )
 
@@ -107,11 +107,11 @@ class IngestStatusUpdateTest
       ("initial", "update"),
       (Ingest.Accepted, Ingest.Accepted),
       (Ingest.Accepted, Ingest.Processing),
-      (Ingest.Accepted, Ingest.Completed),
+      (Ingest.Accepted, Ingest.Succeeded),
       (Ingest.Accepted, Ingest.Failed),
-      (Ingest.Processing, Ingest.Completed),
+      (Ingest.Processing, Ingest.Succeeded),
       (Ingest.Processing, Ingest.Failed),
-      (Ingest.Completed, Ingest.Completed),
+      (Ingest.Succeeded, Ingest.Succeeded),
       (Ingest.Failed, Ingest.Failed)
     )
 
@@ -133,12 +133,12 @@ class IngestStatusUpdateTest
 
     val disallowedStatusUpdates = Table(
       ("initial", "update"),
-      (Ingest.Failed, Ingest.Completed),
+      (Ingest.Failed, Ingest.Succeeded),
       (Ingest.Failed, Ingest.Processing),
       (Ingest.Failed, Ingest.Accepted),
-      (Ingest.Completed, Ingest.Failed),
-      (Ingest.Completed, Ingest.Processing),
-      (Ingest.Completed, Ingest.Accepted),
+      (Ingest.Succeeded, Ingest.Failed),
+      (Ingest.Succeeded, Ingest.Processing),
+      (Ingest.Succeeded, Ingest.Accepted),
       (Ingest.Processing, Ingest.Accepted)
     )
 

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerTestCases.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerTestCases.scala
@@ -287,11 +287,11 @@ trait IngestTrackerTestCases[Context]
           ("initial", "update"),
           (Ingest.Accepted, Ingest.Accepted),
           (Ingest.Accepted, Ingest.Processing),
-          (Ingest.Accepted, Ingest.Completed),
+          (Ingest.Accepted, Ingest.Succeeded),
           (Ingest.Accepted, Ingest.Failed),
-          (Ingest.Processing, Ingest.Completed),
+          (Ingest.Processing, Ingest.Succeeded),
           (Ingest.Processing, Ingest.Failed),
-          (Ingest.Completed, Ingest.Completed),
+          (Ingest.Succeeded, Ingest.Succeeded),
           (Ingest.Failed, Ingest.Failed)
         )
 
@@ -315,12 +315,12 @@ trait IngestTrackerTestCases[Context]
 
         val disallowedStatusUpdates = Table(
           ("initial", "update"),
-          (Ingest.Failed, Ingest.Completed),
+          (Ingest.Failed, Ingest.Succeeded),
           (Ingest.Failed, Ingest.Processing),
           (Ingest.Failed, Ingest.Accepted),
-          (Ingest.Completed, Ingest.Failed),
-          (Ingest.Completed, Ingest.Processing),
-          (Ingest.Completed, Ingest.Accepted),
+          (Ingest.Succeeded, Ingest.Failed),
+          (Ingest.Succeeded, Ingest.Processing),
+          (Ingest.Succeeded, Ingest.Accepted),
           (Ingest.Processing, Ingest.Accepted)
         )
 


### PR DESCRIPTION
Make the internal names better reflect how they're described externally; introduce an Ingest.Completed type so downstream code has a bit less coupling to what the exact statuses are.