### PR TITLE
Plumb in the createBag() method to the bag tracker

### DIFF
--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -60,7 +60,6 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
             createBag(storageManifest)
           }
         },
-
         // We look for /versions at the end of the path: this means we should
         // return a list of versions, not the complete manifest.
         //

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -2,13 +2,13 @@ package uk.ac.wellcome.platform.archive.bag_tracker
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.bag_tracker.services.{
+  CreateBag,
   GetBag,
   GetLatestBag,
   LookupBagVersions
@@ -35,6 +35,7 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
   actorSystem: ActorSystem
 ) extends Runnable
     with Logging
+    with CreateBag
     with GetBag
     with GetLatestBag
     with LookupBagVersions {
@@ -53,13 +54,13 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
   val route: Route =
     pathPrefix("bags") {
       concat(
+        // Store a new bag in the storage manifest dao.
         post {
-          entity(as[StorageManifest]) { manifest =>
-            println(manifest)
-            println("create the manifest!")
-            complete(StatusCodes.Created)
+          entity(as[StorageManifest]) { storageManifest =>
+            createBag(storageManifest)
           }
         },
+
         // We look for /versions at the end of the path: this means we should
         // return a list of versions, not the complete manifest.
         //

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -59,12 +59,17 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
 
       result <- response.status match {
         case StatusCodes.Created =>
-          info(s"CREATED for POST to $requestUri with ${storageManifest.idWithVersion}")
+          info(
+            s"CREATED for POST to $requestUri with ${storageManifest.idWithVersion}"
+          )
           Future(Right(()))
 
         case status =>
           val err = new Exception(s"$status for POST to IngestsTracker")
-          error(f"Unexpected status for POST to $requestUri with ${storageManifest.idWithVersion}", err)
+          error(
+            f"Unexpected status for POST to $requestUri with ${storageManifest.idWithVersion}",
+            err
+          )
           Future(Left(BagTrackerCreateError(err)))
       }
     } yield result

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes, Uri}
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
@@ -41,8 +42,32 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
 
   override def createBag(
     storageManifest: StorageManifest
-  ): Future[Either[BagTrackerError, Unit]] =
-    Future.failed(new Throwable("BOOM!"))
+  ): Future[Either[BagTrackerCreateError, Unit]] =
+    for {
+      manifestEntity <- Marshal(storageManifest).to[RequestEntity]
+
+      requestUri = trackerHost.withPath(Path("/bags"))
+
+      request = HttpRequest(
+        uri = requestUri,
+        method = HttpMethods.POST,
+        entity = manifestEntity
+      )
+
+      _ = info(s"Making request: $request")
+      response <- Http().singleRequest(request)
+
+      result <- response.status match {
+        case StatusCodes.Created =>
+          info(s"CREATED for POST to $requestUri with ${storageManifest.idWithVersion}")
+          Future(Right(()))
+
+        case status =>
+          val err = new Exception(s"$status for POST to IngestsTracker")
+          error(f"Unexpected status for POST to $requestUri with ${storageManifest.idWithVersion}", err)
+          Future(Left(BagTrackerCreateError(err)))
+      }
+    } yield result
 
   override def getLatestBag(
     bagId: BagId

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerError.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerError.scala
@@ -4,6 +4,8 @@ sealed trait BagTrackerError
 
 sealed trait BagTrackerGetError extends BagTrackerError
 
+case class BagTrackerCreateError(err: Throwable) extends BagTrackerError
+
 case class BagTrackerUnknownGetError(err: Throwable) extends BagTrackerGetError
 
 sealed trait BagTrackerListVersionsError extends BagTrackerError

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.archive.bag_tracker.services
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.Route
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
+
+trait CreateBag extends Logging {
+  val storageManifestDao: StorageManifestDao
+
+  def createBag(storageManifest: StorageManifest): Route =
+    storageManifestDao.put(storageManifest) match {
+      case Right(_)           => complete(StatusCodes.Created)
+
+      case Left(storageError) =>
+        warn(s"Unexpected error storing bag ${storageManifest.idWithVersion}", storageError.e)
+        complete(StatusCodes.InternalServerError)
+    }
+}

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
@@ -12,10 +12,13 @@ trait CreateBag extends Logging {
 
   def createBag(storageManifest: StorageManifest): Route =
     storageManifestDao.put(storageManifest) match {
-      case Right(_)           => complete(StatusCodes.Created)
+      case Right(_) => complete(StatusCodes.Created)
 
       case Left(storageError) =>
-        warn(s"Unexpected error storing bag ${storageManifest.idWithVersion}", storageError.e)
+        warn(
+          s"Unexpected error storing bag ${storageManifest.idWithVersion}",
+          storageError.e
+        )
         complete(StatusCodes.InternalServerError)
     }
 }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
@@ -63,6 +63,7 @@ trait BagTrackerClientTestBase extends Matchers with Akka {
 }
 
 trait BagTrackerClientTestCases
-    extends GetBagTestCases
+    extends CreateBagTestCases
+    with GetBagTestCases
     with GetLatestBagTestCases
     with ListVersionsTestCases

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
@@ -1,0 +1,69 @@
+package uk.ac.wellcome.platform.archive.bag_tracker.client
+
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+import uk.ac.wellcome.platform.archive.common.storage.services.EmptyMetadata
+import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
+import uk.ac.wellcome.storage.store.HybridStoreEntry
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
+import uk.ac.wellcome.storage.{StoreWriteError, WriteError}
+
+trait CreateBagTestCases extends AnyFunSpec with EitherValues with ScalaFutures with StorageManifestGenerators with BagTrackerClientTestBase {
+  describe("createBag") {
+    it("stores a bag in the storage manifest dao") {
+      val manifest = createStorageManifest
+
+      withStorageManifestDao(initialManifests = Seq.empty) { dao =>
+        withApi(dao) { _ =>
+          withClient(trackerHost) { client =>
+            val future = client.createBag(manifest)
+
+            whenReady(future) { result =>
+              result shouldBe Right(())
+
+              dao.get(id = manifest.id, version = manifest.version).right.value shouldBe manifest
+            }
+          }
+        }
+      }
+    }
+
+    it("returns a Left[BagTrackerCreateError] if it cannot store the bag") {
+      val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[
+        StorageManifest,
+        EmptyMetadata
+        ]](initialEntries = Map.empty)
+
+      val brokenDao = new MemoryStorageManifestDao(versionedStore) {
+        override def put(storageManifest: StorageManifest): Either[WriteError, StorageManifest] =
+          Left(StoreWriteError(new Throwable("BOOM!")))
+      }
+
+      withApi(brokenDao) { _ =>
+        withClient(trackerHost) { client =>
+          val future = client.createBag(createStorageManifest)
+
+          whenReady(future) {
+            _.left.value shouldBe a[BagTrackerCreateError]
+          }
+        }
+      }
+    }
+
+    it("fails if the tracker API is unavailable") {
+      withApi() { _ =>
+        withClient("http://localhost.nope:8080") { client =>
+          val future = client.createBag(createStorageManifest)
+
+          whenReady(future.failed) {
+            _ shouldBe a[Throwable]
+          }
+        }
+      }
+    }
+  }
+}

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
@@ -12,7 +12,12 @@ import uk.ac.wellcome.storage.store.HybridStoreEntry
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.{StoreWriteError, WriteError}
 
-trait CreateBagTestCases extends AnyFunSpec with EitherValues with ScalaFutures with StorageManifestGenerators with BagTrackerClientTestBase {
+trait CreateBagTestCases
+    extends AnyFunSpec
+    with EitherValues
+    with ScalaFutures
+    with StorageManifestGenerators
+    with BagTrackerClientTestBase {
   describe("createBag") {
     it("stores a bag in the storage manifest dao") {
       val manifest = createStorageManifest
@@ -25,7 +30,10 @@ trait CreateBagTestCases extends AnyFunSpec with EitherValues with ScalaFutures 
             whenReady(future) { result =>
               result shouldBe Right(())
 
-              dao.get(id = manifest.id, version = manifest.version).right.value shouldBe manifest
+              dao
+                .get(id = manifest.id, version = manifest.version)
+                .right
+                .value shouldBe manifest
             }
           }
         }
@@ -36,10 +44,12 @@ trait CreateBagTestCases extends AnyFunSpec with EitherValues with ScalaFutures 
       val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[
         StorageManifest,
         EmptyMetadata
-        ]](initialEntries = Map.empty)
+      ]](initialEntries = Map.empty)
 
       val brokenDao = new MemoryStorageManifestDao(versionedStore) {
-        override def put(storageManifest: StorageManifest): Either[WriteError, StorageManifest] =
+        override def put(
+          storageManifest: StorageManifest
+        ): Either[WriteError, StorageManifest] =
           Left(StoreWriteError(new Throwable("BOOM!")))
       }
 


### PR DESCRIPTION
So somebody can read bags from the database, but how do they get there? With the createBag() method!

This rounds out the set of methods that the bag tracker needs – next up is plumbing it through into other services.

For wellcomecollection/platform#4534