### PR TITLE
IngestsTrackerApi should be a class

### DIFF
--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
@@ -25,22 +25,17 @@ import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 
-trait IngestsTrackerApi[CallbackDestination, UpdatedIngestsDestination]
-    extends Runnable
+class IngestsTrackerApi[CallbackDestination, IngestsDestination](
+  ingestTracker: IngestTracker,
+  messagingService: MessagingService[CallbackDestination, IngestsDestination]
+)(
+  host: String = "localhost", port: Int = 8080
+)(
+  implicit sys: ActorSystem, mat: Materializer
+)extends Runnable
     with Logging {
 
-  val ingestTracker: IngestTracker
-  val messagingService: MessagingService[
-    CallbackDestination,
-    UpdatedIngestsDestination
-  ]
-
-  implicit protected val sys: ActorSystem
-  implicit protected val mat: Materializer
-  implicit protected val exc: ExecutionContextExecutor = sys.dispatcher
-
-  implicit protected val host: String = "localhost"
-  implicit protected val port: Int = 8080
+  implicit val exc: ExecutionContextExecutor = sys.dispatcher
 
   val route: Route =
     concat(

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
@@ -29,10 +29,12 @@ class IngestsTrackerApi[CallbackDestination, IngestsDestination](
   ingestTracker: IngestTracker,
   messagingService: MessagingService[CallbackDestination, IngestsDestination]
 )(
-  host: String = "localhost", port: Int = 8080
+  host: String = "localhost",
+  port: Int = 8080
 )(
-  implicit sys: ActorSystem, mat: Materializer
-)extends Runnable
+  implicit sys: ActorSystem,
+  mat: Materializer
+) extends Runnable
     with Logging {
 
   implicit val exc: ExecutionContextExecutor = sys.dispatcher

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
@@ -42,17 +42,15 @@ object Main extends WellcomeTypesafeApp {
         subject = "Updated ingests sent by the ingests monitor"
       )
 
-    new IngestsTrackerApi[SNSConfig, SNSConfig] {
-      override val messagingService = new MessagingService(
-        callbackNotificationService,
-        updatedIngestsMessageSender
-      )
+    val messagingService = new MessagingService(
+      callbackNotificationService,
+      updatedIngestsMessageSender
+    )
 
-      override val ingestTracker: IngestTracker = new DynamoIngestTracker(
-        config = DynamoBuilder.buildDynamoConfig(config)
-      )
-      override implicit protected val sys: ActorSystem = actorSystem
-      override implicit protected val mat: Materializer = materializer
-    }
+    val ingestTracker: IngestTracker = new DynamoIngestTracker(
+      config = DynamoBuilder.buildDynamoConfig(config)
+    )
+
+    new IngestsTrackerApi[SNSConfig, SNSConfig](ingestTracker, messagingService)()
   }
 }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
@@ -51,6 +51,9 @@ object Main extends WellcomeTypesafeApp {
       config = DynamoBuilder.buildDynamoConfig(config)
     )
 
-    new IngestsTrackerApi[SNSConfig, SNSConfig](ingestTracker, messagingService)()
+    new IngestsTrackerApi[SNSConfig, SNSConfig](
+      ingestTracker,
+      messagingService
+    )()
   }
 }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -1,25 +1,13 @@
 package uk.ac.wellcome.platform.storage.ingests_tracker.fixtures
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestUpdate}
 import uk.ac.wellcome.platform.storage.ingests_tracker.IngestsTrackerApi
-import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
-  CallbackNotificationService,
-  MessagingService
-}
-import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.{
-  IngestStoreUnexpectedError,
-  IngestTracker
-}
+import uk.ac.wellcome.platform.storage.ingests_tracker.services.{CallbackNotificationService, MessagingService}
+import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
@@ -43,19 +31,13 @@ trait IngestsTrackerApiFixture
         val callbackNotificationService =
           new CallbackNotificationService(callbackNotificationMessageSender)
 
-        val app = new IngestsTrackerApi[String, String] {
+        val messagingService: MessagingService[String, String] =
+          new MessagingService(
+            callbackNotificationService,
+            updatedIngestsMessageSender
+          )
 
-          override val messagingService: MessagingService[String, String] =
-            new MessagingService(
-              callbackNotificationService,
-              updatedIngestsMessageSender
-            )
-
-          override val ingestTracker: IngestTracker = ingestTrackerTest
-          override implicit lazy protected val sys: ActorSystem = actorSystem
-          override implicit lazy protected val mat: Materializer =
-            materializer
-        }
+        val app = new IngestsTrackerApi[String, String](ingestTrackerTest, messagingService)()
 
         app.run()
 

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -4,9 +4,16 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.storage.ingests_tracker.IngestsTrackerApi
-import uk.ac.wellcome.platform.storage.ingests_tracker.services.{CallbackNotificationService, MessagingService}
+import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
+  CallbackNotificationService,
+  MessagingService
+}
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
 import uk.ac.wellcome.storage.Version
@@ -37,7 +44,10 @@ trait IngestsTrackerApiFixture
             updatedIngestsMessageSender
           )
 
-        val app = new IngestsTrackerApi[String, String](ingestTrackerTest, messagingService)()
+        val app = new IngestsTrackerApi[String, String](
+          ingestTrackerTest,
+          messagingService
+        )()
 
         app.run()
 


### PR DESCRIPTION
This will hopefully simplify creating IngestsTrackerApi a bit and remove the possibility of "scala.UninitializedFieldError: Uninitialized field" error.