### PR TITLE
Add a createIngest() method to the ingest tracker client

### DIFF
--- a/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -1,17 +1,28 @@
 package uk.ac.wellcome.platform.storage.ingests_tracker.client
 
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
   IngestID,
   IngestUpdate
 }
 
 sealed trait IngestTrackerError
 
+sealed trait IngestTrackerCreateError extends IngestTrackerError {
+  val ingest: Ingest
+}
+
+case class IngestTrackerCreateConflictError(ingest: Ingest)
+  extends IngestTrackerCreateError
+
+case class IngestTrackerUnknownCreateError(ingest: Ingest, err: Throwable)
+  extends IngestTrackerCreateError
+
 sealed trait IngestTrackerUpdateError extends IngestTrackerError {
   val ingestUpdate: IngestUpdate
 }
 
-case class IngestTrackerConflictError(ingestUpdate: IngestUpdate)
+case class IngestTrackerUpdateConflictError(ingestUpdate: IngestUpdate)
     extends IngestTrackerUpdateError
 
 case class IngestTrackerUnknownUpdateError(

--- a/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
+++ b/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerService.scala
@@ -26,7 +26,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
-  IngestTrackerConflictError,
+  IngestTrackerUpdateConflictError,
   IngestTrackerUnknownUpdateError
 }
 import uk.ac.wellcome.typesafe.Runnable
@@ -60,7 +60,7 @@ class IngestsWorkerService(
       case Right(ingest) =>
         info(f"Successfully applied $ingestUpdate, got $ingest")
         Successful(Some(ingest))
-      case Left(IngestTrackerConflictError(_)) =>
+      case Left(IngestTrackerUpdateConflictError(_)) =>
         val err = new Exception(
           f"Error trying to apply update $ingestUpdate, got Conflict"
         )

--- a/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
+++ b/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/fixtures/IngestsWorkerFixtures.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures.IngestTrackerFixtures
 import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
   IngestTrackerClient,
-  IngestTrackerConflictError,
+  IngestTrackerUpdateConflictError,
   IngestTrackerError,
   IngestTrackerUnknownUpdateError
 }
@@ -58,7 +58,7 @@ trait IngestsWorkerFixtures
   )
 
   def conflictClient(ingestUpdate: IngestUpdate) = new FakeIngestTrackerClient(
-    Future.successful(Left(IngestTrackerConflictError(ingestUpdate)))
+    Future.successful(Left(IngestTrackerUpdateConflictError(ingestUpdate)))
   )
 
   def unknownErrorClient(ingestUpdate: IngestUpdate) =


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/storage-service/pull/509

Part of modifying the external-facing ingests API to use the ingests tracker (wellcomecollection/platform#4419).