### PR TITLE
Fix a variety of Terraform bugs

### DIFF
--- a/terraform/modules/service/api/main.tf
+++ b/terraform/modules/service/api/main.tf
@@ -4,6 +4,9 @@ module "base" {
   service_name = var.service_name
   cluster_arn  = var.cluster_arn
 
+  cpu    = var.cpu
+  memory = var.memory
+
   container_definitions = [
     module.nginx_container.container_definition,
     module.app_container.container_definition
@@ -29,6 +32,8 @@ module "base" {
   container_port = module.nginx_container.container_port
 
   subnets = var.subnets
+
+  use_fargate_spot = var.use_fargate_spot
 }
 
 module "nginx_container" {

--- a/terraform/modules/service/base/variables.tf
+++ b/terraform/modules/service/base/variables.tf
@@ -5,13 +5,11 @@ variable "service_name" {
 variable "container_definitions" {}
 
 variable "cpu" {
-  type    = number
-  default = 512
+  type = number
 }
 
 variable "memory" {
-  type    = number
-  default = 1024
+  type = number
 }
 
 variable "cluster_arn" {
@@ -35,8 +33,7 @@ variable "desired_task_count" {
 }
 
 variable "use_fargate_spot" {
-  type    = bool
-  default = false
+  type = bool
 }
 
 variable "target_group_arn" {

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -4,6 +4,9 @@ module "base" {
   service_name = var.service_name
   cluster_arn  = var.cluster_arn
 
+  cpu    = 1024
+  memory = 2048
+
   container_definitions = [
     module.nginx_container.container_definition,
     module.external_api_container.container_definition,
@@ -31,6 +34,10 @@ module "base" {
   container_port = module.nginx_container.container_port
 
   subnets = var.subnets
+
+  # We don't use Fargate Spot for the ingests service, because it includes the
+  # external-facing ingests API which has to stay up.
+  use_fargate_spot = false
 }
 
 module "nginx_container" {

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -4,6 +4,9 @@ module "base" {
   service_name = var.service_name
   cluster_arn  = var.cluster_arn
 
+  cpu    = var.cpu
+  memory = var.memory
+
   container_definitions = [
     module.app_container.container_definition
   ]
@@ -14,6 +17,8 @@ module "base" {
   service_discovery_namespace_id = var.service_discovery_namespace_id
 
   subnets = var.subnets
+
+  use_fargate_spot = var.use_fargate_spot
 }
 
 module "app_container" {

--- a/terraform/modules/service/worker/variables.tf
+++ b/terraform/modules/service/worker/variables.tf
@@ -47,11 +47,6 @@ variable "max_capacity" {
   default = 1
 }
 
-variable "launch_type" {
-  type    = string
-  default = "FARGATE"
-}
-
 variable "security_group_ids" {
   type    = list(string)
   default = []

--- a/terraform/modules/stack/api/variables.tf
+++ b/terraform/modules/stack/api/variables.tf
@@ -1,21 +1,9 @@
-variable "ingests_listener_port" {
-  type = number
-}
-
-variable "bags_listener_port" {
-  type = number
-}
-
 variable "subnets" {
   type = list(string)
 }
 
 variable "aws_region" {
   default = "eu-west-1"
-}
-
-variable "vpc_id" {
-  type = string
 }
 
 variable "namespace" {

--- a/terraform/modules/stack/locals.tf
+++ b/terraform/modules/stack/locals.tf
@@ -14,10 +14,6 @@ locals {
   ingests_indexer_service_name        = "${var.namespace}-ingests_indexer"
   replica_aggregator_service_name     = "${var.namespace}-replica_aggregator"
 
-  logstash_transit_service_name = "${var.namespace}_logstash_transit"
-  logstash_transit_image        = "wellcome/logstash_transit:edgelord"
-  logstash_host                 = "${local.logstash_transit_service_name}.${var.namespace}"
-
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
 
   ingests_listener_port = "65535"

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -312,7 +312,6 @@ module "replicator_verifier_primary" {
   subnets      = var.private_subnets
 
   ingests_topic_arn = module.ingests_topic.arn
-  logstash_host     = local.logstash_host
 
   replicator_lock_table_name  = module.replicator_lock_table.table_name
   replicator_lock_table_index = module.replicator_lock_table.index_name
@@ -361,7 +360,6 @@ module "replicator_verifier_glacier" {
   subnets      = var.private_subnets
 
   ingests_topic_arn = module.ingests_topic.arn
-  logstash_host     = local.logstash_host
 
   replicator_lock_table_name  = module.replicator_lock_table.table_name
   replicator_lock_table_index = module.replicator_lock_table.index_name
@@ -482,7 +480,6 @@ module "notifier" {
 module "api" {
   source = "./api"
 
-  vpc_id  = var.vpc_id
   subnets = var.private_subnets
 
   domain_name      = var.domain_name
@@ -500,8 +497,5 @@ module "api" {
   ]
 
   static_content_bucket_name = var.static_content_bucket_name
-
-  bags_listener_port    = local.bags_listener_port
-  ingests_listener_port = local.ingests_listener_port
 }
 

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -62,7 +62,7 @@ module "bag_verifier" {
     operation_name     = "verification (${var.replica_display_name})"
     JAVA_OPTS          = "${local.java_opts_heap_size} ${local.java_opts_metrics_base},metricNameSpace=${local.bag_verifier_service_name}"
 
-    primary_storage_bucket_name = var.bucket_name
+    primary_storage_bucket_name = var.primary_bucket_name
   }
 
   cpu    = 2048

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -74,10 +74,6 @@ variable "ingests_topic_arn" {
   type = string
 }
 
-variable "logstash_host" {
-  type = string
-}
-
 variable "replicator_lock_table_name" {
   type = string
 }

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -115,16 +115,6 @@ variable "versioner_versions_table_index" {
   type = string
 }
 
-variable "desired_bags_api_count" {
-  default = 3
-  type    = number
-}
-
-variable "desired_ingests_api_count" {
-  default = 3
-  type    = number
-}
-
 variable "archivematica_ingests_bucket" {
   type = string
 }
@@ -140,6 +130,7 @@ variable "ingests_indexer_secrets" {
 variable "min_capacity" {
   type = number
 }
+
 variable "max_capacity" {
   type = number
 }


### PR DESCRIPTION
* Actually pass CPU, memory and Fargate spot definitions to underlying modules
* Remove unused Logstash variables
* Point the Glacier verifier at the right bucket