### PR TITLE
Allow moving an ingest from "failed" to "succeeded"

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -42,11 +42,11 @@ case object Ingest {
     override def toString: String = "processing"
   }
 
-  case object Succeeded extends Completed {
-    override def toString: String = "succeeded"
-  }
-
   case object Failed extends Completed {
     override def toString: String = "failed"
+  }
+
+  case object Succeeded extends Completed {
+    override def toString: String = "succeeded"
   }
 }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -133,19 +133,25 @@ trait IngestTrackerClientTestCases
       }
 
       it("fails to apply a conflicting update") {
-        withIngestsTracker(failedIngest) { ingestsTracker =>
+        val initialIngest = createIngestWith(status = Succeeded)
+        val failedUpdate = createIngestStatusUpdateWith(
+          id = ingest.id,
+          status = Ingest.Failed
+        )
+
+        withIngestsTracker(initialIngest) { ingestsTracker =>
           withIngestTrackerClient(trackerUri) { client =>
-            val update = client.updateIngest(ingestStatusUpdate)
+            val update = client.updateIngest(failedUpdate)
 
             whenReady(update) { result =>
               result shouldBe Left(
-                IngestTrackerUpdateConflictError(ingestStatusUpdate)
+                IngestTrackerUpdateConflictError(failedUpdate)
               )
               ingestsTracker
-                .get(ingest.id)
+                .get(initialIngest.id)
                 .right
                 .get
-                .identifiedT shouldBe failedIngest
+                .identifiedT shouldBe initialIngest
             }
           }
         }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestStatesTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestStatesTest.scala
@@ -132,7 +132,7 @@ class IngestStatusUpdateTest
       (Ingest.Accepted, Ingest.Failed),
       (Ingest.Processing, Ingest.Succeeded),
       (Ingest.Processing, Ingest.Failed),
-      (Ingest.Failed, Ingest.Succeeded),
+      (Ingest.Failed, Ingest.Succeeded)
     )
 
     it("updates the status of an ingest") {

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestStatesTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestStatesTest.scala
@@ -131,7 +131,8 @@ class IngestStatusUpdateTest
       (Ingest.Accepted, Ingest.Succeeded),
       (Ingest.Accepted, Ingest.Failed),
       (Ingest.Processing, Ingest.Succeeded),
-      (Ingest.Processing, Ingest.Failed)
+      (Ingest.Processing, Ingest.Failed),
+      (Ingest.Failed, Ingest.Succeeded),
     )
 
     it("updates the status of an ingest") {
@@ -152,7 +153,6 @@ class IngestStatusUpdateTest
 
     val disallowedStatusUpdates = Table(
       ("initial", "update"),
-      (Ingest.Failed, Ingest.Succeeded),
       (Ingest.Failed, Ingest.Processing),
       (Ingest.Failed, Ingest.Accepted),
       (Ingest.Succeeded, Ingest.Failed),

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTrackerTestCases.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTrackerTestCases.scala
@@ -296,7 +296,7 @@ trait IngestTrackerTestCases[Context]
           (Ingest.Processing, Ingest.Succeeded),
           (Ingest.Failed, Ingest.Failed),
           (Ingest.Failed, Ingest.Succeeded),
-          (Ingest.Succeeded, Ingest.Succeeded),
+          (Ingest.Succeeded, Ingest.Succeeded)
         )
 
         it("updates the status of an ingest") {
@@ -324,7 +324,7 @@ trait IngestTrackerTestCases[Context]
           (Ingest.Failed, Ingest.Processing),
           (Ingest.Succeeded, Ingest.Accepted),
           (Ingest.Succeeded, Ingest.Processing),
-          (Ingest.Succeeded, Ingest.Failed),
+          (Ingest.Succeeded, Ingest.Failed)
         )
 
         it("does not allow the status to go backwards") {

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTrackerTestCases.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTrackerTestCases.scala
@@ -289,12 +289,14 @@ trait IngestTrackerTestCases[Context]
           ("initial", "update"),
           (Ingest.Accepted, Ingest.Accepted),
           (Ingest.Accepted, Ingest.Processing),
-          (Ingest.Accepted, Ingest.Succeeded),
           (Ingest.Accepted, Ingest.Failed),
-          (Ingest.Processing, Ingest.Succeeded),
+          (Ingest.Accepted, Ingest.Succeeded),
+          (Ingest.Processing, Ingest.Processing),
           (Ingest.Processing, Ingest.Failed),
+          (Ingest.Processing, Ingest.Succeeded),
+          (Ingest.Failed, Ingest.Failed),
+          (Ingest.Failed, Ingest.Succeeded),
           (Ingest.Succeeded, Ingest.Succeeded),
-          (Ingest.Failed, Ingest.Failed)
         )
 
         it("updates the status of an ingest") {
@@ -317,13 +319,12 @@ trait IngestTrackerTestCases[Context]
 
         val disallowedStatusUpdates = Table(
           ("initial", "update"),
-          (Ingest.Failed, Ingest.Succeeded),
-          (Ingest.Failed, Ingest.Processing),
+          (Ingest.Processing, Ingest.Accepted),
           (Ingest.Failed, Ingest.Accepted),
-          (Ingest.Succeeded, Ingest.Failed),
-          (Ingest.Succeeded, Ingest.Processing),
+          (Ingest.Failed, Ingest.Processing),
           (Ingest.Succeeded, Ingest.Accepted),
-          (Ingest.Processing, Ingest.Accepted)
+          (Ingest.Succeeded, Ingest.Processing),
+          (Ingest.Succeeded, Ingest.Failed),
         )
 
         it("does not allow the status to go backwards") {


### PR DESCRIPTION
This would allow us to retry ingests that have failed (for example, from the failed replication policy).

I've reordered some bits of the codebase to emphasise the strict waterfall that ingest states can follow.

Closes https://github.com/wellcomecollection/platform/issues/4512