### PR TITLE
Correct permissions for api/indexer

### DIFF
--- a/indexer/reindex_bags_backlog.py
+++ b/indexer/reindex_bags_backlog.py
@@ -210,6 +210,7 @@ def confirm_indexed(elastic_client, published_bags, index):
 
     return flat_list
 
+
 def create_elastic_client(role_arn, es_secrets):
     secretsmanager_client = create_client("secretsmanager", role_arn)
 

--- a/indexer/reindex_bags_backlog.py
+++ b/indexer/reindex_bags_backlog.py
@@ -210,7 +210,6 @@ def confirm_indexed(elastic_client, published_bags, index):
 
     return flat_list
 
-
 def create_elastic_client(role_arn, es_secrets):
     secretsmanager_client = create_client("secretsmanager", role_arn)
 

--- a/terraform/modules/stack/iam_role_policy.tf
+++ b/terraform/modules/stack/iam_role_policy.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role_policy" "bag_register_metrics" {
 
 resource "aws_iam_role_policy" "bags_api_vhs_manifests_readonly" {
   role   = module.bags_api.task_role_name
-  policy = var.vhs_manifests_readonly_policy
+  policy = var.vhs_manifests_readwrite_policy
 }
 
 resource "aws_iam_role_policy" "bags_api_metrics" {

--- a/terraform/modules/stack/iam_role_policy.tf
+++ b/terraform/modules/stack/iam_role_policy.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role_policy" "bag_register_metrics" {
 
 resource "aws_iam_role_policy" "bags_api_vhs_manifests_readonly" {
   role   = module.bags_api.task_role_name
-  policy = var.vhs_manifests_readwrite_policy
+  policy = var.vhs_manifests_readonly_policy
 }
 
 resource "aws_iam_role_policy" "bags_api_metrics" {
@@ -29,9 +29,9 @@ resource "aws_iam_role_policy" "s3_large_response_cache" {
 
 # bag_indexer
 
-resource "aws_iam_role_policy" "bag_indexer_vhs_manifests_readwrite" {
+resource "aws_iam_role_policy" "bag_indexer_vhs_manifests_readonly" {
   role   = module.bag_indexer.task_role_name
-  policy = var.vhs_manifests_readwrite_policy
+  policy = var.vhs_manifests_readonly_policy
 }
 
 resource "aws_iam_role_policy" "bag_indexer_metrics" {


### PR DESCRIPTION
The ~api &~ indexer does not require write access to the VHS.