### PR TITLE
Send a simpler payload from the bag register

### DIFF
--- a/bag_register/src/main/resources/application.conf
+++ b/bag_register/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 aws.sqs.queue.url=${?queue_url}
 aws.outgoing.sns.topic.arn=${?ongoing_topic_arn}
 aws.ingest.sns.topic.arn=${?ingest_topic_arn}
+aws.registration-notifications.sns.topic.arn=${?registrations_topic_arn}
 aws.metrics.namespace=${?metrics_namespace}
 bags.tracker.host=${?bags_tracker_host}
 operation.name=${?operation_name}

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.typesafe.{
   AlpakkaSqsWorkerConfigBuilder,
   CloudwatchMonitoringClientBuilder,
+  SNSBuilder,
   SQSBuilder
 }
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.cloudwatch.CloudwatchMetricsMonitoringClient
@@ -79,10 +80,17 @@ object Main extends WellcomeTypesafeApp {
       operationName
     )
 
+    val registrationNotifications = SNSBuilder.buildSNSMessageSender(
+      config,
+      namespace = "registration-notifications",
+      subject = "Sent by the bag register"
+    )
+
     new BagRegisterWorker(
       config = AlpakkaSqsWorkerConfigBuilder.build(config),
       ingestUpdater = ingestUpdater,
       outgoingPublisher = outgoingPublisher,
+      registrationNotifications = registrationNotifications,
       register = register,
       metricsNamespace = config.required[String]("aws.metrics.namespace")
     )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.bag_register.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -29,6 +32,6 @@ case class RegistrationSummary(
       ("location", location),
       ("space", space),
       ("externalIdentifier", externalIdentifier),
-      ("version", version),
+      ("version", version)
     )
 }

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.archive.bag_register.models
 
 import java.time.Instant
 
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -13,6 +14,8 @@ case class RegistrationSummary(
   ingestId: IngestID,
   location: PrimaryStorageLocation,
   space: StorageSpace,
+  externalIdentifier: ExternalIdentifier,
+  version: BagVersion,
   startTime: Instant,
   maybeEndTime: Option[Instant] = None
 ) extends Summary {
@@ -24,6 +27,8 @@ case class RegistrationSummary(
   override val fieldsToLog: Seq[(String, Any)] =
     Seq(
       ("location", location),
-      ("space", space)
+      ("space", space),
+      ("externalIdentifier", externalIdentifier),
+      ("version", version),
     )
 }

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.AlpakkaSQSWorkerConfig
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.MetricsMonitoringClient
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
-import uk.ac.wellcome.platform.archive.common.{BagRegistrationNotification, KnownReplicasPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRegistrationNotification,
+  KnownReplicasPayload
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -21,7 +24,11 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class BagRegisterWorker[IngestDestination, OutgoingDestination, NotificationDestination](
+class BagRegisterWorker[
+  IngestDestination,
+  OutgoingDestination,
+  NotificationDestination
+](
   val config: AlpakkaSQSWorkerConfig,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
@@ -78,7 +85,9 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination, NotificationDest
       }
     } yield registrationSummary
 
-  private def sendRegistrationNotification(result: IngestStepResult[RegistrationSummary]): Try[Unit] =
+  private def sendRegistrationNotification(
+    result: IngestStepResult[RegistrationSummary]
+  ): Try[Unit] =
     result match {
       case IngestCompleted(summary) =>
         registrationNotifications.sendT[BagRegistrationNotification](

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -3,25 +3,29 @@ package uk.ac.wellcome.platform.archive.bag_register.services
 import akka.actor.ActorSystem
 import io.circe.Decoder
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sqsworker.alpakka.AlpakkaSQSWorkerConfig
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.MetricsMonitoringClient
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
-import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
+import uk.ac.wellcome.platform.archive.common.{BagRegistrationNotification, KnownReplicasPayload}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestCompleted,
   IngestStepResult,
   IngestStepWorker
 }
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
-class BagRegisterWorker[IngestDestination, OutgoingDestination](
+class BagRegisterWorker[IngestDestination, OutgoingDestination, NotificationDestination](
   val config: AlpakkaSQSWorkerConfig,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
+  registrationNotifications: MessageSender[NotificationDestination],
   register: Register,
   val metricsNamespace: String
 )(
@@ -51,7 +55,8 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
         location = payload.knownReplicas.location,
         replicas = payload.knownReplicas.replicas,
         version = payload.version,
-        space = payload.storageSpace
+        space = payload.storageSpace,
+        externalIdentifier = payload.externalIdentifier
       )
 
       _ <- Future.fromTry {
@@ -67,7 +72,25 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
           outgoing = payload
         )
       }
+
+      _ <- Future.fromTry {
+        sendRegistrationNotification(registrationSummary)
+      }
     } yield registrationSummary
+
+  private def sendRegistrationNotification(result: IngestStepResult[RegistrationSummary]): Try[Unit] =
+    result match {
+      case IngestCompleted(summary) =>
+        registrationNotifications.sendT[BagRegistrationNotification](
+          BagRegistrationNotification(
+            space = summary.space,
+            externalIdentifier = summary.externalIdentifier,
+            version = summary.version
+          )
+        )
+
+      case _ => Success(())
+    }
 
   // The IngestStepWorker trait expects a processMessage() method, which returns
   // a Try[…].  That method then gets called to provide the process() method,

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -8,7 +8,10 @@ import uk.ac.wellcome.platform.archive.bag_tracker.client.{
   BagTrackerClient,
   BagTrackerCreateError
 }
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
@@ -32,14 +35,17 @@ class Register(
     location: PrimaryStorageLocation,
     replicas: Seq[SecondaryStorageLocation],
     version: BagVersion,
-    space: StorageSpace
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier
   ): Future[IngestStepResult[RegistrationSummary]] = {
 
     val registration = RegistrationSummary(
       ingestId = ingestId,
       startTime = Instant.now(),
       location = location,
-      space = space
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version
     )
 
     val result: Future[IngestStepResult[RegistrationSummary]] = for {

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -122,7 +122,8 @@ class BagRegisterWorkerTest
 
     val primaryLocation = createPrimaryLocationWith(prefix = bagRoot)
 
-    val knownReplicas = KnownReplicas(location = primaryLocation, replicas = List.empty)
+    val knownReplicas =
+      KnownReplicas(location = primaryLocation, replicas = List.empty)
 
     val payload = createKnownReplicasPayloadWith(
       context = createPipelineContextWith(
@@ -133,15 +134,17 @@ class BagRegisterWorkerTest
       knownReplicas = knownReplicas
     )
 
-    withBagRegisterWorker(registrationNotifications = registrationNotifications) { worker =>
-      val future = worker.processPayload(payload)
+    withBagRegisterWorker(registrationNotifications = registrationNotifications) {
+      worker =>
+        val future = worker.processPayload(payload)
 
-      whenReady(future) {
-        _ shouldBe a[IngestCompleted[_]]
-      }
+        whenReady(future) {
+          _ shouldBe a[IngestCompleted[_]]
+        }
     }
 
-    registrationNotifications.getMessages[BagRegistrationNotification]() shouldBe Seq(
+    registrationNotifications
+      .getMessages[BagRegistrationNotification]() shouldBe Seq(
       BagRegistrationNotification(
         space = space,
         externalIdentifier = bagInfo.externalIdentifier,

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -5,8 +5,10 @@ import java.time.Instant
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
+import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagInfoGenerators,
@@ -101,6 +103,50 @@ class BagRegisterWorkerTest
     assertBagRegisterSucceeded(
       ingestId = payload.ingestId,
       ingests = ingests
+    )
+  }
+
+  it("sends a notification of a registered bag") {
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    val space = createStorageSpace
+    val version = createBagVersion
+
+    val registrationNotifications = new MemoryMessageSender()
+
+    val (bagRoot, bagInfo) = createRegisterBagWith(
+      space = space,
+      version = version
+    )
+
+    val primaryLocation = createPrimaryLocationWith(prefix = bagRoot)
+
+    val knownReplicas = KnownReplicas(location = primaryLocation, replicas = List.empty)
+
+    val payload = createKnownReplicasPayloadWith(
+      context = createPipelineContextWith(
+        storageSpace = space,
+        externalIdentifier = bagInfo.externalIdentifier
+      ),
+      version = version,
+      knownReplicas = knownReplicas
+    )
+
+    withBagRegisterWorker(registrationNotifications = registrationNotifications) { worker =>
+      val future = worker.processPayload(payload)
+
+      whenReady(future) {
+        _ shouldBe a[IngestCompleted[_]]
+      }
+    }
+
+    registrationNotifications.getMessages[BagRegistrationNotification]() shouldBe Seq(
+      BagRegistrationNotification(
+        space = space,
+        externalIdentifier = bagInfo.externalIdentifier,
+        version = version
+      )
     )
   }
 
@@ -269,16 +315,19 @@ class BagRegisterWorkerTest
       MemoryStreamStore[ObjectLocation]()
 
     val ingests = new MemoryMessageSender()
+    val registrationNotifications = new MemoryMessageSender()
 
     // This registration will fail because when the register tries to read the
     // bag from the store, it won't find anything at the primary location
     // in this payload.
     val payload = createKnownReplicasPayload
 
-    val future =
-      withBagRegisterWorker(ingests = ingests) {
-        _.processPayload(payload)
-      }
+    val future = withBagRegisterWorker(
+      ingests = ingests,
+      registrationNotifications = registrationNotifications
+    ) {
+      _.processPayload(payload)
+    }
 
     whenReady(future) {
       _ shouldBe a[IngestFailed[_]]
@@ -288,5 +337,7 @@ class BagRegisterWorkerTest
       ingestId = payload.ingestId,
       ingests = ingests
     )
+
+    registrationNotifications.messages shouldBe empty
   }
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -83,7 +83,8 @@ class RegisterTest
         location = primaryLocation,
         replicas = replicas,
         version = version,
-        space = space
+        space = space,
+        externalIdentifier = bagInfo.externalIdentifier
       )
 
       whenReady(future) { result =>
@@ -141,7 +142,7 @@ class RegisterTest
 
     val storageManifestDao = createStorageManifestDao()
 
-    val (bagObjects, bagRoot, _) =
+    val (bagObjects, bagRoot, bagInfo) =
       withNamespace { implicit namespace =>
         BagBuilder.createBagContentsWith(
           version = version
@@ -178,7 +179,8 @@ class RegisterTest
         location = location,
         replicas = Seq.empty,
         version = version,
-        space = space
+        space = space,
+        externalIdentifier = bagInfo.externalIdentifier
       )
 
       whenReady(future) { result =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.common
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 /** This notification is sent by the storage service to notify another system
@@ -21,7 +24,11 @@ case class BagRegistrationNotification(
 )
 
 case object BagRegistrationNotification {
-  def apply(space: StorageSpace, externalIdentifier: ExternalIdentifier, version: BagVersion): BagRegistrationNotification =
+  def apply(
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    version: BagVersion
+  ): BagRegistrationNotification =
     BagRegistrationNotification(
       space = space,
       externalIdentifier = externalIdentifier,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.platform.archive.common
+
+import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+
+/** This notification is sent by the storage service to notify another system
+  * (which may be entirely separate from the storage service, e.g. the catalogue)
+  * that a bag has been registered.
+  *
+  */
+case class BagRegistrationNotification(
+  space: StorageSpace,
+  externalIdentifier: ExternalIdentifier,
+  version: BagVersion,
+  @JsonKey("type") ontologyType: String = "RegisteredBagNotification"
+)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/BagRegistrationNotification.scala
@@ -6,12 +6,25 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 /** This notification is sent by the storage service to notify another system
   * (which may be entirely separate from the storage service, e.g. the catalogue)
-  * that a bag has been registered.
+  * that a bag has been registered.  You should be able to use this information to
+  * get a bag from the external API.
+  *
+  * We encode a version as a string (v1, v2, v3) rather than a number because that's
+  * what the external API expects.
   *
   */
 case class BagRegistrationNotification(
   space: StorageSpace,
   externalIdentifier: ExternalIdentifier,
-  version: BagVersion,
+  version: String,
   @JsonKey("type") ontologyType: String = "RegisteredBagNotification"
 )
+
+case object BagRegistrationNotification {
+  def apply(space: StorageSpace, externalIdentifier: ExternalIdentifier, version: BagVersion): BagRegistrationNotification =
+    BagRegistrationNotification(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version.toString
+    )
+}

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -468,14 +468,15 @@ module "bag_register" {
   service_name = "${var.namespace}-bag_register"
 
   environment = {
-    queue_url         = module.bag_register_input_queue.url
-    archive_bucket    = var.replica_primary_bucket_name
-    ongoing_topic_arn = module.bag_register_output_topic.arn
-    ingest_topic_arn  = module.ingests_topic.arn
-    metrics_namespace = local.bag_register_service_name
-    operation_name    = "register"
-    bags_tracker_host = "http://${module.bags_api.name}.${var.namespace}:8080"
-    JAVA_OPTS         = local.java_opts_heap_size
+    queue_url               = module.bag_register_input_queue.url
+    archive_bucket          = var.replica_primary_bucket_name
+    ongoing_topic_arn       = module.bag_register_output_topic.arn
+    ingest_topic_arn        = module.ingests_topic.arn
+    registrations_topic_arn = module.registered_bag_notifications_topic.arn
+    metrics_namespace       = local.bag_register_service_name
+    operation_name          = "register"
+    bags_tracker_host       = "http://${module.bags_api.name}.${var.namespace}:8080"
+    JAVA_OPTS               = local.java_opts_heap_size
   }
 
   min_capacity = var.min_capacity

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -349,12 +349,23 @@ resource "aws_sns_topic_policy" "bag_register_output_topic_cross_account_subscri
   policy = data.aws_iam_policy_document.bag_register_output_cross_account_subscription.json
 }
 
-module "bag_reindexer_output_topic" {
+module "registered_bag_notifications_topic" {
   source = "../topic"
 
-  name = "${var.namespace}_bag_reindexer_output_topic"
+  name = "${var.namespace}_registered_bag_notifications"
 
-  role_names = []
+  role_names = [
+    module.bag_register.task_role_name,
+  ]
+}
+
+resource "aws_sns_topic_policy" "registered_bag_notifications_topic_cross_account_subscription" {
+  # We only need to create a policy that allows subscriptions to this topic
+  # if there are other accounts that need access.
+  count = length(var.bag_register_output_subscribe_principals) > 0 ? 1 : 0
+
+  arn    = module.registered_bag_notifications_topic.arn
+  policy = data.aws_iam_policy_document.bag_register_output_cross_account_subscription.json
 }
 
 module "bag_register_output_queue" {
@@ -363,7 +374,6 @@ module "bag_register_output_queue" {
   name = "${var.namespace}_bag_register_output"
 
   topic_arns = [
-    module.bag_reindexer_output_topic.arn,
     module.bag_register_output_topic.arn
   ]
 
@@ -373,3 +383,27 @@ module "bag_register_output_queue" {
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
+module "registered_bag_notifications_queue" {
+  source = "../queue"
+
+  name = "${var.namespace}_registered_bag_notifications"
+
+  topic_arns = [
+    module.registered_bag_notifications_topic.arn,
+  ]
+
+  role_names = []
+
+  aws_region    = var.aws_region
+  dlq_alarm_arn = var.dlq_alarm_arn
+}
+
+# bag reindexer
+
+module "bag_reindexer_output_topic" {
+  source = "../topic"
+
+  name = "${var.namespace}_bag_reindexer_output_topic"
+
+  role_names = []
+}


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4558

This modifies the bag register to send a smaller, simpler message to a new topic. The existing flows are unaffected.