### PR TITLE
Check the structure of fetch URIs in the bag verifier

### DIFF
--- a/bag_verifier/src/main/resources/application.conf
+++ b/bag_verifier/src/main/resources/application.conf
@@ -2,4 +2,5 @@ aws.sqs.queue.url=${?queue_url}
 aws.ingest.sns.topic.arn=${?ingest_topic_arn}
 aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 aws.metrics.namespace=${?metrics_namespace}
+bag-verifier.primary-storage-bucket=${?primary_storage_bucket_name}
 operation.name=${?operation_name}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -67,8 +67,9 @@ object Main extends WellcomeTypesafeApp {
     implicit val s3Listing: Listing[ObjectLocationPrefix, ObjectLocation] =
       S3ObjectLocationListing()
 
-    val verifier =
-      new BagVerifier()
+    val verifier = new BagVerifier(
+      namespace = config.required[String]("bag-verifier.primary-storage-bucket")
+    )
 
     val operationName =
       OperationNameBuilder.getName(config)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -208,7 +208,8 @@ class BagVerifier(namespace: String)(
   // and we don't have to worry about interconnected bag dependencies.
   private def verifyFetchPrefixes(
     bag: Bag,
-    root: ObjectLocationPrefix): InternalResult[Unit] =
+    root: ObjectLocationPrefix
+  ): InternalResult[Unit] =
     bag.fetch match {
       case None => Right(())
 
@@ -225,8 +226,8 @@ class BagVerifier(namespace: String)(
                 // TODO: This could verify the version prefix as well.
                 // TODO: Hard-coding the expected scheme here isn't ideal
                 fetchMetadata.uri.getScheme == "s3" &&
-                  fetchLocation.namespace == root.namespace &&
-                  fetchLocation.path.startsWith(s"${root.path}/")
+                fetchLocation.namespace == root.namespace &&
+                fetchLocation.path.startsWith(s"${root.path}/")
             }
 
         val mismatchedPaths = mismatchedEntries.keys.toSeq
@@ -234,7 +235,8 @@ class BagVerifier(namespace: String)(
         mismatchedPaths match {
           case Nil => Right(())
           case _ =>
-            val message = s"fetch.txt refers to paths in a mismatched prefix: ${mismatchedPaths.mkString(", ")}"
+            val message =
+              s"fetch.txt refers to paths in a mismatched prefix: ${mismatchedPaths.mkString(", ")}"
 
             Left(
               BagVerifierError(
@@ -244,7 +246,6 @@ class BagVerifier(namespace: String)(
             )
         }
     }
-
 
   // Check that the user hasn't sent any files in the bag which
   // also have a fetch file entry.

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -202,6 +202,10 @@ class BagVerifier(namespace: String)(
 
   // Check the user hasn't supplied any fetch entries whcih are in the wrong
   // namespace or path prefix.
+  //
+  // We only allow fetch entries to refer to previous versions of the same bag; this
+  // ensures that a single bag (same space/external identifier) is completely self-contained,
+  // and we don't have to worry about interconnected bag dependencies.
   private def verifyFetchPrefixes(
     bag: Bag,
     root: ObjectLocationPrefix): InternalResult[Unit] =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
 
-class BagVerifier()(
+class BagVerifier(namespace: String)(
   implicit bagReader: BagReader[_],
   resolvable: Resolvable[ObjectLocation],
   verifier: Verifier[_],
@@ -36,6 +36,7 @@ class BagVerifier()(
   def verify(
     ingestId: IngestID,
     root: ObjectLocationPrefix,
+    space: StorageSpace,
     externalIdentifier: ExternalIdentifier
   ): Try[IngestStepResult[VerificationSummary]] =
     Try {
@@ -51,6 +52,14 @@ class BagVerifier()(
           )
 
           _ <- verifyPayloadOxumFileCount(bag)
+
+          _ <- verifyFetchPrefixes(
+            bag,
+            root = ObjectLocationPrefix(
+              namespace = namespace,
+              path = s"$space/$externalIdentifier"
+            )
+          )
 
           verificationResult <- verifyChecksums(
             root = root,
@@ -190,6 +199,48 @@ class BagVerifier()(
 
       case _ => Right(())
     }
+
+  // Check the user hasn't supplied any fetch entries whcih are in the wrong
+  // namespace or path prefix.
+  private def verifyFetchPrefixes(
+    bag: Bag,
+    root: ObjectLocationPrefix): InternalResult[Unit] =
+    bag.fetch match {
+      case None => Right(())
+
+      case Some(BagFetch(entries)) =>
+        val mismatchedEntries =
+          entries
+            .filterNot {
+              case (_, fetchMetadata: BagFetchMetadata) =>
+                val fetchLocation = ObjectLocation(
+                  namespace = fetchMetadata.uri.getHost,
+                  path = fetchMetadata.uri.getPath.stripPrefix("/")
+                )
+
+                // TODO: This could verify the version prefix as well.
+                // TODO: Hard-coding the expected scheme here isn't ideal
+                fetchMetadata.uri.getScheme == "s3" &&
+                  fetchLocation.namespace == root.namespace &&
+                  fetchLocation.path.startsWith(s"${root.path}/")
+            }
+
+        val mismatchedPaths = mismatchedEntries.keys.toSeq
+
+        mismatchedPaths match {
+          case Nil => Right(())
+          case _ =>
+            val message = s"fetch.txt refers to paths in a mismatched prefix: ${mismatchedPaths.mkString(", ")}"
+
+            Left(
+              BagVerifierError(
+                e = new Throwable(message),
+                userMessage = Some(message)
+              )
+            )
+        }
+    }
+
 
   // Check that the user hasn't sent any files in the bag which
   // also have a fetch file entry.

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -40,6 +40,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
       summary <- verifier.verify(
         ingestId = payload.ingestId,
         root = payload.bagRoot,
+        space = payload.storageSpace,
         externalIdentifier = payload.externalIdentifier
       )
       _ <- ingestUpdater.send(payload.ingestId, summary)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -296,77 +296,115 @@ class BagVerifierTest
 
       assertBagIncomplete(badBuilder) {
         case (ingestFailed, _) =>
-          ingestFailed.e.getMessage should startWith("fetch.txt refers to paths that aren't in the bag manifest: ")
+          ingestFailed.e.getMessage should startWith(
+            "fetch.txt refers to paths that aren't in the bag manifest: "
+          )
 
-          ingestFailed.maybeUserFacingMessage.get should startWith("fetch.txt refers to paths that aren't in the bag manifest: ")
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            "fetch.txt refers to paths that aren't in the bag manifest: "
+          )
       }
     }
 
     it("fails if the fetch file refers to a file with the wrong URI scheme") {
       val wrongSchemeBuilder = new S3BagBuilderBase {
-        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
+        override protected def buildFetchEntryLine(
+          entry: PayloadEntry
+        )(implicit namespace: String): String =
           super.buildFetchEntryLine(entry).replace("s3://", "none://")
 
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
       }
 
-      assertBagIncomplete(wrongSchemeBuilder) { case (ingestFailed, _) =>
-        ingestFailed.e.getMessage should startWith("fetch.txt refers to paths in a mismatched prefix:")
+      assertBagIncomplete(wrongSchemeBuilder) {
+        case (ingestFailed, _) =>
+          ingestFailed.e.getMessage should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
 
-        ingestFailed.maybeUserFacingMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix:")
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
       }
     }
 
     it("fails if the fetch file refers to a file in a different namespace") {
       val wrongBucketFetchBuilder = new S3BagBuilderBase {
-        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
+        override protected def buildFetchEntryLine(
+          entry: PayloadEntry
+        )(implicit namespace: String): String =
           super.buildFetchEntryLine(entry)(namespace = s"wrong-$namespace")
 
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
       }
 
-      assertBagIncomplete(wrongBucketFetchBuilder) { case (ingestFailed, _) =>
-        ingestFailed.e.getMessage should startWith("fetch.txt refers to paths in a mismatched prefix:")
+      assertBagIncomplete(wrongBucketFetchBuilder) {
+        case (ingestFailed, _) =>
+          ingestFailed.e.getMessage should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
 
-        ingestFailed.maybeUserFacingMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix:")
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
       }
     }
 
     it("fails if the fetch file refers to a file in the wrong space") {
       val bagSpaceFetchBuilder = new S3BagBuilderBase {
-        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
-          super.buildFetchEntryLine(entry.copy(
-            path = "badspace_" + entry.path
-          ))
+        override protected def buildFetchEntryLine(
+          entry: PayloadEntry
+        )(implicit namespace: String): String =
+          super.buildFetchEntryLine(
+            entry.copy(
+              path = "badspace_" + entry.path
+            )
+          )
 
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
       }
 
-      assertBagIncomplete(bagSpaceFetchBuilder) { case (ingestFailed, _) =>
-        ingestFailed.e.getMessage should startWith("fetch.txt refers to paths in a mismatched prefix:")
+      assertBagIncomplete(bagSpaceFetchBuilder) {
+        case (ingestFailed, _) =>
+          ingestFailed.e.getMessage should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
 
-        ingestFailed.maybeUserFacingMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix:")
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
       }
     }
 
-    it("fails if the fetch file refers to a file with the wrong external identifier") {
+    it(
+      "fails if the fetch file refers to a file with the wrong external identifier"
+    ) {
       val badExternalIdentifierFetchBuilder = new S3BagBuilderBase {
-        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
-          super.buildFetchEntryLine(entry.copy(
-            path = entry.path.replace("/", "/wrong_")
-          ))
+        override protected def buildFetchEntryLine(
+          entry: PayloadEntry
+        )(implicit namespace: String): String =
+          super.buildFetchEntryLine(
+            entry.copy(
+              path = entry.path.replace("/", "/wrong_")
+            )
+          )
 
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
       }
 
-      assertBagIncomplete(badExternalIdentifierFetchBuilder) { case (ingestFailed, _) =>
-        ingestFailed.e.getMessage should startWith("fetch.txt refers to paths in a mismatched prefix:")
+      assertBagIncomplete(badExternalIdentifierFetchBuilder) {
+        case (ingestFailed, _) =>
+          ingestFailed.e.getMessage should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
 
-        ingestFailed.maybeUserFacingMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix:")
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            "fetch.txt refers to paths in a mismatched prefix:"
+          )
       }
     }
   }
@@ -502,7 +540,8 @@ class BagVerifierTest
     it("passes a bag that includes an extra manifest/tag manifest") {
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRoot, bagInfo) =
+          S3BagBuilder.createS3BagWith(bucket, space = space)
 
         val location = bagRoot.asLocation("tagmanifest-sha512.txt")
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -41,7 +41,8 @@ class BagVerifierWorkerTest
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
 
-      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
+      val (bagRootLocation, bagInfo) =
+        S3BagBuilder.createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
@@ -51,7 +52,12 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+      withBagVerifierWorker(
+        ingests,
+        outgoing,
+        bucket = bucket,
+        stepName = "verification"
+      ) {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -75,7 +81,8 @@ class BagVerifierWorkerTest
 
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRootLocation, bagInfo) =
+          S3BagBuilder.createS3BagWith(bucket, space = space)
 
         val payload = createVersionedBagRootPayloadWith(
           context = createPipelineContextWith(
@@ -85,7 +92,12 @@ class BagVerifierWorkerTest
           bagRoot = bagRootLocation
         )
 
-        withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+        withBagVerifierWorker(
+          ingests,
+          outgoing,
+          bucket = bucket,
+          stepName = "verification"
+        ) {
           _.processMessage(payload) shouldBe a[Success[_]]
         }
 
@@ -101,7 +113,8 @@ class BagVerifierWorkerTest
 
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRoot, bagInfo) =
+          S3BagBuilder.createS3BagWith(bucket, space = space)
 
         val payload = createBagRootLocationPayloadWith(
           context = createPipelineContextWith(
@@ -111,7 +124,12 @@ class BagVerifierWorkerTest
           bagRoot = bagRoot
         )
 
-        withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+        withBagVerifierWorker(
+          ingests,
+          outgoing,
+          bucket = bucket,
+          stepName = "verification"
+        ) {
           _.processMessage(payload) shouldBe a[Success[_]]
         }
 
@@ -143,7 +161,12 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+      withBagVerifierWorker(
+        ingests,
+        outgoing,
+        bucket = bucket,
+        stepName = "verification"
+      ) {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -181,7 +204,12 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+      withBagVerifierWorker(
+        ingests,
+        outgoing,
+        bucket = bucket,
+        stepName = "verification"
+      ) {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -221,7 +249,12 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+      withBagVerifierWorker(
+        ingests,
+        outgoing,
+        bucket = bucket,
+        stepName = "verification"
+      ) {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -248,7 +281,8 @@ class BagVerifierWorkerTest
 
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
-      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
+      val (bagRootLocation, bagInfo) =
+        S3BagBuilder.createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
@@ -258,7 +292,12 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
+      withBagVerifierWorker(
+        ingests,
+        outgoing,
+        bucket = bucket,
+        stepName = "verification"
+      ) {
         _.processMessage(payload) shouldBe a[Failure[_]]
       }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -39,16 +39,19 @@ class BagVerifierWorkerTest
     val outgoing = new MemoryMessageSender()
 
     withLocalS3Bucket { bucket =>
-      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+      val space = createStorageSpace
+
+      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
-          externalIdentifier = bagInfo.externalIdentifier
+          externalIdentifier = bagInfo.externalIdentifier,
+          storageSpace = space
         ),
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -71,16 +74,18 @@ class BagVerifierWorkerTest
       val outgoing = new MemoryMessageSender()
 
       withLocalS3Bucket { bucket =>
-        val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+        val space = createStorageSpace
+        val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
 
         val payload = createVersionedBagRootPayloadWith(
           context = createPipelineContextWith(
-            externalIdentifier = bagInfo.externalIdentifier
+            externalIdentifier = bagInfo.externalIdentifier,
+            storageSpace = space
           ),
           bagRoot = bagRootLocation
         )
 
-        withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+        withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
           _.processMessage(payload) shouldBe a[Success[_]]
         }
 
@@ -95,16 +100,18 @@ class BagVerifierWorkerTest
       val outgoing = new MemoryMessageSender()
 
       withLocalS3Bucket { bucket =>
-        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+        val space = createStorageSpace
+        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
 
         val payload = createBagRootLocationPayloadWith(
           context = createPipelineContextWith(
-            externalIdentifier = bagInfo.externalIdentifier
+            externalIdentifier = bagInfo.externalIdentifier,
+            storageSpace = space
           ),
           bagRoot = bagRoot
         )
 
-        withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+        withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
           _.processMessage(payload) shouldBe a[Success[_]]
         }
 
@@ -136,7 +143,7 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -174,7 +181,7 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -214,7 +221,7 @@ class BagVerifierWorkerTest
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
         _.processMessage(payload) shouldBe a[Success[_]]
       }
 
@@ -240,16 +247,18 @@ class BagVerifierWorkerTest
     }
 
     withLocalS3Bucket { bucket =>
-      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+      val space = createStorageSpace
+      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
-          externalIdentifier = bagInfo.externalIdentifier
+          externalIdentifier = bagInfo.externalIdentifier,
+          storageSpace = space
         ),
         bagRoot = bagRootLocation
       )
 
-      withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
+      withBagVerifierWorker(ingests, outgoing, bucket = bucket, stepName = "verification") {
         _.processMessage(payload) shouldBe a[Failure[_]]
       }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -283,12 +283,15 @@ object BagBuilder extends BagBuilderBase
 trait S3BagBuilderBase extends BagBuilderBase with S3Fixtures with Logging {
   def createS3BagWith(
     bucket: Bucket,
+    space: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     payloadFileCount: Int = randomInt(from = 5, to = 50)
   ): (ObjectLocationPrefix, BagInfo) = {
     implicit val namespace: String = bucket.name
 
     val (bagObjects, bagRoot, bagInfo) = createBagContentsWith(
+      space = space,
+      externalIdentifier = externalIdentifier,
       payloadFileCount = payloadFileCount
     )
 

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -108,6 +108,8 @@ module "bag_verifier_pre_replication" {
     metrics_namespace  = local.bag_verifier_pre_repl_service_name
     operation_name     = "verification (pre-replicating to archive storage)"
     JAVA_OPTS          = local.java_opts_heap_size
+
+    primary_storage_bucket_name = var.replica_primary_bucket_name
   }
 
   cpu    = 2048

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -61,6 +61,8 @@ module "bag_verifier" {
     metrics_namespace  = local.bag_verifier_service_name
     operation_name     = "verification (${var.replica_display_name})"
     JAVA_OPTS          = "${local.java_opts_heap_size} ${local.java_opts_metrics_base},metricNameSpace=${local.bag_verifier_service_name}"
+
+    primary_storage_bucket_name = var.bucket_name
   }
 
   cpu    = 2048


### PR DESCRIPTION
-   They should start with s3://.  We could make this configurable, but hard-coding it for now is sufficient.
-   If a fetch URI doesn't point to something in the primary storage bucket, we should reject it.
-   If a fetch URI doesn't point to a path that starts with {space}/{externalIdentifier}, we should reject it.

Closes https://github.com/wellcomecollection/platform/issues/4513