### PR TITLE
Add an S3 bucket policy that blocks Put/Delete except for the replicator

### DIFF
--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -21,7 +21,8 @@ module "critical" {
     "arn:aws:iam::653428163053:user/echo-fs",
   ]
 
-  replica_glacier_read_principals = []
+  replicator_primary_task_role_arn = "arn:aws:iam::975596993436:role/storage-prod-bag-replicator_primary_task_role"
+  replicator_glacier_task_role_arn = "arn:aws:iam::975596993436:role/storage-prod-bag-replicator_glacier_task_role"
 
   # This gives us another layer of protection for the S3 buckets.
   #

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -21,7 +21,8 @@ module "critical" {
     "arn:aws:iam::653428163053:user/echo-fs",
   ]
 
-  replica_glacier_read_principals = []
+  replicator_primary_task_role_arn = "arn:aws:iam::975596993436:role/storage-staging-bag-replicator_primary_task_role"
+  replicator_glacier_task_role_arn = "arn:aws:iam::975596993436:role/storage-staging-bag-replicator_glacier_task_role"
 
   # The staging service shouldn't be the only copy of any important data, so
   # we don't need S3 versioning.

--- a/terraform/modules/critical/variables.tf
+++ b/terraform/modules/critical/variables.tf
@@ -5,12 +5,10 @@ variable "billing_mode" {
   description = "Should be either PAY_PER_REQUEST or PROVISIONED"
 }
 
-variable "replica_primary_read_principals" {
-  type    = list(string)
-  default = []
-}
+variable "replicator_primary_task_role_arn" {}
+variable "replicator_glacier_task_role_arn" {}
 
-variable "replica_glacier_read_principals" {
+variable "replica_primary_read_principals" {
   type    = list(string)
   default = []
 }

--- a/terraform/modules/queue/variables.tf
+++ b/terraform/modules/queue/variables.tf
@@ -12,7 +12,8 @@ variable "dlq_alarm_arn" {
 }
 
 variable "role_names" {
-  type = list(string)
+  type    = list(string)
+  default = []
 }
 
 variable "visibility_timeout_seconds" {

--- a/terraform/modules/stack/outputs.tf
+++ b/terraform/modules/stack/outputs.tf
@@ -10,6 +10,14 @@ output "unpacker_task_role_arn" {
   value = module.bag_unpacker.task_role_arn
 }
 
+output "replicator_primary_task_role_arn" {
+  value = module.replicator_verifier_primary.replicator_task_role_arn
+}
+
+output "replicator_glacier_task_role_arn" {
+  value = module.replicator_verifier_glacier.replicator_task_role_arn
+}
+
 output "api_domain_name" {
   value = module.api.gateway_domain_name
 }
@@ -17,4 +25,3 @@ output "api_domain_name" {
 output "bag_register_output_topic_arn" {
   value = module.bag_register_output_topic.arn
 }
-

--- a/terraform/modules/stack/replicator_verifier_pair/outputs.tf
+++ b/terraform/modules/stack/replicator_verifier_pair/outputs.tf
@@ -6,6 +6,10 @@ output "verifier_output_topic_arn" {
   value = module.bag_verifier_output_topic.arn
 }
 
+output "replicator_task_role_arn" {
+  value = module.bag_replicator.task_role_arn
+}
+
 output "replicator_task_role_name" {
   value = module.bag_replicator.task_role_name
 }
@@ -13,4 +17,3 @@ output "replicator_task_role_name" {
 output "verifier_task_role_name" {
   value = module.bag_verifier.task_role_name
 }
-


### PR DESCRIPTION
This adds another level of protection to the objects in the critical storage buckets. Previously creating a new "S3 super-access" user would allow you to futz with the bucket, but now you need to create such a user *and* unhook this policy first.

This is a test ingest in staging to verify I haven't broken anything: https://wellcome-ingest-inspector.glitch.me/ingests/94745dbe-d74b-4f61-8f24-b0d44d3eec1f