### PR TITLE
Simplify the storage providers we use

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -20,15 +20,18 @@ case object StorageProvider {
     "aws-s3-glacier" -> AmazonS3StorageProvider
   )
 
-  def allowedValues: Seq[String] =
+  def recognisedValues: Seq[String] =
     idLookup.keys.toSeq
+
+  def allowedValues: Seq[String] =
+    (idLookup ++ deprecatedIdLookup).keys.toSeq
 
   def apply(id: String): StorageProvider =
     (idLookup ++ deprecatedIdLookup).get(id) match {
       case Some(provider) => provider
       case None =>
         throw new IllegalArgumentException(
-          s"Unrecognised storage provider ID: $id; valid values are: ${allowedValues.mkString(", ")}"
+          s"Unrecognised storage provider ID: $id; valid values are: ${recognisedValues.mkString(", ")}"
         )
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -43,4 +43,3 @@ case object AmazonS3StorageProvider extends StorageProvider {
 case object AzureBlobStorageProvider extends StorageProvider {
   override val id: String = "azure-blob-storage"
 }
-

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -6,16 +6,25 @@ sealed trait StorageProvider {
 
 case object StorageProvider {
   private val idLookup = Map(
-    StandardStorageProvider.id -> StandardStorageProvider,
-    InfrequentAccessStorageProvider.id -> InfrequentAccessStorageProvider,
-    GlacierStorageProvider.id -> GlacierStorageProvider
+    AmazonS3StorageProvider.id -> AmazonS3StorageProvider,
+    AzureBlobStorageProvider.id -> AzureBlobStorageProvider
+  )
+
+  // This map includes the identifiers of storage providers that we have
+  // removed from the storage service.  We still need to be able to deserialise
+  // them for backwards-compatibility with clients, ingests and storage manifests,
+  // but we don't want to advertise their presence in, say, error messages.
+  private val deprecatedIdLookup = Map(
+    "aws-s3-standard" -> AmazonS3StorageProvider,
+    "aws-s3-ia" -> AmazonS3StorageProvider,
+    "aws-s3-glacier" -> AmazonS3StorageProvider
   )
 
   def allowedValues: Seq[String] =
     idLookup.keys.toSeq
 
   def apply(id: String): StorageProvider =
-    idLookup.get(id) match {
+    (idLookup ++ deprecatedIdLookup).get(id) match {
       case Some(provider) => provider
       case None =>
         throw new IllegalArgumentException(
@@ -24,14 +33,11 @@ case object StorageProvider {
     }
 }
 
-case object StandardStorageProvider extends StorageProvider {
-  override val id: String = "aws-s3-standard"
+case object AmazonS3StorageProvider extends StorageProvider {
+  override val id: String = "amazon-s3"
 }
 
-case object InfrequentAccessStorageProvider extends StorageProvider {
-  override val id: String = "aws-s3-ia"
+case object AzureBlobStorageProvider extends StorageProvider {
+  override val id: String = "azure-blob-storage"
 }
 
-case object GlacierStorageProvider extends StorageProvider {
-  override val id: String = "aws-s3-glacier"
-}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -30,7 +30,7 @@ class SourceLocationPayloadTest
       id = ingestId,
       ingestType = ingestType,
       sourceLocation = SourceLocation(
-        provider = StandardStorageProvider,
+        provider = AmazonS3StorageProvider,
         location = sourceLocation
       ),
       space = space,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -18,7 +18,7 @@ trait IngestGenerators extends BagIdGenerators with ObjectLocationGenerators {
 
   def createSourceLocation: SourceLocation =
     SourceLocation(
-      provider = StandardStorageProvider,
+      provider = AmazonS3StorageProvider,
       location = createObjectLocation
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -66,14 +66,14 @@ trait PayloadGenerators
 
   def createKnownReplicas = KnownReplicas(
     location = PrimaryStorageLocation(
-      provider = InfrequentAccessStorageProvider,
+      provider = AmazonS3StorageProvider,
       prefix = createObjectLocationPrefix
     ),
     replicas = (1 to randomInt(from = 0, to = 5))
       .map(
         _ =>
           SecondaryStorageLocation(
-            provider = InfrequentAccessStorageProvider,
+            provider = AmazonS3StorageProvider,
             prefix = createObjectLocationPrefix
           )
       )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
@@ -1,12 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  GlacierStorageProvider,
-  InfrequentAccessStorageProvider,
-  StandardStorageProvider,
-  StorageProvider
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   PrimaryStorageLocation,
   SecondaryStorageLocation
@@ -18,12 +13,8 @@ trait StorageLocationGenerators
     extends ObjectLocationGenerators
     with StorageRandomThings {
   def createProvider: StorageProvider =
-    chooseFrom(
-      Seq(
-        StandardStorageProvider,
-        InfrequentAccessStorageProvider,
-        GlacierStorageProvider
-      )
+    StorageProvider(
+      id = chooseFrom(StorageProvider.allowedValues)
     )
 
   def createPrimaryLocation: PrimaryStorageLocation =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -3,20 +3,16 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  IngestID,
-  StandardStorageProvider
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 import scala.util.Random
 
 trait StorageManifestGenerators
     extends BagInfoGenerators
     with StorageSpaceGenerators
-    with ObjectLocationGenerators {
+    with StorageLocationGenerators {
 
   val checksumAlgorithm: HashingAlgorithm = SHA256
 
@@ -55,17 +51,9 @@ trait StorageManifestGenerators
           createStorageManifestFile
         )
       ),
-      location = PrimaryStorageLocation(
-        provider = StandardStorageProvider,
-        prefix = createObjectLocationPrefix
-      ),
+      location = createPrimaryLocation,
       replicaLocations = (1 to randomInt(0, 5))
-        .map { _ =>
-          SecondaryStorageLocation(
-            provider = StandardStorageProvider,
-            prefix = createObjectLocationPrefix
-          )
-        },
+        .map { _ => createSecondaryLocation },
       createdDate = createdDate,
       ingestId = ingestId
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -53,7 +53,9 @@ trait StorageManifestGenerators
       ),
       location = createPrimaryLocation,
       replicaLocations = (1 to randomInt(0, 5))
-        .map { _ => createSecondaryLocation },
+        .map { _ =>
+          createSecondaryLocation
+        },
       createdDate = createdDate,
       ingestId = ingestId
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
@@ -10,9 +10,11 @@ class StorageProviderTest
     with TableDrivenPropertyChecks {
   val providerPairs = Table(
     ("id", "provider"),
-    ("aws-s3-standard", StandardStorageProvider),
-    ("aws-s3-ia", InfrequentAccessStorageProvider),
-    ("aws-s3-glacier", GlacierStorageProvider)
+    ("aws-s3-standard", AmazonS3StorageProvider),
+    ("aws-s3-ia", AmazonS3StorageProvider),
+    ("aws-s3-glacier", AmazonS3StorageProvider),
+    ("amazon-s3", AmazonS3StorageProvider),
+    ("azure-blob-storage", AzureBlobStorageProvider),
   )
 
   it("creates the correct storage provider from an ID") {
@@ -29,7 +31,7 @@ class StorageProviderTest
 
     thrown.getMessage shouldBe (
       "Unrecognised storage provider ID: not-a-storage-provider; " +
-        "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier"
+        "valid values are: amazon-s3, azure-blob-storage"
     )
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProviderTest.scala
@@ -14,7 +14,7 @@ class StorageProviderTest
     ("aws-s3-ia", AmazonS3StorageProvider),
     ("aws-s3-glacier", AmazonS3StorageProvider),
     ("amazon-s3", AmazonS3StorageProvider),
-    ("azure-blob-storage", AzureBlobStorageProvider),
+    ("azure-blob-storage", AzureBlobStorageProvider)
   )
 
   it("creates the correct storage provider from an ID") {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
@@ -15,13 +15,19 @@ class DisplayProviderTest
 
   val providerPairs = Table(
     ("display", "internal"),
-    (DisplayProvider("aws-s3-standard"), StandardStorageProvider),
-    (DisplayProvider("aws-s3-ia"), InfrequentAccessStorageProvider),
-    (DisplayProvider("aws-s3-glacier"), GlacierStorageProvider)
+    (DisplayProvider("amazon-s3"), AmazonS3StorageProvider),
+    (DisplayProvider("azure-blob-storage"), AzureBlobStorageProvider),
+  )
+
+  val deprecatedProviderPairs = Table(
+    ("display", "internal"),
+    (DisplayProvider("aws-s3-standard"), AmazonS3StorageProvider),
+    (DisplayProvider("aws-s3-ia"), AmazonS3StorageProvider),
+    (DisplayProvider("aws-s3-glacier"), AmazonS3StorageProvider),
   )
 
   it("turns a DisplayProvider into a StorageProvider") {
-    forAll(providerPairs) {
+    forAll(providerPairs ++ deprecatedProviderPairs) {
       case (
           displayProvider: DisplayProvider,
           storageProvider: StorageProvider
@@ -49,25 +55,21 @@ class DisplayProviderTest
 
     thrown.getMessage shouldBe (
       "Unrecognised storage provider ID: not-a-storage-provider; " +
-        "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier"
+        "valid values are: amazon-s3, azure-blob-storage"
     )
   }
 
   describe("JSON encoding/decoding") {
     val jsonPairs = Table(
-      ("provider", "json"),
+      ("provider", "jsonString"),
       (
-        DisplayProvider("aws-s3-standard"),
-        """{"id": "aws-s3-standard", "type": "Provider"}"""
+        DisplayProvider(AmazonS3StorageProvider),
+        """{"id": "amazon-s3", "type": "Provider"}""",
       ),
       (
-        DisplayProvider("aws-s3-ia"),
-        """{"id": "aws-s3-ia", "type": "Provider"}"""
+        DisplayProvider(AzureBlobStorageProvider),
+        """{"id": "azure-blob-storage", "type": "Provider"}""",
       ),
-      (
-        DisplayProvider("aws-s3-glacier"),
-        """{"id": "aws-s3-glacier", "type": "Provider"}"""
-      )
     )
 
     it("decodes correctly") {
@@ -84,6 +86,19 @@ class DisplayProviderTest
             toJson[DisplayProvider](displayProvider).get,
             jsonString
           )
+      }
+    }
+
+    val deprecatedJsonIds = Table(
+      "json",
+      """{"id": "aws-s3-standard", "type": "Provider"}""",
+      """{"id": "aws-s3-ia", "type": "Provider"}""",
+      """{"id": "aws-s3-glacier", "type": "Provider"}""",
+    )
+
+    it("decodes deprecated storage IDs") {
+      forAll(deprecatedJsonIds) { jsonString =>
+        fromJson[DisplayProvider](jsonString).get.toStorageProvider shouldBe AmazonS3StorageProvider
       }
     }
   }

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayProviderTest.scala
@@ -16,14 +16,14 @@ class DisplayProviderTest
   val providerPairs = Table(
     ("display", "internal"),
     (DisplayProvider("amazon-s3"), AmazonS3StorageProvider),
-    (DisplayProvider("azure-blob-storage"), AzureBlobStorageProvider),
+    (DisplayProvider("azure-blob-storage"), AzureBlobStorageProvider)
   )
 
   val deprecatedProviderPairs = Table(
     ("display", "internal"),
     (DisplayProvider("aws-s3-standard"), AmazonS3StorageProvider),
     (DisplayProvider("aws-s3-ia"), AmazonS3StorageProvider),
-    (DisplayProvider("aws-s3-glacier"), AmazonS3StorageProvider),
+    (DisplayProvider("aws-s3-glacier"), AmazonS3StorageProvider)
   )
 
   it("turns a DisplayProvider into a StorageProvider") {
@@ -64,12 +64,12 @@ class DisplayProviderTest
       ("provider", "jsonString"),
       (
         DisplayProvider(AmazonS3StorageProvider),
-        """{"id": "amazon-s3", "type": "Provider"}""",
+        """{"id": "amazon-s3", "type": "Provider"}"""
       ),
       (
         DisplayProvider(AzureBlobStorageProvider),
-        """{"id": "azure-blob-storage", "type": "Provider"}""",
-      ),
+        """{"id": "azure-blob-storage", "type": "Provider"}"""
+      )
     )
 
     it("decodes correctly") {
@@ -93,7 +93,7 @@ class DisplayProviderTest
       "json",
       """{"id": "aws-s3-standard", "type": "Provider"}""",
       """{"id": "aws-s3-ia", "type": "Provider"}""",
-      """{"id": "aws-s3-glacier", "type": "Provider"}""",
+      """{"id": "aws-s3-glacier", "type": "Provider"}"""
     )
 
     it("decodes deprecated storage IDs") {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -41,7 +41,7 @@ class DisplayIngestTest
         id = id,
         ingestType = CreateIngestType,
         sourceLocation = SourceLocation(
-          provider = StandardStorageProvider,
+          provider = AmazonS3StorageProvider,
           location = ObjectLocation("bukkit", "key.txt")
         ),
         space = StorageSpace(spaceId),
@@ -56,7 +56,7 @@ class DisplayIngestTest
 
       displayIngest.id shouldBe id.underlying
       displayIngest.sourceLocation shouldBe DisplayLocation(
-        DisplayProvider(id = "aws-s3-standard"),
+        DisplayProvider(id = "amazon-s3"),
         bucket = "bukkit",
         path = "key.txt"
       )
@@ -116,7 +116,7 @@ class DisplayIngestTest
 
   describe("RequestDisplayIngest") {
     it("transforms itself into a ingest") {
-      val displayProvider = DisplayProvider(id = "aws-s3-ia")
+      val displayProvider = DisplayProvider(id = "amazon-s3")
       val bucket = "ingest-bucket"
       val path = "bag.zip"
 
@@ -143,7 +143,7 @@ class DisplayIngestTest
 
       ingest.id shouldBe a[IngestID]
       ingest.sourceLocation shouldBe SourceLocation(
-        provider = InfrequentAccessStorageProvider,
+        provider = AmazonS3StorageProvider,
         location = ObjectLocation(bucket, path)
       )
       ingest.callback shouldBe Some(

--- a/ingests/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
+++ b/ingests/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
@@ -49,7 +49,7 @@ trait CreateIngest[UnpackerDestination] extends ResponseBase with Logging {
       )
     } else if (!StorageProvider.allowedValues.contains(providerId)) {
       createBadRequestResponse(
-        s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.allowedValues
+        s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.recognisedValues
           .mkString(", ")}."""
       )
     } else {

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -74,41 +74,41 @@ class CreateIngestApiTest
               Unmarshal(response.entity).to[ResponseDisplayIngest]
             }
 
-          whenReady(ingestFuture) { actualIngest =>
-            actualIngest.context shouldBe contextUrlTest
-            actualIngest.id shouldBe id
-            actualIngest.sourceLocation shouldBe DisplayLocation(
-              provider = DisplayProvider(id = "aws-s3-standard"),
+          whenReady(ingestFuture) { retrievedIngest =>
+            retrievedIngest.context shouldBe contextUrlTest
+            retrievedIngest.id shouldBe id
+            retrievedIngest.sourceLocation shouldBe DisplayLocation(
+              provider = DisplayProvider(id = "amazon-s3"),
               bucket = bucketName,
               path = s3key
             )
 
-            actualIngest.callback.isDefined shouldBe true
-            actualIngest.callback.get.url shouldBe testCallbackUri.toString
-            actualIngest.callback.get.status.get shouldBe DisplayStatus(
+            retrievedIngest.callback.isDefined shouldBe true
+            retrievedIngest.callback.get.url shouldBe testCallbackUri.toString
+            retrievedIngest.callback.get.status.get shouldBe DisplayStatus(
               "processing"
             )
 
-            actualIngest.ingestType shouldBe CreateDisplayIngestType
+            retrievedIngest.ingestType shouldBe CreateDisplayIngestType
 
-            actualIngest.status shouldBe DisplayStatus("accepted")
+            retrievedIngest.status shouldBe DisplayStatus("accepted")
 
-            actualIngest.space shouldBe DisplayStorageSpace(spaceName)
+            retrievedIngest.space shouldBe DisplayStorageSpace(spaceName)
 
-            actualIngest.bag.info.externalIdentifier shouldBe externalIdentifier
+            retrievedIngest.bag.info.externalIdentifier shouldBe externalIdentifier
 
             val expectedIngest = Ingest(
               id = IngestID(id),
               ingestType = CreateIngestType,
               sourceLocation = SourceLocation(
-                provider = StandardStorageProvider,
+                provider = AmazonS3StorageProvider,
                 location = ObjectLocation(bucketName, s3key)
               ),
               space = StorageSpace(spaceName),
               callback = Some(Callback(testCallbackUri, Callback.Pending)),
               status = Ingest.Accepted,
               externalIdentifier = externalIdentifier,
-              createdDate = Instant.parse(actualIngest.createdDate),
+              createdDate = Instant.parse(retrievedIngest.createdDate),
               events = Nil
             )
 
@@ -374,7 +374,7 @@ class CreateIngestApiTest
           badJson(json).noSpaces,
           expectedMessage =
             "Unrecognised value at .sourceLocation.provider.id: got \"not-a-storage-provider\", " +
-              "valid values are: aws-s3-standard, aws-s3-ia, aws-s3-glacier."
+              "valid values are: amazon-s3, azure-blob-storage."
         )
       }
 

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
@@ -71,7 +71,7 @@ class LookupIngestApiTest
                  |    "type": "Location",
                  |    "provider": {
                  |      "type": "Provider",
-                 |      "id": "aws-s3-standard"
+                 |      "id": "amazon-s3"
                  |    },
                  |    "bucket": "${ingest.sourceLocation.location.namespace}",
                  |    "path": "${ingest.sourceLocation.location.path}"

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -88,7 +88,7 @@ class NotifierFeatureTest
                  |    "type": "Location",
                  |    "provider": {
                  |      "type": "Provider",
-                 |      "id": "aws-s3-standard"
+                 |      "id": "amazon-s3"
                  |    },
                  |    "bucket": "${ingest.sourceLocation.location.namespace}",
                  |    "path": "${ingest.sourceLocation.location.path}"
@@ -199,7 +199,7 @@ class NotifierFeatureTest
                    |    "type": "Location",
                    |    "provider": {
                    |      "type": "Provider",
-                   |      "id": "aws-s3-standard"
+                   |      "id": "amazon-s3"
                    |    },
                    |    "bucket": "${ingest.sourceLocation.location.namespace}",
                    |    "path": "${ingest.sourceLocation.location.path}"

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -120,7 +120,7 @@ class CallbackUrlServiceTest
              |    "type": "Location",
              |    "provider": {
              |      "type": "Provider",
-             |      "id": "aws-s3-standard"
+             |      "id": "amazon-s3"
              |    },
              |    "bucket": "${ingest.sourceLocation.location.namespace}",
              |    "path": "${ingest.sourceLocation.location.path}"

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -8,9 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
   ReplicaResult,
   StorageLocation
 }
@@ -28,10 +26,7 @@ class ReplicaAggregatorTest
     with StorageRandomThings {
 
   def createReplicaResultWith(
-    storageLocation: StorageLocation = PrimaryStorageLocation(
-      provider = InfrequentAccessStorageProvider,
-      prefix = createObjectLocationPrefix
-    )
+    storageLocation: StorageLocation = createPrimaryLocation
   ): ReplicaResult =
     ReplicaResult(
       storageLocation = storageLocation,

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -323,7 +323,7 @@ module "replicator_verifier_primary" {
 
   replica_id           = "primary"
   replica_display_name = "primary location"
-  storage_provider     = "aws-s3-ia"
+  storage_provider     = "amazon-s3"
   replica_type         = "primary"
 
   topic_arns = [
@@ -371,7 +371,7 @@ module "replicator_verifier_glacier" {
 
   replica_id           = "glacier"
   replica_display_name = "Amazon Glacier"
-  storage_provider     = "aws-s3-glacier"
+  storage_provider     = "amazon-s3"
   replica_type         = "secondary"
 
   topic_arns = [


### PR DESCRIPTION
This replaces the existing three storage providers (`aws-s3-standard`, `aws-s3-ia` and `aws-s3-glacier`) with two new ones (`amazon-s3` and `azure-blob-storage`).

The old storage providers continue to be accepted – e.g. if Goobi sends an ingest with `"provider": "aws-s3-standard"`, it gets handled correctly, with no change needed – but it simplifies what the storage service emits.

In particular, we'll no longer make claims about the S3 storage class of replicas that may or may not be true (for example, saying a bag is Standard IA when in fact some of the objects are Standard or Glacier). It's a precursor for the MXF work and the third replica.

Closes https://github.com/wellcomecollection/platform/issues/4466