### PR TITLE
Don't duplicate the StorageProvider hierarchy in DisplayProvider

### DIFF
--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
@@ -45,7 +45,8 @@ trait CreateIngest extends ResponseBase with Logging {
       )
     } else if (!StorageProvider.allowedValues.contains(providerId)) {
       createBadRequestResponse(
-        s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.allowedValues.mkString(", ")}."""
+        s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.allowedValues
+          .mkString(", ")}."""
       )
     } else {
       triggerIngestStarter(requestDisplayIngest)

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
@@ -12,7 +12,10 @@ import uk.ac.wellcome.platform.archive.common.http.models.{
   InternalServerErrorResponse,
   UserErrorResponse
 }
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  StorageProvider
+}
 import uk.ac.wellcome.platform.archive.display.ingests.{
   RequestDisplayIngest,
   ResponseDisplayIngest
@@ -28,6 +31,7 @@ trait CreateIngest extends ResponseBase with Logging {
   def createIngest(requestDisplayIngest: RequestDisplayIngest): Route = {
     val space = requestDisplayIngest.space.id
     val externalIdentifier = requestDisplayIngest.bag.info.externalIdentifier
+    val providerId = requestDisplayIngest.sourceLocation.provider.id
 
     if (space.contains("/")) {
       createBadRequestResponse(
@@ -38,6 +42,10 @@ trait CreateIngest extends ResponseBase with Logging {
     } else if (externalIdentifier == "") {
       createBadRequestResponse(
         "Invalid value at .bag.info.externalIdentifier: must not be empty."
+      )
+    } else if (!StorageProvider.allowedValues.contains(providerId)) {
+      createBadRequestResponse(
+        s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.allowedValues.mkString(", ")}."""
       )
     } else {
       triggerIngestStarter(requestDisplayIngest)

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -373,7 +373,8 @@ class CreateIngestApiTest
         assertCatchesMalformedRequest(
           badJson(json).noSpaces,
           expectedMessage =
-            """Invalid value at .sourceLocation.provider.id: got "not-a-storage-provider", valid values are: aws-s3-standard, aws-s3-ia."""
+            "Unrecognised value at .sourceLocation.provider.id: got \"not-a-storage-provider\", " +
+              "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier."
         )
       }
 

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -365,6 +365,18 @@ class CreateIngestApiTest
         )
       }
 
+      it("if the provider field has an invalid value") {
+        val badJson = root.sourceLocation.provider.obj.modify {
+          _.add("id", Json.fromString("not-a-storage-provider"))
+        }
+
+        assertCatchesMalformedRequest(
+          badJson(json).noSpaces,
+          expectedMessage =
+            """Invalid value at .sourceLocation.provider.id: got "not-a-storage-provider", valid values are: aws-s3-standard, aws-s3-ia."""
+        )
+      }
+
       it("if the bucket field is missing") {
         val badJson = root.sourceLocation.obj.modify {
           _.remove("bucket")

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -78,7 +78,7 @@ class CreateIngestApiTest
             actualIngest.context shouldBe contextUrlTest
             actualIngest.id shouldBe id
             actualIngest.sourceLocation shouldBe DisplayLocation(
-              provider = StandardDisplayProvider,
+              provider = DisplayProvider(id = "aws-s3-standard"),
               bucket = bucketName,
               path = s3key
             )
@@ -464,7 +464,7 @@ class CreateIngestApiTest
           |    "type": "Location",
           |    "provider": {
           |      "type": "Provider",
-          |      "id": "${StandardDisplayProvider.id}"
+          |      "id": "aws-s3-standard"
           |    },
           |    "bucket": "$bucket",
           |    "path": "$key"

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -5,15 +5,18 @@ sealed trait StorageProvider {
 }
 
 case object StorageProvider {
+  private val idLookup = Map(
+    StandardStorageProvider.id -> StandardStorageProvider,
+    InfrequentAccessStorageProvider.id -> InfrequentAccessStorageProvider,
+    GlacierStorageProvider.id -> GlacierStorageProvider,
+  )
+
   def apply(id: String): StorageProvider =
-    id match {
-      case StandardStorageProvider.id         => StandardStorageProvider
-      case InfrequentAccessStorageProvider.id => InfrequentAccessStorageProvider
-      case GlacierStorageProvider.id          => GlacierStorageProvider
-      case _ =>
-        throw new IllegalArgumentException(
-          s"Unrecognised storage provider ID: $id"
-        )
+    idLookup.get(id) match {
+      case Some(provider) => provider
+      case None => throw new IllegalArgumentException(
+        s"Unrecognised storage provider ID: $id; valid values are: ${idLookup.keys.mkString(", ")}"
+      )
     }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -8,7 +8,7 @@ case object StorageProvider {
   private val idLookup = Map(
     StandardStorageProvider.id -> StandardStorageProvider,
     InfrequentAccessStorageProvider.id -> InfrequentAccessStorageProvider,
-    GlacierStorageProvider.id -> GlacierStorageProvider,
+    GlacierStorageProvider.id -> GlacierStorageProvider
   )
 
   def allowedValues: Seq[String] =
@@ -17,9 +17,10 @@ case object StorageProvider {
   def apply(id: String): StorageProvider =
     idLookup.get(id) match {
       case Some(provider) => provider
-      case None => throw new IllegalArgumentException(
-        s"Unrecognised storage provider ID: $id; valid values are: ${allowedValues.mkString(", ")}"
-      )
+      case None =>
+        throw new IllegalArgumentException(
+          s"Unrecognised storage provider ID: $id; valid values are: ${allowedValues.mkString(", ")}"
+        )
     }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -11,11 +11,14 @@ case object StorageProvider {
     GlacierStorageProvider.id -> GlacierStorageProvider,
   )
 
+  def allowedValues: Seq[String] =
+    idLookup.keys.toSeq
+
   def apply(id: String): StorageProvider =
     idLookup.get(id) match {
       case Some(provider) => provider
       case None => throw new IllegalArgumentException(
-        s"Unrecognised storage provider ID: $id; valid values are: ${idLookup.keys.mkString(", ")}"
+        s"Unrecognised storage provider ID: $id; valid values are: ${allowedValues.mkString(", ")}"
       )
     }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
@@ -27,6 +27,9 @@ class StorageProviderTest
       StorageProvider("not-a-storage-provider")
     }
 
-    thrown.getMessage shouldBe "Unrecognised storage provider ID: not-a-storage-provider"
+    thrown.getMessage shouldBe (
+      "Unrecognised storage provider ID: not-a-storage-provider; " +
+        "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier"
+    )
   }
 }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayProvider.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayProvider.scala
@@ -1,77 +1,17 @@
 package uk.ac.wellcome.platform.archive.display
 
-import io.circe.CursorOp.DownField
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  GlacierStorageProvider,
-  InfrequentAccessStorageProvider,
-  StandardStorageProvider,
-  StorageProvider
+import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
+
+case class DisplayProvider(
+  id: String,
+  @JsonKey("type") ontologyType: String = "Provider"
+) {
+  def toStorageProvider: StorageProvider =
+    StorageProvider(id)
 }
 
-sealed trait DisplayProvider {
-  val id: String
-  def toStorageProvider: StorageProvider
-}
-
-case object StandardDisplayProvider extends DisplayProvider {
-  override val id: String = StandardStorageProvider.id
-
-  override def toStorageProvider: StorageProvider = StandardStorageProvider
-}
-
-case object InfrequentAccessDisplayProvider extends DisplayProvider {
-  override val id: String = InfrequentAccessStorageProvider.id
-
-  override def toStorageProvider: StorageProvider =
-    InfrequentAccessStorageProvider
-}
-
-case object GlacierDisplayProvider extends DisplayProvider {
-  override val id: String = GlacierStorageProvider.id
-
-  override def toStorageProvider: StorageProvider =
-    GlacierStorageProvider
-}
-
-object DisplayProvider {
+case object DisplayProvider {
   def apply(provider: StorageProvider): DisplayProvider =
-    provider match {
-      case StandardStorageProvider         => StandardDisplayProvider
-      case InfrequentAccessStorageProvider => InfrequentAccessDisplayProvider
-      case GlacierStorageProvider          => GlacierDisplayProvider
-    }
-
-  implicit val decoder
-    : Decoder[DisplayProvider] = Decoder.instance[DisplayProvider](
-    cursor =>
-      for {
-        id <- cursor.downField("id").as[String]
-        provider <- id match {
-          case StandardDisplayProvider.id => Right(StandardDisplayProvider)
-          case InfrequentAccessDisplayProvider.id =>
-            Right(InfrequentAccessDisplayProvider)
-          case GlacierDisplayProvider.id =>
-            Right(GlacierDisplayProvider)
-          case invalidId =>
-            val fields = DownField("id") +: cursor.history
-            Left(
-              DecodingFailure(
-                s"""got "$invalidId", valid values are: ${StandardDisplayProvider.id}, ${InfrequentAccessDisplayProvider.id}.""",
-                fields
-              )
-            )
-        }
-      } yield {
-        provider
-      }
-  )
-
-  implicit val encoder: Encoder[DisplayProvider] =
-    Encoder.instance[DisplayProvider] { provider =>
-      Json.obj(
-        "id" -> Json.fromString(provider.id),
-        "type" -> Json.fromString("Provider")
-      )
-    }
+    DisplayProvider(id = provider.id)
 }

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
@@ -50,7 +50,7 @@ class DisplayProviderTest
     thrown.getMessage shouldBe (
       "Unrecognised storage provider ID: not-a-storage-provider; " +
         "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier"
-      )
+    )
   }
 
   describe("JSON encoding/decoding") {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
@@ -16,9 +15,9 @@ class DisplayProviderTest
 
   val providerPairs = Table(
     ("display", "internal"),
-    (StandardDisplayProvider, StandardStorageProvider),
-    (InfrequentAccessDisplayProvider, InfrequentAccessStorageProvider),
-    (GlacierDisplayProvider, GlacierStorageProvider)
+    (DisplayProvider("aws-s3-standard"), StandardStorageProvider),
+    (DisplayProvider("aws-s3-ia"), InfrequentAccessStorageProvider),
+    (DisplayProvider("aws-s3-glacier"), GlacierStorageProvider)
   )
 
   it("turns a DisplayProvider into a StorageProvider") {
@@ -41,19 +40,32 @@ class DisplayProviderTest
     }
   }
 
+  it("can't turn an invalid provider ID into a storage provider") {
+    val badProvider = DisplayProvider(id = "not-a-storage-provider")
+
+    val thrown = intercept[IllegalArgumentException] {
+      badProvider.toStorageProvider
+    }
+
+    thrown.getMessage shouldBe (
+      "Unrecognised storage provider ID: not-a-storage-provider; " +
+        "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier"
+      )
+  }
+
   describe("JSON encoding/decoding") {
     val jsonPairs = Table(
       ("provider", "json"),
       (
-        StandardDisplayProvider,
+        DisplayProvider("aws-s3-standard"),
         """{"id": "aws-s3-standard", "type": "Provider"}"""
       ),
       (
-        InfrequentAccessDisplayProvider,
+        DisplayProvider("aws-s3-ia"),
         """{"id": "aws-s3-ia", "type": "Provider"}"""
       ),
       (
-        GlacierDisplayProvider,
+        DisplayProvider("aws-s3-glacier"),
         """{"id": "aws-s3-glacier", "type": "Provider"}"""
       )
     )
@@ -73,16 +85,6 @@ class DisplayProviderTest
             jsonString
           )
       }
-    }
-
-    it("fails to parse an unrecognised ID") {
-      val badJson = """{"id": "not-a-real-provider", "type": "Provider"}"""
-
-      val err = fromJson[DisplayProvider](badJson).failed.get
-      err shouldBe a[JsonDecodingError]
-      err.getMessage should startWith(
-        "got \"not-a-real-provider\", valid values are: "
-      )
     }
   }
 }

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -56,7 +56,7 @@ class DisplayIngestTest
 
       displayIngest.id shouldBe id.underlying
       displayIngest.sourceLocation shouldBe DisplayLocation(
-        StandardDisplayProvider,
+        DisplayProvider(id = "aws-s3-standard"),
         bucket = "bukkit",
         path = "key.txt"
       )
@@ -116,7 +116,7 @@ class DisplayIngestTest
 
   describe("RequestDisplayIngest") {
     it("transforms itself into a ingest") {
-      val displayProvider = InfrequentAccessDisplayProvider
+      val displayProvider = DisplayProvider(id = "aws-s3-ia")
       val bucket = "ingest-bucket"
       val path = "bag.zip"
 
@@ -174,7 +174,7 @@ class DisplayIngestTest
 
   def createRequestDisplayIngestWith(
     sourceLocation: DisplayLocation = DisplayLocation(
-      provider = InfrequentAccessDisplayProvider,
+      provider = DisplayProvider(id = "aws-s3-ia"),
       bucket = randomAlphanumeric,
       path = randomAlphanumeric
     ),


### PR DESCRIPTION
As part of https://github.com/wellcomecollection/platform/issues/4466, we may be changing how the storage providers are defined. (If not there, we'll definitely add some new ones for Azure.)

Right now storage providers are defined in two places: the internal model and the display model. They can get out of sync (and already had – witness the old error message on DisplayProvider), and we don't need the hierarchy to the same degree in the display model – make that a transparent case class, and simplify the code.

