### PR TITLE
Add a worker for the ingests indexer

### DIFF
--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
@@ -50,7 +50,7 @@ trait Indexer[Document, DisplayDocument] extends Logging {
             Right(documents)
           } else {
             val failedIds = actualFailures.map { failure =>
-              error(s"Error ingesting ${failure.id}: ${failure.error}")
+              error(s"Error indexing ${failure.id}: ${failure.error}")
               failure.id
             }.toSet
 
@@ -58,7 +58,7 @@ trait Indexer[Document, DisplayDocument] extends Logging {
               failedIds.contains(id(doc))
             }
 
-            Right(failedDocuments)
+            Left(failedDocuments)
           }
         }
       }

--- a/indexer/ingests_indexer/Dockerfile
+++ b/indexer/ingests_indexer/Dockerfile
@@ -1,0 +1,5 @@
+FROM wellcome/typesafe_config_base:edge
+
+ADD target/universal/stage /opt/docker
+
+ENV PROJECT ingests_indexer

--- a/indexer/ingests_indexer/docker-compose.yml
+++ b/indexer/ingests_indexer/docker-compose.yml
@@ -9,3 +9,8 @@ elasticsearch:
     - "cluster.name=wellcome"
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
+sqs:
+  image: "s12v/elasticmq"
+  ports:
+    - "9324:9324"
+    - "4789:9324"

--- a/indexer/ingests_indexer/src/main/resources/application.conf
+++ b/indexer/ingests_indexer/src/main/resources/application.conf
@@ -5,4 +5,4 @@ es.port=${?es_port}
 es.username=${?es_username}
 es.password=${?es_password}
 es.protocol=${?es_protocol}
-es.ingests.indexPrefix=${?es_ingests_index_prefix}
+es.ingests.index-prefix=${?es_ingests_index_prefix}

--- a/indexer/ingests_indexer/src/main/resources/application.conf
+++ b/indexer/ingests_indexer/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+aws.metrics.namespace=${?metrics_namespace}
+aws.sqs.queue.url=${?queue_url}
+es.host=${?es_host}
+es.port=${?es_port}
+es.username=${?es_username}
+es.password=${?es_password}
+es.protocol=${?es_protocol}
+es.ingests.indexPrefix=${?es_ingests_index_prefix}

--- a/indexer/ingests_indexer/src/main/resources/logback.xml
+++ b/indexer/ingests_indexer/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${logstash_host}:5142</destination>
+
+        <!-- encoder is required -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>
+                {"introspection": {"namespace":"${NAMESPACE:-unset}","service_id":"${SERVICE_ID:-unset}","task_id": "${TASK_ID:-unset}","image_id": "${IMAGE_ID:-unset}"}}
+            </customFields>
+        </encoder>
+    </appender>
+
+    <root level="${log_level:-INFO}">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="LOGSTASH"/>
+    </root>
+
+    <!-- reduce external logging -->
+    <logger name="org.apache.http" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
+    <logger name="com.amazonaws" level="WARN"/>
+</configuration>

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
@@ -32,9 +32,13 @@ class IngestsIndexerWorker(
     ingestIndexer
       .index(Seq(ingest)).map {
         case Right(_) =>
-          info(s"Successfully indexed ${ingest.id}")
+          debug(
+            s"Successfully indexed ${ingest.id} " +
+            s"(modified ${ingest.lastModifiedDate.getOrElse(ingest.createdDate)})")
           Successful(None)
 
+        // We can't be sure what the error is here.  The cost of retrying it is
+        // very cheap, so assume it's a flaky error and let it land on the DLQ if not.
         case Left(ingests) =>
           warn(s"Unable to index ${ingest.id}")
           NonDeterministicFailure(

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
@@ -7,8 +7,15 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
 import grizzled.slf4j.Logging
 import io.circe.Decoder
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
-import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
+import uk.ac.wellcome.messaging.worker.models.{
+  NonDeterministicFailure,
+  Result,
+  Successful
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.typesafe.Runnable
@@ -24,17 +31,20 @@ class IngestsIndexerWorker(
   val actorSystem: ActorSystem,
   val sqsAsync: AmazonSQSAsync,
   decoder: Decoder[Ingest]
-) extends Runnable with Logging {
+) extends Runnable
+    with Logging {
 
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   def process(ingest: Ingest): Future[Result[Unit]] =
     ingestIndexer
-      .index(Seq(ingest)).map {
+      .index(Seq(ingest))
+      .map {
         case Right(_) =>
           debug(
             s"Successfully indexed ${ingest.id} " +
-            s"(modified ${ingest.lastModifiedDate.getOrElse(ingest.createdDate)})")
+              s"(modified ${ingest.lastModifiedDate.getOrElse(ingest.createdDate)})"
+          )
           Successful(None)
 
         // We can't be sure what the error is here.  The cost of retrying it is
@@ -42,7 +52,8 @@ class IngestsIndexerWorker(
         case Left(ingests) =>
           warn(s"Unable to index ${ingest.id}")
           NonDeterministicFailure(
-            new Throwable(s"Error indexing ${ingest.id}"), summary = None
+            new Throwable(s"Error indexing ${ingest.id}"),
+            summary = None
           )
       }
 

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorker.scala
@@ -1,0 +1,52 @@
+package uk.ac.wellcome.platform.archive.indexer.ingests
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.sqs
+import akka.stream.alpakka.sqs.MessageAction
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.Message
+import grizzled.slf4j.Logging
+import io.circe.Decoder
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.typesafe.Runnable
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class IngestsIndexerWorker(
+  val config: AlpakkaSQSWorkerConfig,
+  ingestIndexer: IngestIndexer
+)(
+  implicit
+  val monitoringClient: MonitoringClient,
+  val actorSystem: ActorSystem,
+  val sqsAsync: AmazonSQSAsync,
+  decoder: Decoder[Ingest]
+) extends Runnable with Logging {
+
+  implicit val ec: ExecutionContext = actorSystem.dispatcher
+
+  def process(ingest: Ingest): Future[Result[Unit]] =
+    ingestIndexer
+      .index(Seq(ingest)).map {
+        case Right(_) =>
+          info(s"Successfully indexed ${ingest.id}")
+          Successful(None)
+
+        case Left(ingests) =>
+          warn(s"Unable to index ${ingest.id}")
+          NonDeterministicFailure(
+            new Throwable(s"Error indexing ${ingest.id}"), summary = None
+          )
+      }
+
+  val worker: AlpakkaSQSWorker[Ingest, Unit, MonitoringClient] =
+    new AlpakkaSQSWorker[Ingest, Unit, MonitoringClient](config)(process) {
+      override val retryAction: Message => (Message, sqs.MessageAction) =
+        (_, MessageAction.changeMessageVisibility(0))
+    }
+
+  def run(): Future[Any] = worker.start
+}

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
@@ -9,7 +9,11 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.indexer.elasticsearch.ElasticsearchIndexCreator
 import uk.ac.wellcome.platform.archive.indexer.elasticsearch.config.ElasticClientBuilder
@@ -62,7 +66,8 @@ object Main extends WellcomeTypesafeApp {
     )
 
     indexCreator.create(
-      index = index, mappingDefinition = IngestsIndexConfig.mapping
+      index = index,
+      mappingDefinition = IngestsIndexConfig.mapping
     )
 
     val ingestIndexer = new IngestIndexer(

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
@@ -1,0 +1,78 @@
+package uk.ac.wellcome.platform.archive.indexer.ingests
+
+import java.time.format.DateTimeFormatter
+import java.time.LocalDate
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.sksamuel.elastic4s.Index
+import com.typesafe.config.Config
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.ElasticsearchIndexCreator
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.config.ElasticClientBuilder
+import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
+import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+
+import scala.concurrent.ExecutionContextExecutor
+
+object Main extends WellcomeTypesafeApp {
+  runWithConfig { config: Config =>
+    implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
+
+    implicit val executionContext: ExecutionContextExecutor =
+      actorSystem.dispatcher
+
+    implicit val materializer: ActorMaterializer =
+      AkkaBuilder.buildActorMaterializer()
+
+    implicit val monitoringClient: CloudwatchMonitoringClient =
+      CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)
+
+    implicit val sqsClient: AmazonSQSAsync =
+      SQSBuilder.buildSQSAsyncClient(config)
+
+    // Ingests will be written a lot when they're initially processing, then never written
+    // again once the ingest completes.  Lots of writes upfront, then read-only.
+    //
+    // For this reason, we do initial writes into per-week indexes, and then aggregate them
+    // into a single index with a rollup job (https://www.elastic.co/guide/en/kibana/current/data-rollups.html)
+    //
+    // The per-week indexes are small and handle the intensive writes; the long-term index
+    // only gets written to by the rollup job.
+    //
+    // Because the app will scale to zero when it's not running, it's okay to let the
+    // index name be recomputed at startup.
+    //
+    val dateFormatter = DateTimeFormatter.ofPattern("%Y-week%U")
+    val currentWeek = dateFormatter.format(LocalDate.now())
+    val indexPrefix: String = config.getString("es.ingests.indexPrefix")
+    val indexName = s"$indexPrefix--$currentWeek"
+    val index = Index(indexName)
+
+    info(s"Writing ingests to per-week index $index")
+
+    info(s"Creating the Elasticsearch index mapping")
+    val elasticClient = ElasticClientBuilder.buildElasticClient(config)
+
+    val indexCreator = new ElasticsearchIndexCreator(
+      elasticClient = elasticClient
+    )
+
+    indexCreator.create(
+      index = index, mappingDefinition = IngestsIndexConfig.mapping
+    )
+
+    val ingestIndexer = new IngestIndexer(
+      client = elasticClient,
+      index = index
+    )
+
+    new IngestsIndexerWorker(
+      config = AlpakkaSqsWorkerConfigBuilder.build(config),
+      ingestIndexer = ingestIndexer
+    )
+  }
+}

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerFeatureTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerFeatureTest.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.platform.archive.indexer.ingests
+import java.util.UUID
+
+import io.circe.Json
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+import uk.ac.wellcome.platform.archive.indexer.ingests.fixtures.IngestsIndexerFixtures
+
+class IngestsIndexerFeatureTest extends FunSpec with Matchers with EitherValues with IngestsIndexerFixtures with IngestGenerators {
+  it("processes a single message") {
+    val ingest = createIngest
+
+    withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
+      withLocalSqsQueue { queue =>
+        withIngestsIndexerWorker(queue, index) { worker =>
+          worker.run()
+
+          sendNotificationToSQS(queue, ingest)
+
+          eventually {
+            val storedIngest =
+              getT[Json](index, id = ingest.id.toString)
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
+            storedIngestId shouldBe ingest.id.underlying
+          }
+        }
+      }
+    }
+  }
+}

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerFeatureTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerFeatureTest.scala
@@ -7,7 +7,12 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.indexer.ingests.fixtures.IngestsIndexerFixtures
 
-class IngestsIndexerFeatureTest extends FunSpec with Matchers with EitherValues with IngestsIndexerFixtures with IngestGenerators {
+class IngestsIndexerFeatureTest
+    extends FunSpec
+    with Matchers
+    with EitherValues
+    with IngestsIndexerFixtures
+    with IngestGenerators {
   it("processes a single message") {
     val ingest = createIngest
 
@@ -25,7 +30,8 @@ class IngestsIndexerFeatureTest extends FunSpec with Matchers with EitherValues 
                 .right
                 .value
 
-            val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
+            val storedIngestId =
+              UUID.fromString(storedIngest("id").asString.get)
             storedIngestId shouldBe ingest.id.underlying
           }
         }

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorkerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorkerTest.scala
@@ -5,11 +5,19 @@ import java.util.UUID
 import com.sksamuel.elastic4s.ElasticDsl.{properties, textField}
 import io.circe.Json
 import org.scalatest.{EitherValues, FunSpec, Matchers}
-import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Successful}
+import uk.ac.wellcome.messaging.worker.models.{
+  NonDeterministicFailure,
+  Successful
+}
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.indexer.ingests.fixtures.IngestsIndexerFixtures
 
-class IngestsIndexerWorkerTest extends FunSpec with Matchers with EitherValues with IngestsIndexerFixtures with IngestGenerators {
+class IngestsIndexerWorkerTest
+    extends FunSpec
+    with Matchers
+    with EitherValues
+    with IngestsIndexerFixtures
+    with IngestGenerators {
   it("processes a single message") {
     val ingest = createIngest
 

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorkerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexerWorkerTest.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.platform.archive.indexer.ingests
+
+import java.util.UUID
+
+import io.circe.Json
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.messaging.worker.models.Successful
+import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+import uk.ac.wellcome.platform.archive.indexer.ingests.fixtures.IngestsIndexerFixtures
+
+class IngestsIndexerWorkerTest extends FunSpec with Matchers with EitherValues with IngestsIndexerFixtures with IngestGenerators {
+  it("processes a single message") {
+    val ingest = createIngest
+
+    withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
+      val future =
+        withIngestsIndexerWorker(index = index) {
+          _.process(ingest)
+        }
+
+      whenReady(future) {
+        _ shouldBe a[Successful[_]]
+      }
+
+      val storedIngest =
+        getT[Json](index, id = ingest.id.toString)
+          .as[Map[String, Json]]
+          .right
+          .value
+
+      val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
+      storedIngestId shouldBe ingest.id.underlying
+    }
+  }
+}

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/fixtures/IngestsIndexerFixtures.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/fixtures/IngestsIndexerFixtures.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.archive.indexer.ingests.fixtures
+
+import com.sksamuel.elastic4s.Index
+import org.scalatest.Suite
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
+import uk.ac.wellcome.platform.archive.common.fixtures.MonitoringClientFixture
+import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.platform.archive.indexer.ingests.{IngestIndexer, IngestsIndexerWorker}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait IngestsIndexerFixtures extends ElasticsearchFixtures with Akka with AlpakkaSQSWorkerFixtures with MonitoringClientFixture { this: Suite =>
+  def withIngestsIndexerWorker[R](
+    queue: Queue = Queue("queue://test", "arn::test"),
+    index: Index
+  )(testWith: TestWith[IngestsIndexerWorker, R]): R = {
+    val ingestIndexer = new IngestIndexer(
+      client = elasticClient,
+      index = index
+    )
+
+    withActorSystem { implicit actorSystem =>
+      withMonitoringClient { implicit monitoringClient =>
+        val worker = new IngestsIndexerWorker(
+          config = createAlpakkaSQSWorkerConfig(queue),
+          ingestIndexer = ingestIndexer
+        )
+
+        testWith(worker)
+      }
+    }
+  }
+}

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/fixtures/IngestsIndexerFixtures.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/fixtures/IngestsIndexerFixtures.scala
@@ -9,11 +9,18 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.platform.archive.common.fixtures.MonitoringClientFixture
 import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.platform.archive.indexer.ingests.{IngestIndexer, IngestsIndexerWorker}
+import uk.ac.wellcome.platform.archive.indexer.ingests.{
+  IngestIndexer,
+  IngestsIndexerWorker
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait IngestsIndexerFixtures extends ElasticsearchFixtures with Akka with AlpakkaSQSWorkerFixtures with MonitoringClientFixture { this: Suite =>
+trait IngestsIndexerFixtures
+    extends ElasticsearchFixtures
+    with Akka
+    with AlpakkaSQSWorkerFixtures
+    with MonitoringClientFixture { this: Suite =>
   def withIngestsIndexerWorker[R](
     queue: Queue = Queue("queue://test", "arn::test"),
     index: Index


### PR DESCRIPTION
This allows the ingests indexer to, well, actually index things. Read off an SQS queue and log; there's no onward message here.