### PR TITLE
The ingests monitor sends the full body of updated ingests

### DIFF
--- a/ingests/src/main/resources/application.conf
+++ b/ingests/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 aws.sqs.queue.url=${?queue_url}
 aws.callbackNotifications.sns.topic.arn=${?callback_notifications_topic_arn}
 aws.updatedIngests.sns.topic.arn=${?updated_ingests_topic_arn}
-aws.dynamo.tableName=${?archive_ingest_table_name}
+aws.dynamo.tableName=${?ingests_table_name}
 aws.metrics.namespace=${?metrics_namespace}

--- a/ingests/src/main/resources/application.conf
+++ b/ingests/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 aws.sqs.queue.url=${?queue_url}
-aws.sns.topic.arn=${?topic_arn}
+aws.callbackNotifications.sns.topic.arn=${?callback_notifications_topic_arn}
+aws.updatedIngests.sns.topic.arn=${?updated_ingests_topic_arn}
 aws.dynamo.tableName=${?archive_ingest_table_name}
 aws.metrics.namespace=${?metrics_namespace}

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
@@ -48,14 +48,22 @@ object Main extends WellcomeTypesafeApp {
     val callbackNotificationService = new CallbackNotificationService(
       messageSender = SNSBuilder.buildSNSMessageSender(
         config,
+        namespace = "callbackNotifications",
         subject = "Sent from the ingests service"
       )
+    )
+
+    val updatedIngestsMessageSender = SNSBuilder.buildSNSMessageSender(
+      config,
+      namespace = "updatedIngests",
+      subject = "Updated ingests sent by the ingests monitor"
     )
 
     new IngestsWorker(
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),
       ingestTracker = ingestTracker,
-      callbackNotificationService = callbackNotificationService
+      callbackNotificationService = callbackNotificationService,
+      updatedIngestsMessageSender = updatedIngestsMessageSender
     )
   }
 }

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
@@ -78,7 +78,7 @@ class IngestsWorker[CallbackDestination, UpdatedIngestsDestination](
     val updatedIngestResult = updatedIngestsMessageSender.sendT(ingest)
 
     (callbackResult, updatedIngestResult) match {
-      case (Success(_), Success(_))   => Success(())
+      case (Success(_), Success(_)) => Success(())
 
       case (Failure(callbackErr), Success(_)) =>
         warn(s"Failed to send the callback notification: $callbackErr")
@@ -91,7 +91,11 @@ class IngestsWorker[CallbackDestination, UpdatedIngestsDestination](
       case (Failure(callbackErr), Failure(updatedIngestErr)) =>
         warn(s"Failed to send the callback notification: $callbackErr")
         warn(s"Failed to send the updated ingest: $updatedIngestErr")
-        Failure(new Throwable("Both of the ongoing messages failed to send correctly!"))
+        Failure(
+          new Throwable(
+            "Both of the ongoing messages failed to send correctly!"
+          )
+        )
     }
   }
 

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sqsworker.alpakka.{
   AlpakkaSQSWorker,
   AlpakkaSQSWorkerConfig
@@ -24,10 +25,11 @@ import uk.ac.wellcome.typesafe.Runnable
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class IngestsWorker[CallbackDestination](
+class IngestsWorker[CallbackDestination, UpdatedIngestsDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
   ingestTracker: IngestTracker,
-  callbackNotificationService: CallbackNotificationService[CallbackDestination]
+  callbackNotificationService: CallbackNotificationService[CallbackDestination],
+  updatedIngestsMessageSender: MessageSender[UpdatedIngestsDestination]
 )(implicit actorSystem: ActorSystem, mc: MonitoringClient, sc: AmazonSQSAsync)
     extends Runnable
     with Logging {

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -87,7 +87,9 @@ class IngestsFeatureTest
     }
 
     it("sends a message with the updated ingest") {
-      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(expectedIngest)
+      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(
+        expectedIngest
+      )
     }
   }
 }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -55,9 +55,10 @@ class IngestsFeatureTest
     it("reads messages from the queue") {
       withLocalSqsQueue { queue =>
         withIngestWorker(
-          queue,
-          ingestTracker,
-          callbackNotificationMessageSender
+          queue = queue,
+          ingestTracker = ingestTracker,
+          callbackNotificationMessageSender = callbackNotificationMessageSender,
+          updatedIngestsMessageSender = updatedIngestsMessageSender
         ) { _ =>
           sendNotificationToSQS[IngestUpdate](queue, ingestStatusUpdate)
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Succeeded
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   CallbackNotification,
+  Ingest,
   IngestUpdate
 }
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryIngestTracker
@@ -49,6 +50,7 @@ class IngestsFeatureTest
       createMemoryIngestTrackerWith(initialIngests = Seq(ingest))
 
     val callbackNotificationMessageSender = new MemoryMessageSender()
+    val updatedIngestsMessageSender = new MemoryMessageSender()
 
     it("reads messages from the queue") {
       withLocalSqsQueue { queue =>
@@ -81,6 +83,10 @@ class IngestsFeatureTest
         ingestStatusUpdate.id,
         ingestStatusUpdate.events.map { _.description }
       )
+    }
+
+    it("sends a message with the updated ingest") {
+      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(expectedIngest)
     }
   }
 }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -24,8 +24,9 @@ trait IngestsFixtures
   def withIngestWorker[R](
     queue: Queue = Queue(url = "queue://test", arn = "arn::queue"),
     ingestTracker: IngestTracker,
-    callbackNotificationMessageSender: MemoryMessageSender
-  )(testWith: TestWith[IngestsWorker[String], R]): R =
+    callbackNotificationMessageSender: MemoryMessageSender,
+    updatedIngestsMessageSender: MemoryMessageSender = new MemoryMessageSender()
+  )(testWith: TestWith[IngestsWorker[String, String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
         withMaterializer { implicit materializer =>

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -36,7 +36,8 @@ trait IngestsFixtures
           val service = new IngestsWorker(
             alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
             ingestTracker = ingestTracker,
-            callbackNotificationService = callbackNotificationService
+            callbackNotificationService = callbackNotificationService,
+            updatedIngestsMessageSender = updatedIngestsMessageSender
           )
 
           service.run()

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -59,7 +59,8 @@ class IngestsWorkerServiceTest
     it("processes the message") {
       withIngestWorker(
         ingestTracker = ingestTracker,
-        callbackNotificationMessageSender = callbackNotificationMessageSender
+        callbackNotificationMessageSender = callbackNotificationMessageSender,
+        updatedIngestsMessageSender = updatedIngestsMessageSender
       ) {
         _.processMessage(ingestStatusUpdate).success.value shouldBe a[
           Successful[_]
@@ -118,7 +119,8 @@ class IngestsWorkerServiceTest
     it("processes both messages") {
       withIngestWorker(
         ingestTracker = ingestTracker,
-        callbackNotificationMessageSender = callbackNotificationMessageSender
+        callbackNotificationMessageSender = callbackNotificationMessageSender,
+        updatedIngestsMessageSender = updatedIngestsMessageSender
       ) { service =>
         service
           .processMessage(ingestStatusUpdate1)

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -203,9 +203,7 @@ class IngestsWorkerServiceTest
       status = Succeeded
     )
 
-    val throwable = new Throwable("BOOM!")
-    val callbackNotificationMessageSender = createBrokenSender(throwable)
-
+    val callbackNotificationMessageSender = createBrokenSender
     val updatedIngestsMessageSender = new MemoryMessageSender()
 
     val ingestTracker: MemoryIngestTracker =
@@ -222,9 +220,12 @@ class IngestsWorkerServiceTest
 
       result.success.value shouldBe a[NonDeterministicFailure[_]]
 
-      result.success.value
+      val err = result.success.value
         .asInstanceOf[NonDeterministicFailure[_]]
-        .failure shouldBe throwable
+        .failure
+
+      err shouldBe a[Throwable]
+      err.getMessage shouldBe "One or both of the ongoing messages failed to send correctly"
     }
 
     it("sends the updated ingest body") {
@@ -241,9 +242,7 @@ class IngestsWorkerServiceTest
     )
 
     val callbackNotificationMessageSender = new MemoryMessageSender()
-
-    val throwable = new Throwable("BOOM!")
-    val updatedIngestsMessageSender = createBrokenSender(throwable)
+    val updatedIngestsMessageSender = createBrokenSender
 
     val ingestTracker: MemoryIngestTracker =
       createMemoryIngestTrackerWith(initialIngests = Seq(ingest))
@@ -259,9 +258,12 @@ class IngestsWorkerServiceTest
 
       result.success.value shouldBe a[NonDeterministicFailure[_]]
 
-      result.success.value
+      val err = result.success.value
         .asInstanceOf[NonDeterministicFailure[_]]
-        .failure shouldBe throwable
+        .failure
+
+      err shouldBe a[Throwable]
+      err.getMessage shouldBe "One or both of the ongoing messages failed to send correctly"
     }
 
     it("sends the callback notification") {
@@ -269,9 +271,9 @@ class IngestsWorkerServiceTest
     }
   }
   
-  private def createBrokenSender(throwable: Throwable): MemoryMessageSender =
+  private def createBrokenSender: MemoryMessageSender =
     new MemoryMessageSender() {
       override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
-        Failure(throwable)
+        Failure(new Throwable("BOOM!"))
     }
 }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -86,7 +86,9 @@ class IngestsWorkerServiceTest
     }
 
     it("sends a message with the updated ingest") {
-      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(expectedIngest)
+      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(
+        expectedIngest
+      )
     }
   }
 
@@ -156,7 +158,8 @@ class IngestsWorkerServiceTest
         events = ingestStatusUpdate1.events ++ ingestStatusUpdate2.events
       )
 
-      updatedIngestsMessageSender.getMessages[Ingest] shouldBe Seq(expectedIngest1, expectedIngest2)
+      updatedIngestsMessageSender
+        .getMessages[Ingest] shouldBe Seq(expectedIngest1, expectedIngest2)
     }
   }
 
@@ -186,7 +189,10 @@ class IngestsWorkerServiceTest
     }
 
     it("does not update the ingest tracker") {
-      ingestTracker.get(ingestUpdate.id).left.value shouldBe a[IngestDoesNotExistError]
+      ingestTracker
+        .get(ingestUpdate.id)
+        .left
+        .value shouldBe a[IngestDoesNotExistError]
     }
 
     it("does not send any messages") {
@@ -307,8 +313,10 @@ class IngestsWorkerServiceTest
       updatedIngestsMessageSender.messages shouldBe empty
     }
   }
-  
-  private def createBrokenSender(throwable: Throwable = new Throwable("BOOM!")): MemoryMessageSender =
+
+  private def createBrokenSender(
+    throwable: Throwable = new Throwable("BOOM!")
+  ): MemoryMessageSender =
     new MemoryMessageSender() {
       override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
         Failure(throwable)

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -398,7 +398,7 @@ module "ingests" {
     queue_url                        = module.ingests_input_queue.url
     callback_notifications_topic_arn = module.ingests_monitor_callback_notifications_topic.arn
     updated_ingests_topic_arn        = module.updated_ingests_topic.arn
-    archive_ingest_table_name        = var.ingests_table_name
+    ingests_table_name               = var.ingests_table_name
     metrics_namespace                = local.ingests_service_name
     logstash_host                    = local.logstash_host
   }

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -395,11 +395,12 @@ module "ingests" {
   service_name = "${var.namespace}-ingests"
 
   env_vars = {
-    queue_url                 = module.ingests_input_queue.url
-    topic_arn                 = module.ingests_output_topic.arn
-    archive_ingest_table_name = var.ingests_table_name
-    metrics_namespace         = local.ingests_service_name
-    logstash_host             = local.logstash_host
+    queue_url                        = module.ingests_input_queue.url
+    callback_notifications_topic_arn = module.ingests_monitor_callback_notifications_topic.arn
+    updated_ingests_topic_arn        = module.updated_ingests_topic.arn
+    archive_ingest_table_name        = var.ingests_table_name
+    metrics_namespace                = local.ingests_service_name
+    logstash_host                    = local.logstash_host
   }
 
   # We always run at least one ingests monitor so messages from other apps are

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -51,10 +51,17 @@ module "ingests_input_queue" {
   max_receive_count = 10
 }
 
-module "ingests_output_topic" {
+module "updated_ingests_topic" {
   source = "../topic"
 
-  name       = "${var.namespace}_ingests_output"
+  name       = "${var.namespace}_updated_ingests"
+  role_names = [module.ingests.task_role_name]
+}
+
+module "ingests_monitor_callback_notifications_topic" {
+  source = "../topic"
+
+  name       = "${var.namespace}_ingests_monitor_callback_notifications"
   role_names = [module.ingests.task_role_name]
 }
 
@@ -65,7 +72,7 @@ module "notifier_input_queue" {
 
   name = "${var.namespace}_notifier"
 
-  topic_arns = [module.ingests_output_topic.arn]
+  topic_arns = [module.ingests_monitor_callback_notifications_topic.arn]
 
   role_names = [module.notifier.task_role_name]
 

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -65,6 +65,17 @@ module "ingests_monitor_callback_notifications_topic" {
   role_names = [module.ingests.task_role_name]
 }
 
+module "updated_ingests_queue" {
+  source = "../queue"
+
+  name = "${var.namespace}_updated_ingests"
+
+  topic_arns = [module.updated_ingests_topic.arn]
+
+  aws_region    = var.aws_region
+  dlq_alarm_arn = var.dlq_alarm_arn
+}
+
 # notifier
 
 module "notifier_input_queue" {


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/storage-service/pull/473. First step of https://github.com/wellcomecollection/platform/issues/4417.

This patch modifies the ingests service to send the complete ingest to SNS every time it gets an update. It also includes the Terraform wiring, and a queue so we can see if it’s doing so successfully.