### PR TITLE
Allow for double-sending of messages in the bag unpacker tests

### DIFF
--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -54,9 +54,9 @@ class UnpackerFeatureTest
                   )
                 )
 
-                outgoing.getMessages[UnpackedBagLocationPayload] shouldBe Seq(
-                  expectedPayload
-                )
+                outgoing
+                  .getMessages[UnpackedBagLocationPayload]
+                  .distinct shouldBe Seq(expectedPayload)
 
                 assertTopicReceivesIngestUpdates(
                   sourceLocationPayload.ingestId,


### PR DESCRIPTION
This caused a failure in a recent Travis run.  Because SQS sends messages at least once, sometimes it sends them twice, and then `getMessages()` returns two duplicate messages.  Adding `.distinct` should stop this test from being flaky.

See https://travis-ci.org/github/wellcomecollection/storage-service/jobs/672406335