### PR TITLE
Add a getLatest() bag method to the bag tracker

### DIFF
--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -8,9 +8,20 @@ import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bag_tracker.services.{GetBag, GetLatestBag, LookupBagVersions}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.bag_tracker.services.{
+  GetBag,
+  GetLatestBag,
+  LookupBagVersions
+}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  StorageManifest,
+  StorageSpace
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -83,8 +94,9 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
               )
 
               parameter('version.as[Int] ?) {
-                case None          => getLatestBag(bagId = bagId)
-                case Some(version) => getBag(bagId = bagId, version = BagVersion(version))
+                case None => getLatestBag(bagId = bagId)
+                case Some(version) =>
+                  getBag(bagId = bagId, version = BagVersion(version))
               }
           }
         }

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -62,7 +62,9 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
         .withQuery(Query(("version", version.underlying.toString)))
     )
 
-  private def getManifest(requestUri: Uri): Future[Either[BagTrackerGetError, StorageManifest]] = {
+  private def getManifest(
+    requestUri: Uri
+  ): Future[Either[BagTrackerGetError, StorageManifest]] = {
     val request = HttpRequest(uri = requestUri, method = HttpMethods.GET)
     info(s"Making request: $request")
 

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -46,7 +46,7 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
 
   override def getLatestBag(
     bagId: BagId
-  ): Future[Either[BagTrackerError, StorageManifest]] =
+  ): Future[Either[BagTrackerGetError, StorageManifest]] =
     getManifest(
       trackerHost
         .withPath(Path(s"/bags/$bagId"))

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -47,18 +47,23 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
   override def getLatestBag(
     bagId: BagId
   ): Future[Either[BagTrackerError, StorageManifest]] =
-    Future.failed(new Throwable("BOOM!"))
+    getManifest(
+      trackerHost
+        .withPath(Path(s"/bags/$bagId"))
+    )
 
   override def getBag(
     bagId: BagId,
     version: BagVersion
-  ): Future[Either[BagTrackerGetError, StorageManifest]] = {
-    val requestUri = trackerHost
-      .withPath(Path(s"/bags/$bagId"))
-      .withQuery(Query(("version", version.underlying.toString)))
+  ): Future[Either[BagTrackerGetError, StorageManifest]] =
+    getManifest(
+      trackerHost
+        .withPath(Path(s"/bags/$bagId"))
+        .withQuery(Query(("version", version.underlying.toString)))
+    )
 
+  private def getManifest(requestUri: Uri): Future[Either[BagTrackerGetError, StorageManifest]] = {
     val request = HttpRequest(uri = requestUri, method = HttpMethods.GET)
-
     info(s"Making request: $request")
 
     for {

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.archive.bag_tracker.services
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.Route
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
+import uk.ac.wellcome.storage.NoMaximaValueError
+
+trait GetLatestBag extends Logging {
+  val storageManifestDao: StorageManifestDao
+
+  def getLatestBag(bagId: BagId): Route = {
+    storageManifestDao.getLatest(bagId) match {
+      case Right(manifest) =>
+        info(s"Found latest version of bag $bagId is ${manifest.version}")
+        complete(manifest)
+
+      case Left(_: NoMaximaValueError) =>
+        info(s"Could not find any versions of bag $bagId")
+        complete(StatusCodes.NotFound)
+
+      case Left(err) =>
+        warn(s"Unexpected error looking for latest version of bag $bagId: $err")
+        complete(StatusCodes.InternalServerError)
+    }
+  }
+}

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
@@ -8,7 +8,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.storage.NoMaximaValueError
+import uk.ac.wellcome.storage.NoVersionExistsError
 
 trait GetLatestBag extends Logging {
   val storageManifestDao: StorageManifestDao
@@ -19,7 +19,7 @@ trait GetLatestBag extends Logging {
         info(s"Found latest version of bag $bagId is ${manifest.version}")
         complete(manifest)
 
-      case Left(_: NoMaximaValueError) =>
+      case Left(_: NoVersionExistsError) =>
         info(s"Could not find any versions of bag $bagId")
         complete(StatusCodes.NotFound)
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
@@ -64,4 +64,5 @@ trait BagTrackerClientTestBase extends Matchers with Akka {
 
 trait BagTrackerClientTestCases
     extends GetBagTestCases
+    with GetLatestBagTestCases
     with ListVersionsTestCases

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -3,7 +3,14 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, StorageManifestGenerators}
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+import uk.ac.wellcome.platform.archive.common.storage.services.EmptyMetadata
+import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
+import uk.ac.wellcome.storage.{ReadError, StoreReadError}
+import uk.ac.wellcome.storage.store.HybridStoreEntry
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 trait GetLatestBagTestCases extends AnyFunSpec
   with EitherValues
@@ -14,15 +21,62 @@ trait GetLatestBagTestCases extends AnyFunSpec
 
   describe("getLatestBag()") {
     it("finds the latest version of a bag") {
-      true shouldBe false
+      val space = createStorageSpace
+      val externalIdentifier = createExternalIdentifier
+
+      val manifests = (1 to 5).map { version =>
+        createStorageManifestWith(
+          space = space,
+          bagInfo = createBagInfoWith(externalIdentifier = externalIdentifier),
+          version = BagVersion(version)
+        )
+      }
+
+      val bagId = BagId(space = space, externalIdentifier = externalIdentifier)
+
+      withApi(initialManifests = manifests) { _ =>
+        withClient(trackerHost) { client =>
+          val future = client.getLatestBag(bagId = bagId)
+
+          whenReady(future) {
+            _.right.value shouldBe manifests.last
+          }
+        }
+      }
     }
 
     it("returns a Left[BagTrackerNotFoundError] if the bag does not exist") {
-      true shouldBe false
+      withApi() { _ =>
+        withClient(trackerHost) { client =>
+          val future = client.getLatestBag(bagId = createBagId)
+
+          whenReady(future) {
+            _.left.value shouldBe BagTrackerNotFoundError()
+          }
+        }
+      }
     }
 
     it("returns a Left[BagTrackerUnknownGetError] if the API has an unexpected error") {
-      true shouldBe false
+      val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[
+        StorageManifest,
+        EmptyMetadata
+        ]](initialEntries = Map.empty)
+
+      val brokenDao = new MemoryStorageManifestDao(versionedStore) {
+        override def getLatest(id: BagId): Either[ReadError, StorageManifest] =
+          Left(StoreReadError(new Throwable("BOOM!")))
+      }
+
+      withApi(brokenDao) { _ =>
+        withClient(trackerHost) { client =>
+          val future = client.getLatestBag(bagId = createBagId)
+
+          whenReady(future) {
+            _.left.value shouldBe a[BagTrackerUnknownGetError]
+          }
+        }
+      }
     }
 
     it("fails if the tracker API is unavailable") {

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.platform.archive.bag_tracker.client
+
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, StorageManifestGenerators}
+
+trait GetLatestBagTestCases extends AnyFunSpec
+  with EitherValues
+  with ScalaFutures
+  with BagIdGenerators
+  with BagTrackerClientTestBase
+  with StorageManifestGenerators {
+
+  describe("getLatestBag()") {
+    it("finds the latest version of a bag") {
+      true shouldBe false
+    }
+
+    it("returns a Left[BagTrackerNotFoundError] if the bag does not exist") {
+      true shouldBe false
+    }
+
+    it("returns a Left[BagTrackerUnknownGetError] if the API has an unexpected error") {
+      true shouldBe false
+    }
+
+    it("fails if the tracker API is unavailable") {
+      withApi() { _ =>
+        withClient("http://localhost.nope:8080") { client =>
+          val future = client.getLatestBag(bagId = createBagId)
+
+          whenReady(future.failed) {
+            _ shouldBe a[Throwable]
+          }
+        }
+      }
+    }
+  }
+}

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -4,7 +4,10 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
-import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, StorageManifestGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagIdGenerators,
+  StorageManifestGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.EmptyMetadata
 import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
@@ -12,12 +15,13 @@ import uk.ac.wellcome.storage.{ReadError, StoreReadError}
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
-trait GetLatestBagTestCases extends AnyFunSpec
-  with EitherValues
-  with ScalaFutures
-  with BagIdGenerators
-  with BagTrackerClientTestBase
-  with StorageManifestGenerators {
+trait GetLatestBagTestCases
+    extends AnyFunSpec
+    with EitherValues
+    with ScalaFutures
+    with BagIdGenerators
+    with BagTrackerClientTestBase
+    with StorageManifestGenerators {
 
   describe("getLatestBag()") {
     it("finds the latest version of a bag") {
@@ -57,11 +61,13 @@ trait GetLatestBagTestCases extends AnyFunSpec
       }
     }
 
-    it("returns a Left[BagTrackerUnknownGetError] if the API has an unexpected error") {
+    it(
+      "returns a Left[BagTrackerUnknownGetError] if the API has an unexpected error"
+    ) {
       val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[
         StorageManifest,
         EmptyMetadata
-        ]](initialEntries = Map.empty)
+      ]](initialEntries = Map.empty)
 
       val brokenDao = new MemoryStorageManifestDao(versionedStore) {
         override def getLatest(id: BagId): Either[ReadError, StorageManifest] =


### PR DESCRIPTION
Now people who aren't picky about the version can look up a bag.

For https://github.com/wellcomecollection/platform/issues/4534