### PR TITLE
Use the new transfer checks in the bag replicator

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator
 
 import java.time.Instant
 
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models._
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.storage.listing.Listing
 import uk.ac.wellcome.storage.transfer.{PrefixTransfer, TransferResult}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
@@ -15,8 +17,13 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 // For example, in the BagReplicator, we verify the tag manifests
 // are the same after replication completes.
 
-trait Replicator {
+trait Replicator extends Logging {
   implicit val prefixTransfer: PrefixTransfer[
+    ObjectLocationPrefix,
+    ObjectLocation
+  ]
+
+  implicit val prefixListing: Listing[
     ObjectLocationPrefix,
     ObjectLocation
   ]
@@ -31,9 +38,38 @@ trait Replicator {
       request = request
     )
 
+    // If we know that there is nothing under the prefix (and we're the only
+    // replicator writing to it due to the lock), we can skip checking for
+    // overwrites.
+    //
+    // This gives us read-after-write consistency, rather than eventual
+    // consistency, and makes the verifier more reliable.
+    //
+    // See: https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html
+    //
+    //      Amazon S3 provides read-after-write consistency for PUTS of new objects
+    //      in your S3 bucket in all Regions with one caveat. The caveat is that if
+    //      you make a HEAD or GET request to a key name before the object is created,
+    //      then create the object shortly after that, a subsequent GET might not
+    //      return the object due to eventual consistency.
+    //
+    // See also: https://github.com/wellcomecollection/platform/issues/3897
+    //
+    // In theory this could be even more sophisticated, and compare the keys to
+    // replicate against a list of existing keys -- but that would make the code
+    // even more complicated, and it's not clear it would be beneficial.
+    //
+    val checkForExisting = prefixListing.list(request.srcPrefix) match {
+      case Right(listing) if listing.isEmpty => false
+      case _                                 => true
+    }
+
+    debug(s"Consistency mode: checkForExisting = $checkForExisting")
+
     prefixTransfer.transferPrefix(
       srcPrefix = request.srcPrefix,
-      dstPrefix = request.dstPrefix
+      dstPrefix = request.dstPrefix,
+      checkForExisting = checkForExisting
     ) match {
       case Right(_) =>
         ReplicationSucceeded(summary.complete)

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.StorageClass
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
-import uk.ac.wellcome.storage.listing.s3.{S3ObjectLocationListing, S3ObjectSummaryListing}
+import uk.ac.wellcome.storage.listing.s3.{
+  S3ObjectLocationListing,
+  S3ObjectSummaryListing
+}
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.StorageClass
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
+import uk.ac.wellcome.storage.listing.s3.{S3ObjectLocationListing, S3ObjectSummaryListing}
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
@@ -19,4 +20,10 @@ class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
   //
   implicit val prefixTransfer: S3PrefixTransfer =
     S3PrefixTransfer(storageClass = StorageClass.Standard)
+
+  implicit val s3ObjectSummaryListing: S3ObjectSummaryListing =
+    new S3ObjectSummaryListing()
+
+  override implicit val prefixListing: S3ObjectLocationListing =
+    new S3ObjectLocationListing()
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicatorTest.scala
@@ -133,9 +133,9 @@ class BagReplicatorTest
       // original and the replica.
 
       implicit val badTransfer: S3Transfer = new S3Transfer() {
-        override def transfer(
+        override def transferWithOverwrites(
           src: ObjectLocation,
-          dst: ObjectLocation
+          dst: ObjectLocation,
         ): Either[TransferFailure, TransferSuccess] =
           if (dst.path.endsWith("/tagmanifest-sha256.txt")) {
             s3Client.putObject(
@@ -145,7 +145,7 @@ class BagReplicatorTest
             )
             Right(TransferPerformed(src, dst))
           } else {
-            super.transfer(src, dst)
+            super.transferWithOverwrites(src, dst)
           }
       }
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicatorTest.scala
@@ -135,7 +135,7 @@ class BagReplicatorTest
       implicit val badTransfer: S3Transfer = new S3Transfer() {
         override def transferWithOverwrites(
           src: ObjectLocation,
-          dst: ObjectLocation,
+          dst: ObjectLocation
         ): Either[TransferFailure, TransferSuccess] =
           if (dst.path.endsWith("/tagmanifest-sha256.txt")) {
             s3Client.putObject(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{
   ReplicationSucceeded
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 
 class S3ReplicatorTest
@@ -54,6 +54,58 @@ class S3ReplicatorTest
 
       result shouldBe a[ReplicationSucceeded]
       result.summary.maybeEndTime.isDefined shouldBe true
+    }
+  }
+
+  it("fails if there are already different objects in the prefix") {
+    withLocalS3Bucket { bucket =>
+      val locations = (1 to 5).map { _ =>
+        createObjectLocationWith(bucket, key = s"src/$randomAlphanumeric")
+      }
+
+      val objects = locations.map { _ -> randomAlphanumeric }.toMap
+
+      objects.foreach {
+        case (loc, contents) =>
+          s3Client.putObject(
+            loc.namespace,
+            loc.path,
+            contents
+          )
+      }
+
+      val srcPrefix = ObjectLocationPrefix(
+        namespace = bucket.name,
+        path = "src/"
+      )
+
+      val dstPrefix = ObjectLocationPrefix(
+        namespace = bucket.name,
+        path = "dst/"
+      )
+
+      // Write something to the first destination.  The replicator should realise
+      // this object already exists, and refuse to overwrite it.
+      val badContents = randomAlphanumeric
+
+      val dstLocation = ObjectLocation(
+        namespace = bucket.name,
+        path = locations.head.path.replace("src/", "dst/")
+      )
+
+      s3Client.putObject(dstLocation.namespace, dstLocation.path, badContents)
+
+      val result = new S3Replicator().replicate(
+        ingestId = createIngestID,
+        request = ReplicationRequest(
+          srcPrefix = srcPrefix,
+          dstPrefix = dstPrefix
+        )
+      )
+
+      result shouldBe a[ReplicationFailed]
+
+      getContentFromS3(dstLocation) shouldBe badContents
     }
   }
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -348,7 +348,7 @@ class BagReplicatorWorkerTest
 
               implicit val badS3Transfer: S3Transfer =
                 new S3Transfer() {
-                  override def transfer(
+                  override def transferWithOverwrites(
                     src: ObjectLocation,
                     dst: ObjectLocation
                   ): Either[TransferFailure, TransferSuccess] =
@@ -361,7 +361,7 @@ class BagReplicatorWorkerTest
 
                       Right(TransferPerformed(src, dst))
                     } else {
-                      super.transfer(src, dst)
+                      super.transferWithOverwrites(src, dst)
                     }
                 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json = "2.3.0"
     val messaging = "9.1.0"
     val monitoring = "4.0.0"
-    val storage = "8.1.0"
+    val storage = "8.2.0"
     val typesafe = "2.0.0"
   }
 


### PR DESCRIPTION
This should avoid consistency bugs if we're replicating into a known-empty prefix.

Closes https://github.com/wellcomecollection/platform/issues/3897