### PR TITLE
Build a minimal S3 object tagger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
     - env: SBT_PROJECT=ingests_api
     - env: SBT_PROJECT=notifier
 
+    - env: TASK=s3_object_tagger-test
+
     # - env: TASK=python_client-test
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SBT_DOCKER_LIBRARIES    = common
 SBT_NO_DOCKER_LIBRARIES = bags_common display
 
 PYTHON_APPS =
-LAMBDAS 	=
+LAMBDAS 	= s3_object_tagger
 
 TF_NAME = storage
 TF_PATH = $(STACK_ROOT)/terraform

--- a/s3_object_tagger/README.md
+++ b/s3_object_tagger/README.md
@@ -1,0 +1,23 @@
+# S3 object tagger
+
+This Lambda receives the event stream from the `wellcomecollection-storage` bucket, and applies tags to some objects.
+
+
+
+## Moving infrequently-accessed objects to cold storage tiers
+
+At time of writing, the storage service keeps two replicas of every bag:
+
+-   A warm access replica in `wellcomecollection-storage`
+-   A cold replica in `wellcomecollection-storage-replica-ireland`
+    This is a backup, which is lifecycled to Glacier Deep Archive.
+-   (Soon) A cold replica in Azure Blob Storage.
+
+We need to be able to access most files at zero notice, for example to display content on the website.
+These files are kept in the warm replica in the Standard IA storage class.
+
+There are some files we know we don't need immediate access to: for example, the high-resolution video masters from A/V digitisation.
+The A/V workflow creates a smaller MP4 file that can be user for the website.
+We keep the master file in case we need to re-encode it, but we don't need day-to-day access.
+
+We give these objects a special tag, and the lifecycle rules on the bucket move them into cold storage tiers.

--- a/s3_object_tagger/src/tag_chooser.py
+++ b/s3_object_tagger/src/tag_chooser.py
@@ -1,0 +1,25 @@
+import os
+
+
+def choose_tags(bucket, key):
+    """
+    Given the bucket, key and size of an object, decide what tags (if any)
+    should be applied to it.
+    """
+    storage_space, *_ = key.split("/")
+
+    tags = []
+
+    # Add a tag to MXF files in the "digitised" space.
+    #
+    # These are high-resolution video masters from A/V digitisation.  We keep
+    # them around in case we need to re-encode the video in future, but we don't
+    # access them day-to-day.
+    #
+    # Apply a tag so they can be lifecycled to a cold storage tier.
+    _, file_extension = os.path.splitext(key)
+
+    if storage_space == "digitised" and file_extension.lower() == ".mxf":
+        tags.append(("FileType", "MXF video master"))
+
+    return tags

--- a/s3_object_tagger/src/test_tag_chooser.py
+++ b/s3_object_tagger/src/test_tag_chooser.py
@@ -1,0 +1,20 @@
+import pytest
+
+from tag_chooser import choose_tags
+
+
+@pytest.mark.parametrize("key, expected_tags", [
+    # MXF video masters get a tag
+    ("digitised/b1234/v1/cats.mxf", [("FileType", "MXF video master")]),
+
+    # If the file extension is uppercase, it gets tagged
+    ("digitised/b1234/v1/cats.MXF", [("FileType", "MXF video master")]),
+
+    # Files with a different extension don't get tagged
+    ("digitised/b1234/v1/cats.mp4", []),
+
+    # MXF files in a different space don't get tagged
+    ("born-digital/CA/TS/v1/cats.MXF", []),
+])
+def test_choose_tags(key, expected_tags):
+    assert choose_tags(bucket="wellcomecollection-example", key=key) == expected_tags

--- a/s3_object_tagger/src/test_tag_chooser.py
+++ b/s3_object_tagger/src/test_tag_chooser.py
@@ -3,18 +3,18 @@ import pytest
 from tag_chooser import choose_tags
 
 
-@pytest.mark.parametrize("key, expected_tags", [
-    # MXF video masters get a tag
-    ("digitised/b1234/v1/cats.mxf", [("FileType", "MXF video master")]),
-
-    # If the file extension is uppercase, it gets tagged
-    ("digitised/b1234/v1/cats.MXF", [("FileType", "MXF video master")]),
-
-    # Files with a different extension don't get tagged
-    ("digitised/b1234/v1/cats.mp4", []),
-
-    # MXF files in a different space don't get tagged
-    ("born-digital/CA/TS/v1/cats.MXF", []),
-])
+@pytest.mark.parametrize(
+    "key, expected_tags",
+    [
+        # MXF video masters get a tag
+        ("digitised/b1234/v1/cats.mxf", [("FileType", "MXF video master")]),
+        # If the file extension is uppercase, it gets tagged
+        ("digitised/b1234/v1/cats.MXF", [("FileType", "MXF video master")]),
+        # Files with a different extension don't get tagged
+        ("digitised/b1234/v1/cats.mp4", []),
+        # MXF files in a different space don't get tagged
+        ("born-digital/CA/TS/v1/cats.MXF", []),
+    ],
+)
 def test_choose_tags(key, expected_tags):
     assert choose_tags(bucket="wellcomecollection-example", key=key) == expected_tags


### PR DESCRIPTION
This PR just implements a rule for deciding what tags should be applied to an object, in a way that should be fairly extensible if we decide to add more rules in future.

A first step towards https://github.com/wellcomecollection/platform/issues/4488