### PR TITLE
Reorganise the display library to reflect the ingests/bags split

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/responses/LookupBag.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.http.models.{
   UserErrorResponse
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.archive.display.manifests.DisplayStorageManifest
+import uk.ac.wellcome.platform.archive.display.bags.DisplayStorageManifest
 import uk.ac.wellcome.storage.{NoMaximaValueError, NoVersionExistsError}
 
 import scala.concurrent.ExecutionContext

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.display.RequestDisplayIngest
+import uk.ac.wellcome.platform.archive.display.ingests.RequestDisplayIngest
 import uk.ac.wellcome.platform.storage.ingests.api.responses.{
   CreateIngest,
   LookupIngest

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.archive.common.http.models.{
   UserErrorResponse
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.display.{
+import uk.ac.wellcome.platform.archive.display.ingests.{
   RequestDisplayIngest,
   ResponseDisplayIngest
 }

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/LookupIngest.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/LookupIngest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.tracker.{
   IngestDoesNotExistError,
   IngestTracker
 }
-import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
+import uk.ac.wellcome.platform.archive.display.ingests.ResponseDisplayIngest
 
 trait LookupIngest extends ResponseBase with Logging {
   val ingestTracker: IngestTracker

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -20,6 +20,7 @@ import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display._
+import uk.ac.wellcome.platform.archive.display.ingests._
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsApiFixture
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFile.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFile.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFileManifest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFileManifest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.storage.models.FileManifest

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayStorageManifest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayStorageManifest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import java.net.URL
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/ResponseDisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/bags/ResponseDisplayBagInfo.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayBag.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import io.circe.generic.extras.JsonKey
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayBagInfo.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayCallback.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayCallback.scala
@@ -1,4 +1,5 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
+
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models.Callback
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngest.scala
@@ -8,7 +8,10 @@ import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayStorageSpace}
+import uk.ac.wellcome.platform.archive.display.{
+  DisplayLocation,
+  DisplayStorageSpace
+}
 
 sealed trait DisplayIngest
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import java.net.{URI, URL}
 import java.time.Instant
@@ -8,6 +8,7 @@ import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayStorageSpace}
 
 sealed trait DisplayIngest
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestEvent.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestEvent.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestEvent

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestType.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestType.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import uk.ac.wellcome.platform.archive.common.ingests.models.{

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayStatus.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayStatus.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFileManifestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayFileManifestTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayStorageManifestInfoTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/bags/DisplayStorageManifestInfoTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.display.manifests
+package uk.ac.wellcome.platform.archive.display.bags
 
 import java.time.format.DateTimeFormatter
 

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -4,7 +4,10 @@ import java.net.{URI, URL}
 import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, IngestGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagIdGenerators,
+  IngestGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -1,16 +1,14 @@
-package uk.ac.wellcome.platform.archive.display
+package uk.ac.wellcome.platform.archive.display.ingests
 
 import java.net.{URI, URL}
 import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.common.generators.{
-  BagIdGenerators,
-  IngestGenerators
-}
+import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, IngestGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexer.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import io.circe._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.display.manifests.DisplayStorageManifest
+import uk.ac.wellcome.platform.archive.display.bags.DisplayStorageManifest
 import uk.ac.wellcome.platform.archive.indexer.elasticsearch.Indexer
 
 import scala.concurrent.ExecutionContext

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/ManifestIndexerTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.Assertion
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.display.manifests.DisplayStorageManifest
+import uk.ac.wellcome.platform.archive.display.bags.DisplayStorageManifest
 import uk.ac.wellcome.platform.archive.indexer.IndexerTestCases
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import io.circe._
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
+import uk.ac.wellcome.platform.archive.display.ingests.ResponseDisplayIngest
 import uk.ac.wellcome.platform.archive.indexer.elasticsearch.Indexer
 
 import scala.concurrent.ExecutionContext

--- a/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
+++ b/indexer/ingests_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexerTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Ingest,
   IngestEvent
 }
-import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
+import uk.ac.wellcome.platform.archive.display.ingests.ResponseDisplayIngest
 import uk.ac.wellcome.platform.archive.indexer.IndexerTestCases
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -10,7 +10,7 @@ import io.circe.Printer
 import io.circe.syntax._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
+import uk.ac.wellcome.platform.archive.display.ingests.ResponseDisplayIngest
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}


### PR DESCRIPTION
Particularly given some of the naming overlaps – e.g. there's a DisplayBagInfo for ingests (how you tell us the external identifier) and for bags (based on the bag-info.txt).

This should make the distinction a little clearer.