### PR TITLE
Add a getIngest() method to the ingest tracker API

### DIFF
--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
@@ -11,6 +11,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Ingest,
+  IngestID,
   IngestUpdate
 }
 
@@ -19,7 +20,9 @@ import scala.concurrent.{ExecutionContext, Future}
 trait IngestTrackerClient {
   def updateIngest(
     ingestUpdate: IngestUpdate
-  ): Future[Either[IngestTrackerError, Ingest]]
+  ): Future[Either[IngestTrackerUpdateError, Ingest]]
+
+  def getIngest(id: IngestID): Future[Either[IngestTrackerGetError, Ingest]]
 }
 
 class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
@@ -30,7 +33,7 @@ class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
 
   def updateIngest(
     ingestUpdate: IngestUpdate
-  ): Future[Either[IngestTrackerError, Ingest]] =
+  ): Future[Either[IngestTrackerUpdateError, Ingest]] =
     for {
       ingestUpdateEntity <- Marshal(ingestUpdate).to[RequestEntity]
 
@@ -57,7 +60,36 @@ class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
         case status =>
           val err = new Exception(f"$status from IngestsTracker")
           error(f"NOT OK for PATCH to $requestUri with $ingestUpdate", err)
-          Future(Left(IngestTrackerUnknownError(ingestUpdate, err)))
+          Future(Left(IngestTrackerUnknownUpdateError(ingestUpdate, err)))
       }
     } yield ingest
+
+  override def getIngest(id: IngestID): Future[Either[IngestTrackerGetError, Ingest]] = {
+    val path = Path(s"/ingest/$id")
+    val requestUri = trackerHost.withPath(path)
+
+    val request = HttpRequest(
+      uri = requestUri,
+      method = HttpMethods.GET
+    )
+
+    info(s"Making request $request")
+
+    for {
+      response <- Http().singleRequest(request)
+
+      ingest <- response.status match {
+        case StatusCodes.OK =>
+          info(s"OK for GET to $requestUri")
+          Unmarshal(response.entity).to[Ingest].map(Right(_))
+        case StatusCodes.NotFound =>
+          warn(s"Not Found for GET to $requestUri")
+          Future(Left(IngestTrackerNotFoundError(id)))
+        case status =>
+          val err = new Exception(s"$status from IngestsTracker")
+          error(f"NOT OK for GET to $requestUri, err")
+          Future(Left(IngestTrackerUnknownGetError(id, err)))
+      }
+    } yield ingest
+  }
 }

--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
@@ -18,7 +18,9 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 import scala.concurrent.{ExecutionContext, Future}
 
 trait IngestTrackerClient {
-  def createIngest(ingest: Ingest): Future[Either[IngestTrackerCreateError, Unit]]
+  def createIngest(
+    ingest: Ingest
+  ): Future[Either[IngestTrackerCreateError, Unit]]
 
   def updateIngest(
     ingestUpdate: IngestUpdate
@@ -33,7 +35,9 @@ class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
 
   implicit val ec: ExecutionContext = as.dispatcher
 
-  override def createIngest(ingest: Ingest): Future[Either[IngestTrackerCreateError, Unit]] =
+  override def createIngest(
+    ingest: Ingest
+  ): Future[Either[IngestTrackerCreateError, Unit]] =
     for {
       ingestEntity <- Marshal(ingest).to[RequestEntity]
 

--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
@@ -64,7 +64,9 @@ class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
       }
     } yield ingest
 
-  override def getIngest(id: IngestID): Future[Either[IngestTrackerGetError, Ingest]] = {
+  override def getIngest(
+    id: IngestID
+  ): Future[Either[IngestTrackerGetError, Ingest]] = {
     val path = Path(s"/ingest/$id")
     val requestUri = trackerHost.withPath(path)
 

--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -1,11 +1,26 @@
 package uk.ac.wellcome.platform.storage.ingests_tracker.client
 
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestUpdate
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestID,
+  IngestUpdate
+}
 
-sealed trait IngestTrackerError {
+sealed trait IngestTrackerError
+
+sealed trait IngestTrackerUpdateError extends IngestTrackerError {
   val ingestUpdate: IngestUpdate
 }
+
 case class IngestTrackerConflictError(ingestUpdate: IngestUpdate)
-    extends IngestTrackerError
-case class IngestTrackerUnknownError(ingestUpdate: IngestUpdate, err: Throwable)
-    extends IngestTrackerError
+    extends IngestTrackerUpdateError
+
+case class IngestTrackerUnknownUpdateError(ingestUpdate: IngestUpdate, err: Throwable)
+    extends IngestTrackerUpdateError
+
+sealed trait IngestTrackerGetError extends IngestTrackerError {
+  val id: IngestID
+}
+
+case class IngestTrackerNotFoundError(id: IngestID) extends IngestTrackerGetError
+
+case class IngestTrackerUnknownGetError(id: IngestID, err: Throwable) extends IngestTrackerGetError

--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -13,10 +13,10 @@ sealed trait IngestTrackerCreateError extends IngestTrackerError {
 }
 
 case class IngestTrackerCreateConflictError(ingest: Ingest)
-  extends IngestTrackerCreateError
+    extends IngestTrackerCreateError
 
 case class IngestTrackerUnknownCreateError(ingest: Ingest, err: Throwable)
-  extends IngestTrackerCreateError
+    extends IngestTrackerCreateError
 
 sealed trait IngestTrackerUpdateError extends IngestTrackerError {
   val ingestUpdate: IngestUpdate

--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -14,13 +14,17 @@ sealed trait IngestTrackerUpdateError extends IngestTrackerError {
 case class IngestTrackerConflictError(ingestUpdate: IngestUpdate)
     extends IngestTrackerUpdateError
 
-case class IngestTrackerUnknownUpdateError(ingestUpdate: IngestUpdate, err: Throwable)
-    extends IngestTrackerUpdateError
+case class IngestTrackerUnknownUpdateError(
+  ingestUpdate: IngestUpdate,
+  err: Throwable
+) extends IngestTrackerUpdateError
 
 sealed trait IngestTrackerGetError extends IngestTrackerError {
   val id: IngestID
 }
 
-case class IngestTrackerNotFoundError(id: IngestID) extends IngestTrackerGetError
+case class IngestTrackerNotFoundError(id: IngestID)
+    extends IngestTrackerGetError
 
-case class IngestTrackerUnknownGetError(id: IngestID, err: Throwable) extends IngestTrackerGetError
+case class IngestTrackerUnknownGetError(id: IngestID, err: Throwable)
+    extends IngestTrackerGetError

--- a/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -2,94 +2,111 @@ package uk.ac.wellcome.platform.storage.ingests_tracker.client
 
 import java.time.Instant
 
-import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.common.fixtures.HttpFixtures
-import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Failed
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Succeeded
+import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryIngestTracker
 import uk.ac.wellcome.platform.storage.ingests_tracker.fixtures.IngestsTrackerApiFixture
 
-class IngestTrackerClientTest
-    extends AnyFunSpec
+trait IngestTrackerClientTestCases
+  extends AnyFunSpec
     with Matchers
-    with Eventually
-    with HttpFixtures
     with IngestsTrackerApiFixture
-    with IngestGenerators
-    with IntegrationPatience {
+    with ScalaFutures {
 
-  implicit val as = ActorSystem()
-
-  val host = "http://localhost:8080"
-
-  val ingestTrackerClient = new AkkaIngestTrackerClient(Uri(host))
-
-  val ingest = createIngestWith(
+  val ingest: Ingest = createIngestWith(
     createdDate = Instant.now()
   )
 
-  val ingestStatusUpdate =
+  val ingestStatusUpdate: IngestStatusUpdate =
     createIngestStatusUpdateWith(
       id = ingest.id,
       status = Succeeded
     )
 
-  val succeededIngest = ingest.copy(
+  val succeededIngest: Ingest = ingest.copy(
     status = Succeeded,
     events = ingestStatusUpdate.events
   )
 
-  val failedIngest = ingest.copy(
+  val failedIngest: Ingest = ingest.copy(
     status = Failed,
     events = ingestStatusUpdate.events
   )
 
-  it("updates a valid ingest") {
+  def withIngestTrackerClient[R](testWith: TestWith[IngestTrackerClient, R]): R
+
+  private def withIngestsTracker[R](ingest: Ingest)(testWith: TestWith[MemoryIngestTracker, R]): R =
     withIngestsTrackerApi(Seq(ingest)) {
       case (_, _, ingestsTracker) =>
-        val update = ingestTrackerClient.updateIngest(ingestStatusUpdate)
+        testWith(ingestsTracker)
+    }
 
-        whenReady(update) { result =>
-          result shouldBe Right(succeededIngest)
-          ingestsTracker
-            .get(ingest.id)
-            .right
-            .get
-            .identifiedT shouldBe succeededIngest
+  describe("behaves as an IngestTrackerClient") {
+    describe("updateIngest") {
+      it("applies a valid update") {
+        withIngestsTracker(ingest) { ingestsTracker =>
+          withIngestTrackerClient { client =>
+            val update = client.updateIngest(ingestStatusUpdate)
+
+            whenReady(update) { result =>
+              result shouldBe Right(succeededIngest)
+              ingestsTracker
+                .get(ingest.id)
+                .right
+                .get
+                .identifiedT shouldBe succeededIngest
+            }
+          }
         }
+      }
 
+      it("fails to apply a conflicting update") {
+        withIngestsTracker(failedIngest) { ingestsTracker =>
+          withIngestTrackerClient { client =>
+            val update = client.updateIngest(ingestStatusUpdate)
+
+            whenReady(update) { result =>
+              result shouldBe Left(IngestTrackerConflictError(ingestStatusUpdate))
+              ingestsTracker
+                .get(ingest.id)
+                .right
+                .get
+                .identifiedT shouldBe failedIngest
+            }
+          }
+        }
+      }
+
+      it("errors if the tracker API is down") {
+        withBrokenIngestsTrackerApi { _ =>
+          withIngestTrackerClient { client =>
+            val update = client.updateIngest(ingestStatusUpdate)
+
+            whenReady(update) { result =>
+              result shouldBe a[Left[_, _]]
+              result.left.get shouldBe a[IngestTrackerUnknownError]
+            }
+          }
+        }
+      }
     }
   }
+}
 
-  it("fails if the ingest update conflicts with the stored ingest") {
-    withIngestsTrackerApi(Seq(failedIngest)) {
-      case (_, _, ingestsTracker) =>
-        val update = ingestTrackerClient.updateIngest(ingestStatusUpdate)
+class AkkaIngestTrackerClientTest extends IngestTrackerClientTestCases with IntegrationPatience {
+  override def withIngestTrackerClient[R](testWith: TestWith[IngestTrackerClient, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val client = new AkkaIngestTrackerClient(trackerHost = Uri("http://localhost:8080"))
 
-        whenReady(update) { result =>
-          result shouldBe Left(IngestTrackerConflictError(ingestStatusUpdate))
-          ingestsTracker
-            .get(ingest.id)
-            .right
-            .get
-            .identifiedT shouldBe failedIngest
-        }
+      testWith(client)
     }
-  }
-
-  it("errors with a broken api") {
-    withBrokenIngestsTrackerApi {
-      case (_, _, _) =>
-        val update = ingestTrackerClient.updateIngest(ingestStatusUpdate)
-
-        whenReady(update) { result =>
-          result shouldBe a[Left[_, _]]
-          result.left.get shouldBe a[IngestTrackerUnknownError]
-        }
-    }
-  }
 }

--- a/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -59,19 +59,20 @@ trait IngestTrackerClientTestCases
   describe("behaves as an IngestTrackerClient") {
     describe("createIngest") {
       it("creates a new ingest") {
-        withIngestsTrackerApi() { case (_, _, ingestsTracker) =>
-          withIngestTrackerClient(trackerUri) { client =>
-            val create = client.createIngest(ingest)
+        withIngestsTrackerApi() {
+          case (_, _, ingestsTracker) =>
+            withIngestTrackerClient(trackerUri) { client =>
+              val create = client.createIngest(ingest)
 
-            whenReady(create) { result =>
-              result shouldBe Right(())
-              ingestsTracker
-                .get(ingest.id)
-                .right
-                .get
-                .identifiedT shouldBe ingest
+              whenReady(create) { result =>
+                result shouldBe Right(())
+                ingestsTracker
+                  .get(ingest.id)
+                  .right
+                  .get
+                  .identifiedT shouldBe ingest
+              }
             }
-          }
         }
       }
 

--- a/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryInges
 import uk.ac.wellcome.platform.storage.ingests_tracker.fixtures.IngestsTrackerApiFixture
 
 trait IngestTrackerClientTestCases
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with IngestsTrackerApiFixture
     with ScalaFutures {
@@ -44,9 +44,13 @@ trait IngestTrackerClientTestCases
 
   val trackerUri = "http://localhost:8080"
 
-  def withIngestTrackerClient[R](trackerUri: String)(testWith: TestWith[IngestTrackerClient, R]): R
+  def withIngestTrackerClient[R](trackerUri: String)(
+    testWith: TestWith[IngestTrackerClient, R]
+  ): R
 
-  private def withIngestsTracker[R](ingest: Ingest)(testWith: TestWith[MemoryIngestTracker, R]): R =
+  private def withIngestsTracker[R](
+    ingest: Ingest
+  )(testWith: TestWith[MemoryIngestTracker, R]): R =
     withIngestsTrackerApi(Seq(ingest)) {
       case (_, _, ingestsTracker) =>
         testWith(ingestsTracker)
@@ -77,7 +81,9 @@ trait IngestTrackerClientTestCases
             val update = client.updateIngest(ingestStatusUpdate)
 
             whenReady(update) { result =>
-              result shouldBe Left(IngestTrackerConflictError(ingestStatusUpdate))
+              result shouldBe Left(
+                IngestTrackerConflictError(ingestStatusUpdate)
+              )
               ingestsTracker
                 .get(ingest.id)
                 .right
@@ -159,8 +165,12 @@ trait IngestTrackerClientTestCases
   }
 }
 
-class AkkaIngestTrackerClientTest extends IngestTrackerClientTestCases with IntegrationPatience {
-  override def withIngestTrackerClient[R](trackerUri: String)(testWith: TestWith[IngestTrackerClient, R]): R =
+class AkkaIngestTrackerClientTest
+    extends IngestTrackerClientTestCases
+    with IntegrationPatience {
+  override def withIngestTrackerClient[R](
+    trackerUri: String
+  )(testWith: TestWith[IngestTrackerClient, R]): R =
     withActorSystem { implicit actorSystem =>
       val client = new AkkaIngestTrackerClient(trackerHost = Uri(trackerUri))
 

--- a/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
+++ b/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
@@ -27,7 +27,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
   IngestTrackerConflictError,
-  IngestTrackerUnknownError
+  IngestTrackerUnknownUpdateError
 }
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -66,7 +66,7 @@ class IngestsWorkerService(
         )
         warn(err)
         DeterministicFailure[Ingest](err)
-      case Left(IngestTrackerUnknownError(_, err)) =>
+      case Left(IngestTrackerUnknownUpdateError(_, err)) =>
         error(s"Error trying to apply $ingestUpdate, got UnknownError", err)
         NonDeterministicFailure[Ingest](err)
     } recover {

--- a/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
+++ b/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
@@ -26,8 +26,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
-  IngestTrackerUpdateConflictError,
-  IngestTrackerUnknownUpdateError
+  IngestTrackerUnknownUpdateError,
+  IngestTrackerUpdateConflictError
 }
 import uk.ac.wellcome.typesafe.Runnable
 

--- a/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
+++ b/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
@@ -63,7 +63,9 @@ trait IngestsWorkerFixtures
 
   def unknownErrorClient(ingestUpdate: IngestUpdate) =
     new FakeIngestTrackerClient(
-      Future.successful(Left(IngestTrackerUnknownUpdateError(ingestUpdate, error)))
+      Future.successful(
+        Left(IngestTrackerUnknownUpdateError(ingestUpdate, error))
+      )
     )
 
   def failedFutureClient(error: Throwable = error) =

--- a/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
+++ b/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
@@ -16,9 +16,9 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures.IngestTrackerFixtures
 import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
-  IngestTrackerUpdateConflictError,
   IngestTrackerError,
-  IngestTrackerUnknownUpdateError
+  IngestTrackerUnknownUpdateError,
+  IngestTrackerUpdateConflictError
 }
 import uk.ac.wellcome.platform.storage.ingests_worker.services.IngestsWorkerService
 

--- a/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
+++ b/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
   IngestTrackerConflictError,
   IngestTrackerError,
-  IngestTrackerUnknownError
+  IngestTrackerUnknownUpdateError
 }
 import uk.ac.wellcome.platform.storage.ingests_worker.services.IngestsWorkerService
 
@@ -63,7 +63,7 @@ trait IngestsWorkerFixtures
 
   def unknownErrorClient(ingestUpdate: IngestUpdate) =
     new FakeIngestTrackerClient(
-      Future.successful(Left(IngestTrackerUnknownError(ingestUpdate, error)))
+      Future.successful(Left(IngestTrackerUnknownUpdateError(ingestUpdate, error)))
     )
 
   def failedFutureClient(error: Throwable = error) =


### PR DESCRIPTION
Part of modifying the external-facing ingests API to use the ingests tracker (https://github.com/wellcomecollection/platform/issues/4419).

I tweaked the test cases to make them more generic, and had to rename a few of the existing errors to distinguish between and update/get error.