### PR TITLE
Write all the ingests to a single index, not multiple indexes

### DIFF
--- a/indexer/ingests_indexer/src/main/resources/application.conf
+++ b/indexer/ingests_indexer/src/main/resources/application.conf
@@ -5,4 +5,4 @@ es.port=${?es_port}
 es.username=${?es_username}
 es.password=${?es_password}
 es.protocol=${?es_protocol}
-es.ingests.index-prefix=${?es_ingests_index_prefix}
+es.ingests.index-name=${?es_ingests_index_name}

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
@@ -1,8 +1,5 @@
 package uk.ac.wellcome.platform.archive.indexer.ingests
 
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
@@ -39,25 +36,8 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: SqsAsyncClient =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    // Ingests will be written a lot when they're initially processing, then never written
-    // again once the ingest completes.  Lots of writes upfront, then read-only.
-    //
-    // For this reason, we do initial writes into per-day indexes, and then aggregate them
-    // into a single index with a rollup job (https://www.elastic.co/guide/en/kibana/current/data-rollups.html)
-    //
-    // The per-day indexes are small and handle the intensive writes; the long-term index
-    // only gets written to by the rollup job.
-    //
-    // Because the app will scale to zero when it's not running, it's okay if the
-    // index name only changes when the app starts.
-    //
-    val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
-    val currentWeek = dateFormatter.format(LocalDate.now())
-    val indexPrefix: String = config.required[String]("es.ingests.index-prefix")
-    val indexName = s"$indexPrefix--$currentWeek"
-    val index = Index(indexName)
-
-    info(s"Writing ingests to per-week index $index")
+    val index = Index(name = config.required[String]("es.ingests.index-name"))
+    info(s"Writing ingests to index $index")
 
     info(s"Creating the Elasticsearch index mapping")
     val elasticClient = ElasticClientBuilder.buildElasticClient(config)

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -60,7 +60,7 @@ module "ingests_indexer" {
     queue_url         = module.updated_ingests_queue.url
     metrics_namespace = local.ingests_indexer_service_name
 
-    es_ingests_index_prefix = var.es_ingests_index_prefix
+    es_ingests_index_name = var.es_ingests_index_name
   }
 
   secrets = var.ingests_indexer_secrets

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -129,7 +129,7 @@ variable "archivematica_ingests_bucket" {
   type = string
 }
 
-variable "es_ingests_index_prefix" {
+variable "es_ingests_index_name" {
   type = string
 }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -50,7 +50,7 @@ module "stack_prod" {
   replicas_table_arn  = data.terraform_remote_state.critical_prod.outputs.replicas_table_arn
   replicas_table_name = data.terraform_remote_state.critical_prod.outputs.replicas_table_name
 
-  es_ingests_index_prefix = "storage_ingests"
+  es_ingests_index_name = "storage_ingests"
 
   ingests_indexer_secrets = {
     es_host     = "prod/ingests_indexer/es_host"

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -50,7 +50,7 @@ module "stack_staging" {
   replicas_table_arn  = data.terraform_remote_state.critical_staging.outputs.replicas_table_arn
   replicas_table_name = data.terraform_remote_state.critical_staging.outputs.replicas_table_name
 
-  es_ingests_index_prefix = "storage_stage_ingests"
+  es_ingests_index_name = "storage_stage_ingests"
 
   ingests_indexer_secrets = {
     es_host     = "stage/ingests_indexer/es_host"


### PR DESCRIPTION
This makes everything a bit simpler:

* We don't have to manage rollup jobs
* The same ingest doesn't appear multiple times in different indexes
* We only have ~280k ingests in prod; the size of the index is tiny by Elasticsearch standards

Closes https://github.com/wellcomecollection/platform/issues/4525

I'll go through and send all the existing ingests for reindexing once this is applied.