### PR TITLE
The object tagger adds new tags, rather than replacing old ones

### DIFF
--- a/s3_object_tagger/src/tag_chooser.py
+++ b/s3_object_tagger/src/tag_chooser.py
@@ -8,7 +8,7 @@ def choose_tags(*, bucket, key):
     """
     storage_space, *_ = key.split("/")
 
-    tags = []
+    tags = {}
 
     # Add a tag to MXF files in the "digitised" space.
     #
@@ -20,6 +20,6 @@ def choose_tags(*, bucket, key):
     _, file_extension = os.path.splitext(key)
 
     if storage_space == "digitised" and file_extension.lower() == ".mxf":
-        tags.append(("Content-Type", "application/mxf"))
+        tags["Content-Type"] = "application/mxf"
 
     return tags

--- a/s3_object_tagger/src/test_s3_object_tagger.py
+++ b/s3_object_tagger/src/test_s3_object_tagger.py
@@ -4,7 +4,7 @@ import boto3
 from moto import mock_s3
 import pytest
 
-from s3_object_tagger import apply_tags
+from s3_object_tagger import add_tags
 
 
 def _get_s3_object(s3_client, *, bucket, key):
@@ -33,22 +33,42 @@ def s3_bucket(s3_client):
     return bucket_name
 
 
-def test_apply_tags_no_op(s3_bucket, s3_client):
+def test_add_tags_no_op(s3_bucket, s3_client):
     s3_client.put_object(Bucket=s3_bucket, Key="example.txt", Body=b"Hello world")
 
-    apply_tags(s3_client, bucket=s3_bucket, key="example.txt", tags=[])
+    add_tags(s3_client, bucket=s3_bucket, key="example.txt", tags={})
 
     body, tags = _get_s3_object(s3_client, bucket=s3_bucket, key="example.txt")
     assert body == b"Hello world"
     assert tags == []
 
 
-def test_can_apply_tags(s3_bucket, s3_client):
+def test_can_add_tags(s3_bucket, s3_client):
     s3_client.put_object(Bucket=s3_bucket, Key="example.txt", Body=b"Hello world")
 
-    tags_to_set = [("Content-Type", "text/plain"), ("Language", "English")]
-    apply_tags(s3_client, bucket=s3_bucket, key="example.txt", tags=tags_to_set)
+    tags_to_set = {"Content-Type": "text/plain", "Language": "English"}
+    add_tags(s3_client, bucket=s3_bucket, key="example.txt", tags=tags_to_set)
 
     body, tags = _get_s3_object(s3_client, bucket=s3_bucket, key="example.txt")
     assert body == b"Hello world"
-    assert tags == tags_to_set
+    assert tags == [("Content-Type", "text/plain"), ("Language", "English")]
+
+
+def test_does_not_replace_existing_tags(s3_bucket, s3_client):
+    s3_client.put_object(
+        Bucket=s3_bucket,
+        Key="example.txt",
+        Body=b"Hello world",
+        Tagging="Language=English",
+    )
+
+    add_tags(
+        s3_client,
+        bucket=s3_bucket,
+        key="example.txt",
+        tags={"Content-Type": "text/plain"},
+    )
+
+    body, tags = _get_s3_object(s3_client, bucket=s3_bucket, key="example.txt")
+    assert body == b"Hello world"
+    assert tags == [("Language", "English"), ("Content-Type", "text/plain")]

--- a/s3_object_tagger/src/test_tag_chooser.py
+++ b/s3_object_tagger/src/test_tag_chooser.py
@@ -7,13 +7,13 @@ from tag_chooser import choose_tags
     "key, expected_tags",
     [
         # MXF video masters get a tag
-        ("digitised/b1234/v1/cats.mxf", [("Content-Type", "application/mxf")]),
+        ("digitised/b1234/v1/cats.mxf", {"Content-Type": "application/mxf"}),
         # If the file extension is uppercase, it gets tagged
-        ("digitised/b1234/v1/cats.MXF", [("Content-Type", "application/mxf")]),
+        ("digitised/b1234/v1/cats.MXF", {"Content-Type": "application/mxf"}),
         # Files with a different extension don't get tagged
-        ("digitised/b1234/v1/cats.mp4", []),
+        ("digitised/b1234/v1/cats.mp4", {}),
         # MXF files in a different space don't get tagged
-        ("born-digital/CA/TS/v1/cats.MXF", []),
+        ("born-digital/CA/TS/v1/cats.MXF", {}),
     ],
 )
 def test_choose_tags(key, expected_tags):

--- a/terraform/modules/stack/lambda_s3_object_tagger.tf
+++ b/terraform/modules/stack/lambda_s3_object_tagger.tf
@@ -15,7 +15,13 @@ module "s3_object_tagger" {
 
 data "aws_iam_policy_document" "allow_put_object_tag" {
   statement {
+    # A PutObjectTag API call completely replaces the tags on an object,
+    # so the Lambda has to read the existing tags first, add the new tags,
+    # and Put the complete set back.
+    #
+    # Thus, it needs both Get- and PutObjectTagging.
     actions = [
+      "s3:GetObjectTagging",
       "s3:PutObjectTagging",
     ]
 


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/4562

* If the object already had tags, we append the Content-Type tag to the existing tags, rather than replacing them all
* If the object already has a Content-Type tag with a different value, throw an error rather than overwriting the existing value