### PR TITLE
Ensure ingest updates are ordered

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -19,7 +19,7 @@ trait StorageRandomThings extends RandomThings {
   def randomChecksumValue = ChecksumValue(randomAlphanumeric)
 
   def randomInstant: Instant =
-    Instant.now().plusSeconds(Random.nextInt())
+    Instant.now().plusSeconds(Random.nextInt().abs)
 
   private val collectionMax = 10
 

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.archive.indexer.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
-import com.sksamuel.elastic4s.requests.bulk.BulkResponse
+import com.sksamuel.elastic4s.requests.bulk.{BulkResponse, BulkResponseItem}
+import com.sksamuel.elastic4s.requests.common.VersionType.ExternalGte
 import grizzled.slf4j.Logging
 import io.circe.{Encoder, Json, JsonObject}
 import io.circe.parser.parse
@@ -19,6 +20,7 @@ trait Indexer[Document, DisplayDocument] extends Logging {
 
   protected def id(doc: Document): String
   protected def toDisplay(doc: Document): DisplayDocument
+  protected def version(doc: Document): Long
 
   final def index(
     documents: Seq[Document]
@@ -28,21 +30,33 @@ trait Indexer[Document, DisplayDocument] extends Logging {
     val inserts = documents.map { doc =>
       indexInto(index)
         .id { id(doc) }
+        .version(version(doc))
+        .versionType(ExternalGte)
         .doc { asJson(toDisplay(doc)) }
     }
 
     client
       .execute { bulk(inserts) }
       .map { response: Response[BulkResponse] =>
-        if (response.isError || response.result.errors) {
+        if (response.isError) {
           error(s"Error from Elasticsearch: $response")
           Left(documents)
         } else {
-          val failedIds = response.result.failures.map { _.id }.toSet
+          val actualFailures =
+            response.result
+              .failures
+              .filterNot { isVersionConflictException }
 
-          if (failedIds.isEmpty) {
+          if (actualFailures.isEmpty) {
             Right(documents)
           } else {
+            val failedIds = actualFailures
+              .map { failure =>
+                error(s"Error ingesting ${failure.id}: ${failure.error}")
+                failure.id
+              }
+              .toSet
+
             val failedDocuments = documents.filter { doc =>
               failedIds.contains(id(doc))
             }
@@ -77,5 +91,20 @@ trait Indexer[Document, DisplayDocument] extends Logging {
 
       case Left(_) => jsonString
     }
+  }
+
+  private def isVersionConflictException(bulkResponseItem: BulkResponseItem): Boolean = {
+    // This error is returned by Elasticsearch when we try to PUT a document
+    // with a lower version than the existing version.
+    val alreadyIndexedHasHigherVersion = bulkResponseItem.error
+      .exists(bulkError =>
+        bulkError.`type`.contains("version_conflict_engine_exception"))
+
+    if (alreadyIndexedHasHigherVersion) {
+      info(
+        s"Skipping ${bulkResponseItem.id} because already indexed item has a higher version (${bulkResponseItem.error}")
+    }
+
+    alreadyIndexedHasHigherVersion
   }
 }

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
@@ -43,19 +43,16 @@ trait Indexer[Document, DisplayDocument] extends Logging {
           Left(documents)
         } else {
           val actualFailures =
-            response.result
-              .failures
+            response.result.failures
               .filterNot { isVersionConflictException }
 
           if (actualFailures.isEmpty) {
             Right(documents)
           } else {
-            val failedIds = actualFailures
-              .map { failure =>
-                error(s"Error ingesting ${failure.id}: ${failure.error}")
-                failure.id
-              }
-              .toSet
+            val failedIds = actualFailures.map { failure =>
+              error(s"Error ingesting ${failure.id}: ${failure.error}")
+              failure.id
+            }.toSet
 
             val failedDocuments = documents.filter { doc =>
               failedIds.contains(id(doc))
@@ -93,16 +90,21 @@ trait Indexer[Document, DisplayDocument] extends Logging {
     }
   }
 
-  private def isVersionConflictException(bulkResponseItem: BulkResponseItem): Boolean = {
+  private def isVersionConflictException(
+    bulkResponseItem: BulkResponseItem
+  ): Boolean = {
     // This error is returned by Elasticsearch when we try to PUT a document
     // with a lower version than the existing version.
     val alreadyIndexedHasHigherVersion = bulkResponseItem.error
-      .exists(bulkError =>
-        bulkError.`type`.contains("version_conflict_engine_exception"))
+      .exists(
+        bulkError =>
+          bulkError.`type`.contains("version_conflict_engine_exception")
+      )
 
     if (alreadyIndexedHasHigherVersion) {
       info(
-        s"Skipping ${bulkResponseItem.id} because already indexed item has a higher version (${bulkResponseItem.error}")
+        s"Skipping ${bulkResponseItem.id} because already indexed item has a higher version (${bulkResponseItem.error}"
+      )
     }
 
     alreadyIndexedHasHigherVersion

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
@@ -27,7 +27,7 @@ class IngestIndexer(val client: ElasticClient, val index: Index)(
 
   override protected def version(ingest: Ingest): Long =
     ingest.lastModifiedDate match {
-      case Some(modifiedDate) => modifiedDate.getEpochSecond
-      case None               => ingest.createdDate.getEpochSecond
+      case Some(modifiedDate) => modifiedDate.toEpochMilli
+      case None               => ingest.createdDate.toEpochMilli
     }
 }

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
@@ -24,4 +24,10 @@ class IngestIndexer(val client: ElasticClient, val index: Index)(
       ingest = ingest,
       contextUrl = new URL("http://localhost:9200")
     )
+
+  override protected def version(ingest: Ingest): Long =
+    ingest.lastModifiedDate match {
+      case Some(modifiedDate) => modifiedDate.getEpochSecond
+      case None               => ingest.createdDate.getEpochSecond
+    }
 }

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -109,20 +109,32 @@ class IngestIndexerTest
       val olderIngest = createIngestWith(
         id = ingestId,
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101))
+          IngestEvent(
+            description = "event 1",
+            createdDate = Instant.ofEpochMilli(101)
+          )
         ),
         createdDate = Instant.ofEpochMilli(1)
       )
 
       val newerIngest = olderIngest.copy(
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101)),
-          IngestEvent(description = "event 2", createdDate = Instant.ofEpochMilli(102))
+          IngestEvent(
+            description = "event 1",
+            createdDate = Instant.ofEpochMilli(101)
+          ),
+          IngestEvent(
+            description = "event 2",
+            createdDate = Instant.ofEpochMilli(102)
+          )
         ),
         createdDate = Instant.ofEpochMilli(2)
       )
 
-      assert(olderIngest.lastModifiedDate.get.isBefore(newerIngest.lastModifiedDate.get))
+      assert(
+        olderIngest.lastModifiedDate.get
+          .isBefore(newerIngest.lastModifiedDate.get)
+      )
 
       it("a newer ingest replaces an older ingest") {
         withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
@@ -130,7 +142,9 @@ class IngestIndexerTest
 
           val future = ingestsIndexer
             .index(Seq(olderIngest))
-            .flatMap { _ => ingestsIndexer.index(Seq(newerIngest)) }
+            .flatMap { _ =>
+              ingestsIndexer.index(Seq(newerIngest))
+            }
 
           whenReady(future) { result =>
             result.right.value shouldBe Seq(newerIngest)
@@ -152,7 +166,9 @@ class IngestIndexerTest
 
           val future = ingestsIndexer
             .index(Seq(newerIngest))
-            .flatMap { _ => ingestsIndexer.index(Seq(olderIngest)) }
+            .flatMap { _ =>
+              ingestsIndexer.index(Seq(olderIngest))
+            }
 
           whenReady(future) { result =>
             result.right.value shouldBe Seq(olderIngest)
@@ -180,8 +196,14 @@ class IngestIndexerTest
 
       val newerIngest = olderIngest.copy(
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101)),
-          IngestEvent(description = "event 2", createdDate = Instant.ofEpochMilli(102))
+          IngestEvent(
+            description = "event 1",
+            createdDate = Instant.ofEpochMilli(101)
+          ),
+          IngestEvent(
+            description = "event 2",
+            createdDate = Instant.ofEpochMilli(102)
+          )
         ),
         createdDate = Instant.ofEpochMilli(2)
       )
@@ -195,7 +217,9 @@ class IngestIndexerTest
 
           val future = ingestsIndexer
             .index(Seq(olderIngest))
-            .flatMap { _ => ingestsIndexer.index(Seq(newerIngest)) }
+            .flatMap { _ =>
+              ingestsIndexer.index(Seq(newerIngest))
+            }
 
           whenReady(future) { result =>
             result.right.value shouldBe Seq(newerIngest)
@@ -217,7 +241,9 @@ class IngestIndexerTest
 
           val future = ingestsIndexer
             .index(Seq(newerIngest))
-            .flatMap { _ => ingestsIndexer.index(Seq(olderIngest)) }
+            .flatMap { _ =>
+              ingestsIndexer.index(Seq(olderIngest))
+            }
 
           whenReady(future) { result =>
             result.right.value shouldBe Seq(olderIngest)

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -109,17 +109,17 @@ class IngestIndexerTest
       val olderIngest = createIngestWith(
         id = ingestId,
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochSecond(101))
+          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101))
         ),
-        createdDate = Instant.ofEpochSecond(1)
+        createdDate = Instant.ofEpochMilli(1)
       )
 
       val newerIngest = olderIngest.copy(
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochSecond(101)),
-          IngestEvent(description = "event 2", createdDate = Instant.ofEpochSecond(102))
+          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101)),
+          IngestEvent(description = "event 2", createdDate = Instant.ofEpochMilli(102))
         ),
-        createdDate = Instant.ofEpochSecond(2)
+        createdDate = Instant.ofEpochMilli(2)
       )
 
       assert(olderIngest.lastModifiedDate.get.isBefore(newerIngest.lastModifiedDate.get))
@@ -175,15 +175,15 @@ class IngestIndexerTest
       val olderIngest = createIngestWith(
         id = ingestId,
         events = Seq.empty,
-        createdDate = Instant.ofEpochSecond(1)
+        createdDate = Instant.ofEpochMilli(1)
       )
 
       val newerIngest = olderIngest.copy(
         events = Seq(
-          IngestEvent(description = "event 1", createdDate = Instant.ofEpochSecond(101)),
-          IngestEvent(description = "event 2", createdDate = Instant.ofEpochSecond(102))
+          IngestEvent(description = "event 1", createdDate = Instant.ofEpochMilli(101)),
+          IngestEvent(description = "event 2", createdDate = Instant.ofEpochMilli(102))
         ),
-        createdDate = Instant.ofEpochSecond(2)
+        createdDate = Instant.ofEpochMilli(2)
       )
 
       assert(olderIngest.lastModifiedDate.isEmpty)


### PR DESCRIPTION
We want we only put the newest version of an Ingest in Elasticsearch.

The Ingest model doesn't have a version, but it does have a modified date (the latest event it received), or the created date as a fallback. Use that field as the version in Elasticsearch to ensure updates are ordered correctly.

Useful links:

* The Ingest model. https://github.com/wellcomecollection/storage-service/blob/master/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
* The Indexer class in the catalogue that this code is based on: https://github.com/wellcomecollection/catalogue/blob/master/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/Indexer.scala

Note: in the catalogue we index the internal model and then convert it to a display model in the Catalogue API; here we're indexing the display models directly, because we expect the primary interface for this data to be Kibana (at least, for now).

Part of https://github.com/wellcomecollection/platform/issues/4417