### PR TITLE
Add a mapping for indexing storage manifests

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.http.models.{
   UserErrorResponse
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.storage.bags.api.models.ResponseDisplayBag
+import uk.ac.wellcome.platform.archive.display.manifests.DisplayStorageManifest
 import uk.ac.wellcome.storage.{NoMaximaValueError, NoVersionExistsError}
 
 import scala.concurrent.ExecutionContext
@@ -44,7 +44,7 @@ trait LookupBag extends Logging with ResponseBase {
       case Right(storageManifest) =>
         respondWithHeaders(etag) {
           complete(
-            ResponseDisplayBag(
+            DisplayStorageManifest(
               storageManifest = storageManifest,
               contextUrl = contextURL
             )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -35,7 +35,8 @@ trait StorageManifestGenerators
     space: StorageSpace = createStorageSpace,
     bagInfo: BagInfo = createBagInfo,
     version: BagVersion = createBagVersion,
-    fileCount: Int = 3
+    fileCount: Int = 3,
+    createdDate: Instant = Instant.now
   ): StorageManifest =
     StorageManifest(
       space = space,
@@ -65,7 +66,7 @@ trait StorageManifestGenerators
             prefix = createObjectLocationPrefix
           )
         },
-      createdDate = Instant.now,
+      createdDate = createdDate,
       ingestId = ingestId
     )
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFile.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFile.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFileManifest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFileManifest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.storage.models.FileManifest

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayStorageManifest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayStorageManifest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import java.net.URL
 
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.display.{
   DisplayStorageSpace
 }
 
-case class ResponseDisplayBag(
+case class DisplayStorageManifest(
   @JsonKey("@context") context: String,
   id: String,
   space: DisplayStorageSpace,
@@ -23,12 +23,12 @@ case class ResponseDisplayBag(
   @JsonKey("type") ontologyType: String = "Bag"
 )
 
-object ResponseDisplayBag {
+object DisplayStorageManifest {
   def apply(
     storageManifest: StorageManifest,
     contextUrl: URL
-  ): ResponseDisplayBag =
-    ResponseDisplayBag(
+  ): DisplayStorageManifest =
+    DisplayStorageManifest(
       context = contextUrl.toString,
       id = storageManifest.id.toString,
       space = DisplayStorageSpace(storageManifest.space.underlying),

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/ResponseDisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/manifests/ResponseDisplayBagInfo.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFileManifestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayFileManifestTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayStorageManifestInfoTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/manifests/DisplayStorageManifestInfoTest.scala
@@ -1,11 +1,11 @@
-package uk.ac.wellcome.platform.storage.bags.api.models
+package uk.ac.wellcome.platform.archive.display.manifests
 
 import java.time.format.DateTimeFormatter
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.BagInfoGenerators
 
-class ResponseDisplayBagInfoTest
+class DisplayStorageManifestInfoTest
     extends FunSpec
     with Matchers
     with BagInfoGenerators {

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.archive.indexer.bag
+
+import java.net.URL
+
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import io.circe._
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+import uk.ac.wellcome.platform.archive.display.manifests.DisplayStorageManifest
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.Indexer
+
+import scala.concurrent.ExecutionContext
+
+class ManifestIndexer(val client: ElasticClient, val index: Index)(
+  implicit
+  val ec: ExecutionContext,
+  val encoder: Encoder[DisplayStorageManifest]
+) extends Indexer[StorageManifest, DisplayStorageManifest] {
+
+  override protected def id(storageManifest: StorageManifest): String =
+    storageManifest.idWithVersion
+
+  override protected def toDisplay(storageManifest: StorageManifest): DisplayStorageManifest =
+    DisplayStorageManifest(
+      storageManifest = storageManifest,
+      contextUrl = new URL("http://localhost:9200")
+    )
+
+  override protected def version(storageManifest: StorageManifest): Long =
+    storageManifest.createdDate.toEpochMilli
+}

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
@@ -19,7 +19,9 @@ class ManifestIndexer(val client: ElasticClient, val index: Index)(
   override protected def id(storageManifest: StorageManifest): String =
     storageManifest.idWithVersion
 
-  override protected def toDisplay(storageManifest: StorageManifest): DisplayStorageManifest =
+  override protected def toDisplay(
+    storageManifest: StorageManifest
+  ): DisplayStorageManifest =
     DisplayStorageManifest(
       storageManifest = storageManifest,
       contextUrl = new URL("http://localhost:9200")

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestsIndexConfig.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestsIndexConfig.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.platform.archive.indexer.bag
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.mappings.{FieldDefinition, KeywordField, ObjectField}
+import com.sksamuel.elastic4s.requests.mappings.{
+  FieldDefinition,
+  KeywordField,
+  ObjectField
+}
 import uk.ac.wellcome.platform.archive.indexer.elasticsearch.IndexConfig
 
 object ManifestsIndexConfig extends IndexConfig {

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestsIndexConfig.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestsIndexConfig.scala
@@ -1,0 +1,48 @@
+package uk.ac.wellcome.platform.archive.indexer.bag
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.mappings.{FieldDefinition, KeywordField, ObjectField}
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.IndexConfig
+
+object ManifestsIndexConfig extends IndexConfig {
+  protected def keywordFieldWithText(name: String): KeywordField =
+    keywordField(name).fields(textField("text"))
+
+  private val displayInfoFields: Seq[FieldDefinition] = Seq(
+    keywordFieldWithText("externalIdentifier"),
+    keywordField("payloadOxum"),
+    dateField("baggingDate"),
+    keywordField("sourceOrganization"),
+    keywordField("externalDescription"),
+    keywordField("internalSenderIdentifier"),
+    keywordField("internalSenderDescription"),
+    keywordField("type")
+  )
+
+  private def displayManifestFields(name: String): ObjectField =
+    objectField(name).fields(
+      keywordField("checksumAlgorithm"),
+      objectField("files").fields(
+        keywordField("checksum"),
+        keywordFieldWithText("name"),
+        keywordField("path"),
+        longField("size"),
+        keywordField("type")
+      ),
+      keywordField("type")
+    )
+
+  override protected val fields: Seq[FieldDefinition] =
+    Seq(
+      keywordFieldWithText("id"),
+      objectField("space").fields(displaySpaceFields),
+      objectField("info").fields(displayInfoFields),
+      displayManifestFields("manifest"),
+      displayManifestFields("tagManifest"),
+      objectField("location").fields(displayLocationFields),
+      objectField("replicaLocations").fields(displayLocationFields),
+      dateField("createdDate"),
+      keywordField("version"),
+      keywordField("type")
+    )
+}

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
@@ -15,35 +15,43 @@ import uk.ac.wellcome.platform.archive.indexer.IndexerTestCases
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ManifestIndexerTest
-  extends IndexerTestCases[StorageManifest, DisplayStorageManifest]
+    extends IndexerTestCases[StorageManifest, DisplayStorageManifest]
     with StorageManifestGenerators {
 
   override val mapping: MappingDefinition = ManifestsIndexConfig.mapping
 
-  override def createIndexer(client: ElasticClient, index: Index): ManifestIndexer =
+  override def createIndexer(
+    client: ElasticClient,
+    index: Index
+  ): ManifestIndexer =
     new ManifestIndexer(client, index = index)
 
   override def createDocument: StorageManifest = createStorageManifest
 
-  override def id(storageManifest: StorageManifest): String = storageManifest.idWithVersion
+  override def id(storageManifest: StorageManifest): String =
+    storageManifest.idWithVersion
 
   override def assertMatch(
     storedManifest: Map[String, Json],
-    manifest: StorageManifest): Assertion = {
+    manifest: StorageManifest
+  ): Assertion = {
     val storedId = storedManifest("id").asString.get
     storedId shouldBe manifest.id.toString
 
     val fileManifest =
       storedManifest("manifest")
-        .as[Map[String, Json]].right.get
+        .as[Map[String, Json]]
+        .right
+        .get
 
     val filenames =
-      fileManifest("files")
-        .asArray.get
+      fileManifest("files").asArray.get
         .map { _.as[Map[String, Json]].right.get }
         .map { _("name").asString.get }
 
-    filenames should contain theSameElementsAs manifest.manifest.files.map { _.name }
+    filenames should contain theSameElementsAs manifest.manifest.files.map {
+      _.name
+    }
   }
 
   override def createDocumentPair: (StorageManifest, StorageManifest) = {

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
@@ -28,13 +28,13 @@ class ManifestIndexerTest
   override def id(storageManifest: StorageManifest): String = storageManifest.idWithVersion
 
   override def assertMatch(
-    storedDocument: Map[String, Json],
-    storageManifest: StorageManifest): Assertion = {
-    val storedId = storedDocument("id").asString.get
-    storedId shouldBe storageManifest.id.toString
+    storedManifest: Map[String, Json],
+    manifest: StorageManifest): Assertion = {
+    val storedId = storedManifest("id").asString.get
+    storedId shouldBe manifest.id.toString
 
     val fileManifest =
-      storedDocument("manifest")
+      storedManifest("manifest")
         .as[Map[String, Json]].right.get
 
     val filenames =
@@ -43,7 +43,7 @@ class ManifestIndexerTest
         .map { _.as[Map[String, Json]].right.get }
         .map { _("name").asString.get }
 
-    filenames should contain theSameElementsAs storageManifest.manifest.files.map { _.name }
+    filenames should contain theSameElementsAs manifest.manifest.files.map { _.name }
   }
 
   override def createDocumentPair: (StorageManifest, StorageManifest) = {

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
@@ -1,0 +1,244 @@
+package uk.ac.wellcome.platform.archive.indexer.bag
+
+import java.time.Instant
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.http.JavaClientExceptionWrapper
+import io.circe.Json
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.ElasticClientFactory
+import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ManifestIndexerTest extends FunSpec with Matchers with EitherValues with ElasticsearchFixtures with StorageManifestGenerators {
+  it("indexes a single manifest") {
+    withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+      val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+      val manifest = createStorageManifest
+
+      whenReady(manifestIndexer.index(manifest)) { result =>
+        result.right.value shouldBe manifest
+
+        val storedManifest =
+          getT[Json](index, id = manifest.idWithVersion)
+            .as[Map[String, Json]]
+            .right
+            .value
+
+        val storedId = storedManifest("id").asString.get
+        storedId shouldBe manifest.id.toString
+      }
+    }
+  }
+
+  it("indexes multiple manifests") {
+    withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+      val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+      val manifestCount = 10
+      val manifests = (1 to manifestCount).map { _ =>
+        createStorageManifest
+      }
+
+      whenReady(manifestIndexer.index(manifests)) { result =>
+        result.right.value shouldBe manifests
+
+        eventually {
+          val storedManifests = searchT[Json](index, query = matchAllQuery())
+
+          storedManifests should have size manifestCount
+
+          val storedIds =
+            storedManifests
+              .map { _.as[Map[String, Json]].right.value }
+              .map { _("id").asString.get }
+
+          storedIds shouldBe manifests.map { _.id.toString }
+        }
+      }
+    }
+  }
+
+  it("returns a Left if the document can't be indexed correctly") {
+    val manifest = createStorageManifest
+
+    val badMapping = properties(
+      Seq(textField("name"))
+    )
+
+    withLocalElasticsearchIndex(badMapping) { index =>
+      val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+      whenReady(manifestIndexer.index(manifest)) {
+        _.left.value shouldBe manifest
+      }
+    }
+  }
+
+  it("fails if Elasticsearch doesn't respond") {
+    val badClient = ElasticClientFactory.create(
+      hostname = esHost,
+      port = esPort + 1,
+      protocol = "http",
+      username = "elastic",
+      password = "changeme"
+    )
+
+    val index = createIndex
+    val manifestIndexer = new ManifestIndexer(badClient, index = index)
+
+    val manifest = createStorageManifest
+
+    whenReady(manifestIndexer.index(manifest).failed) {
+      _ shouldBe a[JavaClientExceptionWrapper]
+    }
+  }
+
+  describe("orders updates correctly") {
+    describe("when both manifests have a modified date") {
+      val space = createStorageSpace
+      val externalIdentifier = createExternalIdentifier
+
+      val olderManifest = createStorageManifestWith(
+        space = space,
+        bagInfo = createBagInfoWith(
+          externalIdentifier = externalIdentifier
+        ),
+        createdDate = Instant.ofEpochMilli(1)
+      )
+
+      val newerManifest = createStorageManifestWith(
+        space = space,
+        bagInfo = createBagInfoWith(
+          externalIdentifier = externalIdentifier
+        ),
+        createdDate = Instant.ofEpochMilli(2)
+      )
+
+      it("a newer ingest replaces an older ingest") {
+        withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+          val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+          val future = manifestIndexer
+            .index(olderManifest)
+            .flatMap { _ =>
+              manifestIndexer.index(newerManifest)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe newerManifest
+
+            val storedManifest =
+              getT[Json](index, id = olderManifest.idWithVersion)
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            val storedId = storedManifest("id").asString.get
+            storedId shouldBe olderManifest.id.toString
+          }
+        }
+      }
+
+      it("an older ingest does not replace a newer ingest") {
+        withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+          val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+          val future = manifestIndexer
+            .index(newerManifest)
+            .flatMap { _ =>
+              manifestIndexer.index(olderManifest)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe olderManifest
+
+            val storedManifest =
+              getT[Json](index, id = olderManifest.idWithVersion)
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            val storedId = storedManifest("id").asString.get
+            storedId shouldBe olderManifest.id.toString
+          }
+        }
+      }
+    }
+
+    describe("when one ingest does not have a modified date") {
+      val space = createStorageSpace
+      val externalIdentifier = createExternalIdentifier
+
+      val olderManifest = createStorageManifestWith(
+        space = space,
+        bagInfo = createBagInfoWith(
+          externalIdentifier = externalIdentifier
+        ),
+        createdDate = Instant.ofEpochMilli(1)
+      )
+
+      val newerManifest = createStorageManifestWith(
+        space = space,
+        bagInfo = createBagInfoWith(
+          externalIdentifier = externalIdentifier
+        ),
+        createdDate = Instant.ofEpochMilli(2)
+      )
+
+      it("a newer ingest replaces an older ingest") {
+        withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+          val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+          val future = manifestIndexer
+            .index(olderManifest)
+            .flatMap { _ =>
+              manifestIndexer.index(newerManifest)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe newerManifest
+
+            val storedManifest =
+              getT[Json](index, id = olderManifest.idWithVersion)
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            val storedId = storedManifest("id").asString.get
+            storedId shouldBe olderManifest.id.toString
+          }
+        }
+      }
+
+      it("an older ingest does not replace a newer ingest") {
+        withLocalElasticsearchIndex(ManifestsIndexConfig.mapping) { index =>
+          val manifestIndexer = new ManifestIndexer(elasticClient, index = index)
+
+          val future = manifestIndexer
+            .index(newerManifest)
+            .flatMap { _ =>
+              manifestIndexer.index(olderManifest)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe olderManifest
+
+            val storedManifest =
+              getT[Json](index, id = olderManifest.idWithVersion)
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            val storedId = storedManifest("id").asString.get
+            storedId shouldBe olderManifest.id.toString
+          }
+        }
+      }
+    }
+  }
+}

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/IndexConfig.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/IndexConfig.scala
@@ -34,6 +34,12 @@ trait IndexConfig {
       keywordField("type")
     )
 
+  protected val displaySpaceFields: Seq[FieldDefinition] =
+    Seq(
+      keywordField("id"),
+      keywordField("type")
+    )
+
   protected val fields: Seq[FieldDefinition]
 
   def mapping: MappingDefinition =

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
@@ -90,6 +90,13 @@ trait Indexer[Document, DisplayDocument] extends Logging {
     }
   }
 
+  final def index(document: Document): Future[Either[Document, Document]] =
+    index(Seq(document))
+      .map {
+        case Right(Seq(doc)) => Right(doc)
+        case Left(Seq(doc))  => Left(doc)
+      }
+
   private def isVersionConflictException(
     bulkResponseItem: BulkResponseItem
   ): Boolean = {

--- a/indexer/common/src/test/scala/uk/ac/wellcome/platform/archive/indexer/IndexerTestCases.scala
+++ b/indexer/common/src/test/scala/uk/ac/wellcome/platform/archive/indexer/IndexerTestCases.scala
@@ -1,0 +1,162 @@
+package uk.ac.wellcome.platform.archive.indexer
+
+import com.sksamuel.elastic4s.ElasticDsl.{matchAllQuery, properties, textField}
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.http.JavaClientExceptionWrapper
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import io.circe.Json
+import org.scalatest.{Assertion, EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.{ElasticClientFactory, Indexer}
+import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait IndexerTestCases[Document, DisplayDocument]
+  extends FunSpec
+    with Matchers
+    with EitherValues
+    with ElasticsearchFixtures {
+  val mapping: MappingDefinition
+
+  def createIndexer(client: ElasticClient, index: Index): Indexer[Document, DisplayDocument]
+
+  def createDocument: Document
+  def id(document: Document): String
+
+  def assertMatch(storedDocument: Map[String, Json], expectedDocument: Document): Assertion
+
+  // Create a pair of documents: one older, one newer
+  def createDocumentPair: (Document, Document)
+
+  describe("it behaves as an Indexer") {
+    it("indexes a single document") {
+      withLocalElasticsearchIndex(mapping) { index =>
+        val indexer = createIndexer(elasticClient, index = index)
+
+        val document = createDocument
+
+        whenReady(indexer.index(document)) { result =>
+          result.right.value shouldBe document
+
+          val storedDocument: Map[String, Json] =
+            getT[Json](index, id = id(document))
+              .as[Map[String, Json]]
+              .right
+              .value
+
+          assertMatch(storedDocument, document)
+        }
+      }
+    }
+
+    it("indexes multiple documents") {
+      withLocalElasticsearchIndex(mapping) { index =>
+        val indexer = createIndexer(elasticClient, index = index)
+
+        val documentCount = 10
+        val documents = (1 to documentCount).map { _ =>
+          createDocument
+        }
+
+        whenReady(indexer.index(documents)) { result =>
+          result.right.value shouldBe documents
+
+          eventually {
+            val storedManifests = searchT[Json](index, query = matchAllQuery())
+
+            storedManifests should have size documentCount
+          }
+        }
+      }
+    }
+
+    it("returns a Left if the document can't be indexed correctly") {
+      val document = createDocument
+
+      val badMapping = properties(
+        Seq(textField("name"))
+      )
+
+      withLocalElasticsearchIndex(badMapping) { index =>
+        val indexer = createIndexer(elasticClient, index = index)
+
+        whenReady(indexer.index(document)) {
+          _.left.value shouldBe document
+        }
+      }
+    }
+
+    it("fails if Elasticsearch doesn't respond") {
+      val badClient = ElasticClientFactory.create(
+        hostname = esHost,
+        port = esPort + 1,
+        protocol = "http",
+        username = "elastic",
+        password = "changeme"
+      )
+
+      val index = createIndex
+      val indexer = createIndexer(badClient, index = index)
+
+      val document = createDocument
+
+      whenReady(indexer.index(document).failed) {
+        _ shouldBe a[JavaClientExceptionWrapper]
+      }
+    }
+
+    describe("orders updates correctly") {
+      it("a newer document replaces an older document") {
+        val (olderDocument, newerDocument) = createDocumentPair
+
+        withLocalElasticsearchIndex(mapping) { index =>
+          val indexer = createIndexer(elasticClient, index = index)
+
+          val future = indexer
+            .index(olderDocument)
+            .flatMap { _ =>
+              indexer.index(newerDocument)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe newerDocument
+
+            val storedDocument =
+              getT[Json](index, id = id(olderDocument))
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            assertMatch(storedDocument, newerDocument)
+          }
+        }
+      }
+
+      it("an older document replaces an newer document") {
+        val (olderDocument, newerDocument) = createDocumentPair
+
+        withLocalElasticsearchIndex(mapping) { index =>
+          val indexer = createIndexer(elasticClient, index = index)
+
+          val future = indexer
+            .index(newerDocument)
+            .flatMap { _ =>
+              indexer.index(olderDocument)
+            }
+
+          whenReady(future) { result =>
+            result.right.value shouldBe olderDocument
+
+            val storedDocument =
+              getT[Json](index, id = id(olderDocument))
+                .as[Map[String, Json]]
+                .right
+                .value
+
+            assertMatch(storedDocument, newerDocument)
+          }
+        }
+      }
+    }
+  }
+}

--- a/indexer/common/src/test/scala/uk/ac/wellcome/platform/archive/indexer/IndexerTestCases.scala
+++ b/indexer/common/src/test/scala/uk/ac/wellcome/platform/archive/indexer/IndexerTestCases.scala
@@ -6,24 +6,33 @@ import com.sksamuel.elastic4s.http.JavaClientExceptionWrapper
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import io.circe.Json
 import org.scalatest.{Assertion, EitherValues, FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.indexer.elasticsearch.{ElasticClientFactory, Indexer}
+import uk.ac.wellcome.platform.archive.indexer.elasticsearch.{
+  ElasticClientFactory,
+  Indexer
+}
 import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait IndexerTestCases[Document, DisplayDocument]
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with EitherValues
     with ElasticsearchFixtures {
   val mapping: MappingDefinition
 
-  def createIndexer(client: ElasticClient, index: Index): Indexer[Document, DisplayDocument]
+  def createIndexer(
+    client: ElasticClient,
+    index: Index
+  ): Indexer[Document, DisplayDocument]
 
   def createDocument: Document
   def id(document: Document): String
 
-  def assertMatch(storedDocument: Map[String, Json], expectedDocument: Document): Assertion
+  def assertMatch(
+    storedDocument: Map[String, Json],
+    expectedDocument: Document
+  ): Assertion
 
   // Create a pair of documents: one older, one newer
   def createDocumentPair: (Document, Document)

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexConfig.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestsIndexConfig.scala
@@ -24,12 +24,6 @@ object IngestsIndexConfig extends IndexConfig {
       keywordField("type")
     )
 
-  private val displaySpaceFields: Seq[FieldDefinition] =
-    Seq(
-      keywordField("id"),
-      keywordField("type")
-    )
-
   private val displayIngestEventFields: Seq[FieldDefinition] =
     Seq(
       textField("description"),

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -10,26 +10,35 @@ import org.scalatest.Assertion
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestEvent}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestEvent
+}
 import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
 import uk.ac.wellcome.platform.archive.indexer.IndexerTestCases
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IngestIndexerTest
-  extends IndexerTestCases[Ingest, ResponseDisplayIngest]
+    extends IndexerTestCases[Ingest, ResponseDisplayIngest]
     with IngestGenerators {
 
   override val mapping: MappingDefinition = IngestsIndexConfig.mapping
 
-  override def createIndexer(client: ElasticClient, index: Index): IngestIndexer =
+  override def createIndexer(
+    client: ElasticClient,
+    index: Index
+  ): IngestIndexer =
     new IngestIndexer(client, index = index)
 
   override def createDocument: Ingest = createIngest
 
   override def id(ingest: Ingest): String = ingest.id.toString
 
-  override def assertMatch(storedIngest: Map[String, Json], ingest: Ingest): Assertion = {
+  override def assertMatch(
+    storedIngest: Map[String, Json],
+    ingest: Ingest
+  ): Assertion = {
     val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
     storedIngestId shouldBe ingest.id.underlying
 

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -3,275 +3,154 @@ package uk.ac.wellcome.platform.archive.indexer.ingests
 import java.time.Instant
 import java.util.UUID
 
-import com.sksamuel.elastic4s.ElasticDsl.{matchAllQuery, properties, textField}
-import com.sksamuel.elastic4s.http.JavaClientExceptionWrapper
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import com.sksamuel.elastic4s.{ElasticClient, Index}
 import io.circe.Json
-import org.scalatest.{EitherValues, FunSpec, Matchers}
+import org.scalatest.Assertion
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestEvent
-import uk.ac.wellcome.platform.archive.indexer.elasticsearch.ElasticClientFactory
-import uk.ac.wellcome.platform.archive.indexer.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestEvent}
+import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
+import uk.ac.wellcome.platform.archive.indexer.IndexerTestCases
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IngestIndexerTest
-    extends FunSpec
-    with Matchers
-    with EitherValues
-    with IngestGenerators
-    with ElasticsearchFixtures {
+  extends IndexerTestCases[Ingest, ResponseDisplayIngest]
+    with IngestGenerators {
 
-  it("indexes a single ingest") {
-    withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-      val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
+  override val mapping: MappingDefinition = IngestsIndexConfig.mapping
 
-      val ingest = createIngest
+  override def createIndexer(client: ElasticClient, index: Index): IngestIndexer =
+    new IngestIndexer(client, index = index)
 
-      whenReady(ingestsIndexer.index(ingest)) { result =>
-        result.right.value shouldBe ingest
+  override def createDocument: Ingest = createIngest
 
-        val storedIngest =
-          getT[Json](index, id = ingest.id.toString)
-            .as[Map[String, Json]]
-            .right
-            .value
+  override def id(ingest: Ingest): String = ingest.id.toString
 
-        val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
-        storedIngestId shouldBe ingest.id.underlying
+  override def assertMatch(storedIngest: Map[String, Json], ingest: Ingest): Assertion = {
+    val storedIngestId = UUID.fromString(storedIngest("id").asString.get)
+    storedIngestId shouldBe ingest.id.underlying
 
-        val storedExternalIdentifier = ExternalIdentifier(
-          storedIngest("bag").asObject.get
-            .toMap("info")
-            .asObject
-            .get
-            .toMap("externalIdentifier")
-            .asString
-            .get
+    val storedExternalIdentifier = ExternalIdentifier(
+      storedIngest("bag").asObject.get
+        .toMap("info")
+        .asObject
+        .get
+        .toMap("externalIdentifier")
+        .asString
+        .get
+    )
+    storedExternalIdentifier shouldBe ingest.externalIdentifier
+  }
+
+  override def createDocumentPair: (Ingest, Ingest) = {
+    val ingestId = createIngestID
+
+    val olderIngest = createIngestWith(
+      id = ingestId,
+      events = Seq(
+        IngestEvent(
+          description = "event 1",
+          createdDate = Instant.ofEpochMilli(101)
         )
-        storedExternalIdentifier shouldBe ingest.externalIdentifier
-      }
-    }
-  }
-
-  it("indexes multiple ingests") {
-    withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-      val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
-
-      val ingestCount = 10
-      val ingests = (1 to ingestCount).map { _ =>
-        createIngest
-      }
-
-      whenReady(ingestsIndexer.index(ingests)) { result =>
-        result.right.value shouldBe ingests
-
-        eventually {
-          val storedIngests = searchT[Json](index, query = matchAllQuery())
-
-          storedIngests should have size ingestCount
-
-          val storedIds =
-            storedIngests
-              .map { _.as[Map[String, Json]].right.value }
-              .map { _("id").asString.get }
-
-          storedIds shouldBe ingests.map { _.id.toString }
-        }
-      }
-    }
-  }
-
-  it("returns a Left if the document can't be indexed correctly") {
-    val ingest = createIngest
-
-    val badMapping = properties(
-      Seq(textField("name"))
+      ),
+      createdDate = Instant.ofEpochMilli(1)
     )
 
-    withLocalElasticsearchIndex(badMapping) { index =>
-      val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
-
-      whenReady(ingestsIndexer.index(ingest)) {
-        _.left.value shouldBe ingest
-      }
-    }
-  }
-
-  it("fails if Elasticsearch doesn't respond") {
-    val badClient = ElasticClientFactory.create(
-      hostname = esHost,
-      port = esPort + 1,
-      protocol = "http",
-      username = "elastic",
-      password = "changeme"
+    val newerIngest = olderIngest.copy(
+      events = Seq(
+        IngestEvent(
+          description = "event 1",
+          createdDate = Instant.ofEpochMilli(101)
+        ),
+        IngestEvent(
+          description = "event 2",
+          createdDate = Instant.ofEpochMilli(102)
+        )
+      ),
+      createdDate = Instant.ofEpochMilli(2)
     )
 
-    val index = createIndex
-    val ingestsIndexer = new IngestIndexer(badClient, index = index)
+    assert(
+      olderIngest.lastModifiedDate.get
+        .isBefore(newerIngest.lastModifiedDate.get)
+    )
 
-    val ingest = createIngest
-
-    whenReady(ingestsIndexer.index(ingest).failed) {
-      _ shouldBe a[JavaClientExceptionWrapper]
-    }
+    (olderIngest, newerIngest)
   }
 
-  describe("orders updates correctly") {
-    describe("when both ingests have a modified date") {
-      val ingestId = createIngestID
+  describe("orders updates when one ingest does not have a modified date") {
+    val ingestId = createIngestID
 
-      val olderIngest = createIngestWith(
-        id = ingestId,
-        events = Seq(
-          IngestEvent(
-            description = "event 1",
-            createdDate = Instant.ofEpochMilli(101)
-          )
+    val olderIngest = createIngestWith(
+      id = ingestId,
+      events = Seq.empty,
+      createdDate = Instant.ofEpochMilli(1)
+    )
+
+    val newerIngest = olderIngest.copy(
+      events = Seq(
+        IngestEvent(
+          description = "event 1",
+          createdDate = Instant.ofEpochMilli(101)
         ),
-        createdDate = Instant.ofEpochMilli(1)
-      )
+        IngestEvent(
+          description = "event 2",
+          createdDate = Instant.ofEpochMilli(102)
+        )
+      ),
+      createdDate = Instant.ofEpochMilli(2)
+    )
 
-      val newerIngest = olderIngest.copy(
-        events = Seq(
-          IngestEvent(
-            description = "event 1",
-            createdDate = Instant.ofEpochMilli(101)
-          ),
-          IngestEvent(
-            description = "event 2",
-            createdDate = Instant.ofEpochMilli(102)
-          )
-        ),
-        createdDate = Instant.ofEpochMilli(2)
-      )
+    assert(olderIngest.lastModifiedDate.isEmpty)
+    assert(newerIngest.lastModifiedDate.isDefined)
 
-      assert(
-        olderIngest.lastModifiedDate.get
-          .isBefore(newerIngest.lastModifiedDate.get)
-      )
+    it("a newer ingest replaces an older ingest") {
+      withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
+        val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
-      it("a newer ingest replaces an older ingest") {
-        withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-          val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
-
-          val future = ingestsIndexer
-            .index(olderIngest)
-            .flatMap { _ =>
-              ingestsIndexer.index(newerIngest)
-            }
-
-          whenReady(future) { result =>
-            result.right.value shouldBe newerIngest
-
-            val storedIngest =
-              getT[Json](index, id = ingestId.toString)
-                .as[Map[String, Json]]
-                .right
-                .value
-
-            storedIngest("events").asArray.get.size shouldBe 2
+        val future = ingestsIndexer
+          .index(olderIngest)
+          .flatMap { _ =>
+            ingestsIndexer.index(newerIngest)
           }
-        }
-      }
 
-      it("an older ingest does not replace a newer ingest") {
-        withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-          val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
+        whenReady(future) { result =>
+          result.right.value shouldBe newerIngest
 
-          val future = ingestsIndexer
-            .index(newerIngest)
-            .flatMap { _ =>
-              ingestsIndexer.index(olderIngest)
-            }
+          val storedIngest =
+            getT[Json](index, id = ingestId.toString)
+              .as[Map[String, Json]]
+              .right
+              .value
 
-          whenReady(future) { result =>
-            result.right.value shouldBe olderIngest
-
-            val storedIngest =
-              getT[Json](index, id = ingestId.toString)
-                .as[Map[String, Json]]
-                .right
-                .value
-
-            storedIngest("events").asArray.get.size shouldBe 2
-          }
+          storedIngest("events").asArray.get.size shouldBe 2
         }
       }
     }
 
-    describe("when one ingest does not have a modified date") {
-      val ingestId = createIngestID
+    it("an older ingest does not replace a newer ingest") {
+      withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
+        val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
-      val olderIngest = createIngestWith(
-        id = ingestId,
-        events = Seq.empty,
-        createdDate = Instant.ofEpochMilli(1)
-      )
-
-      val newerIngest = olderIngest.copy(
-        events = Seq(
-          IngestEvent(
-            description = "event 1",
-            createdDate = Instant.ofEpochMilli(101)
-          ),
-          IngestEvent(
-            description = "event 2",
-            createdDate = Instant.ofEpochMilli(102)
-          )
-        ),
-        createdDate = Instant.ofEpochMilli(2)
-      )
-
-      assert(olderIngest.lastModifiedDate.isEmpty)
-      assert(newerIngest.lastModifiedDate.isDefined)
-
-      it("a newer ingest replaces an older ingest") {
-        withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-          val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
-
-          val future = ingestsIndexer
-            .index(olderIngest)
-            .flatMap { _ =>
-              ingestsIndexer.index(newerIngest)
-            }
-
-          whenReady(future) { result =>
-            result.right.value shouldBe newerIngest
-
-            val storedIngest =
-              getT[Json](index, id = ingestId.toString)
-                .as[Map[String, Json]]
-                .right
-                .value
-
-            storedIngest("events").asArray.get.size shouldBe 2
+        val future = ingestsIndexer
+          .index(newerIngest)
+          .flatMap { _ =>
+            ingestsIndexer.index(olderIngest)
           }
-        }
-      }
 
-      it("an older ingest does not replace a newer ingest") {
-        withLocalElasticsearchIndex(IngestsIndexConfig.mapping) { index =>
-          val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
+        whenReady(future) { result =>
+          result.right.value shouldBe olderIngest
 
-          val future = ingestsIndexer
-            .index(newerIngest)
-            .flatMap { _ =>
-              ingestsIndexer.index(olderIngest)
-            }
+          val storedIngest =
+            getT[Json](index, id = ingestId.toString)
+              .as[Map[String, Json]]
+              .right
+              .value
 
-          whenReady(future) { result =>
-            result.right.value shouldBe olderIngest
-
-            val storedIngest =
-              getT[Json](index, id = ingestId.toString)
-                .as[Map[String, Json]]
-                .right
-                .value
-
-            storedIngest("events").asArray.get.size shouldBe 2
-          }
+          storedIngest("events").asArray.get.size shouldBe 2
         }
       }
     }

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -29,8 +29,8 @@ class IngestIndexerTest
 
       val ingest = createIngest
 
-      whenReady(ingestsIndexer.index(Seq(ingest))) { result =>
-        result.right.value shouldBe Seq(ingest)
+      whenReady(ingestsIndexer.index(ingest)) { result =>
+        result.right.value shouldBe ingest
 
         val storedIngest =
           getT[Json](index, id = ingest.id.toString)
@@ -93,8 +93,8 @@ class IngestIndexerTest
     withLocalElasticsearchIndex(badMapping) { index =>
       val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
-      whenReady(ingestsIndexer.index(Seq(ingest))) {
-        _.left.value shouldBe Seq(ingest)
+      whenReady(ingestsIndexer.index(ingest)) {
+        _.left.value shouldBe ingest
       }
     }
   }
@@ -113,7 +113,7 @@ class IngestIndexerTest
 
     val ingest = createIngest
 
-    whenReady(ingestsIndexer.index(Seq(ingest)).failed) {
+    whenReady(ingestsIndexer.index(ingest).failed) {
       _ shouldBe a[JavaClientExceptionWrapper]
     }
   }
@@ -157,13 +157,13 @@ class IngestIndexerTest
           val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
           val future = ingestsIndexer
-            .index(Seq(olderIngest))
+            .index(olderIngest)
             .flatMap { _ =>
-              ingestsIndexer.index(Seq(newerIngest))
+              ingestsIndexer.index(newerIngest)
             }
 
           whenReady(future) { result =>
-            result.right.value shouldBe Seq(newerIngest)
+            result.right.value shouldBe newerIngest
 
             val storedIngest =
               getT[Json](index, id = ingestId.toString)
@@ -181,13 +181,13 @@ class IngestIndexerTest
           val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
           val future = ingestsIndexer
-            .index(Seq(newerIngest))
+            .index(newerIngest)
             .flatMap { _ =>
-              ingestsIndexer.index(Seq(olderIngest))
+              ingestsIndexer.index(olderIngest)
             }
 
           whenReady(future) { result =>
-            result.right.value shouldBe Seq(olderIngest)
+            result.right.value shouldBe olderIngest
 
             val storedIngest =
               getT[Json](index, id = ingestId.toString)
@@ -232,13 +232,13 @@ class IngestIndexerTest
           val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
           val future = ingestsIndexer
-            .index(Seq(olderIngest))
+            .index(olderIngest)
             .flatMap { _ =>
-              ingestsIndexer.index(Seq(newerIngest))
+              ingestsIndexer.index(newerIngest)
             }
 
           whenReady(future) { result =>
-            result.right.value shouldBe Seq(newerIngest)
+            result.right.value shouldBe newerIngest
 
             val storedIngest =
               getT[Json](index, id = ingestId.toString)
@@ -256,13 +256,13 @@ class IngestIndexerTest
           val ingestsIndexer = new IngestIndexer(elasticClient, index = index)
 
           val future = ingestsIndexer
-            .index(Seq(newerIngest))
+            .index(newerIngest)
             .flatMap { _ =>
-              ingestsIndexer.index(Seq(olderIngest))
+              ingestsIndexer.index(olderIngest)
             }
 
           whenReady(future) { result =>
-            result.right.value shouldBe Seq(olderIngest)
+            result.right.value shouldBe olderIngest
 
             val storedIngest =
               getT[Json](index, id = ingestId.toString)


### PR DESCRIPTION
Follows #483, the first half of https://github.com/wellcomecollection/platform/issues/4410

This adds code for indexing storage manifests as their display models (without any nested documents). I'll add code for indexing individual files in a separate PR, because I suspect that might need more thought.