### PR TITLE
Fix a flaky bag verifier test

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -21,7 +21,7 @@ case object Checksum extends Logging {
     inputStream: InputStream,
     algorithm: HashingAlgorithm
   ): Try[Checksum] = {
-    debug(s"Creating Checksum for $inputStream with  $algorithm")
+    debug(s"Creating Checksum for $inputStream with $algorithm")
     val checksum = Hasher
       .hash(inputStream)
       .map { _.getChecksumValue(algorithm) }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -292,18 +292,6 @@ trait S3BagBuilderBase extends BagBuilderBase with S3Fixtures with Logging {
       payloadFileCount = payloadFileCount
     )
 
-    // This tracing is here to help debug a flaky issue in the
-    // bag verifier tests: https://github.com/wellcometrust/platform/issues/3952
-    //
-    // Specifically, sometimes when Travis creates a bag, it complains that
-    // the Payload-Oxum has one less file than in the bag manifest.  Hopefully
-    // if that is happening, we'll spot it here.
-    //
-    // Once that ticket is closed, this logging can be deleted.
-    debug(s"bagObjects = $bagObjects")
-    debug(s"bagRoot = $bagRoot")
-    debug(s"bagInfo = $bagInfo")
-
     implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
     uploadBagObjects(bagObjects)
 


### PR DESCRIPTION
This was an absolute pain to figure out -- a test that fails sometimes (and has been doing so since *October*), but with no apparent error or reason.

When I finally sat down to look at it more carefully, I found some suspicious clues:

-   I saw the bag starting to verify multiple times, and multiple "Verification started" ingest events being sent.
-   The bag seemed to complete verification successfully; there were no errors complaining about a bad checksum or anything.
-   The comment about payloads being received multiple times should have been more of a hint.
-   The exact assertion that was failing was around the size of the DLQ, not the queue.

So here's the issue:

The size of the bag is randomly chosen at test time, based on a couple of factors:

-   How many payload files are in the bag (5 to 50)
-   The path to each of those files (1 to 5 folders deep)
-   How much data is in each file (1 to 256 characters)

If the bag was sufficiently big, it would miss the SQS visibility timeout and be resent, and eventually the test would fail.  You could make the test fail reliably by increasing the lower bound (or fixing) the size of the bag to be suitably large.

Increasing the timeout on the SQS queue makes the problem go away.

Closes https://github.com/wellcomecollection/platform/issues/3952