### PR TITLE
Mapping tweaks for bag indexer

### DIFF
--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagsIndexConfig.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagsIndexConfig.scala
@@ -44,7 +44,7 @@ object BagsIndexConfig extends IndexConfig {
       objectField("info").fields(infoFields),
       objectField("location").fields(locationFields),
       objectField("replicaLocations").fields(locationFields),
-      objectField("files").fields(fileFields),
+      nestedField("files").fields(fileFields),
       intField("filesCount"),
       longField("filesTotalSize"),
       keywordField("type")

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/models/IndexedStorageManifest.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/models/IndexedStorageManifest.scala
@@ -66,7 +66,7 @@ case class IndexedLocation(
 object IndexedLocation {
   def apply(location: StorageLocation): IndexedLocation =
     IndexedLocation(
-      provider = location.provider.toString,
+      provider = location.provider.id,
       bucket = location.prefix.namespace,
       path = location.prefix.path
     )

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/services/FileSuffix.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/services/FileSuffix.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.indexer.bags.services
 
 object FileSuffix {
   def getSuffix(name: String): Option[String] = {
-    val splitName = name.split("\\.")
+    val splitName = name.split(".+\\.")
 
     if (splitName.length > 1) {
       Some(splitName.last.toLowerCase)

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/services/FileSuffixTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/services/FileSuffixTest.scala
@@ -14,31 +14,22 @@ class FileSuffixTest
     with IngestGenerators
     with StorageManifestGenerators {
 
-  private val names = Seq(
-    "foo.TXT",
-    "bar.txt",
-    "bat.png",
-    "mystery file",
-    "bad..bmp",
-    "nosuffix",
-    "",
-    "worse.jif.",
-    "file.with.full.stops.scala"
+  private val names = Map(
+    "foo.JAR" -> Some("jar"),
+    "bar.txt" -> Some("txt"),
+    "bat.png" -> Some("png"),
+    "a.b.log" -> Some("log"),
+    "no..bmp" -> Some("bmp"),
+    "ab.jif." -> None,
+    ".abcdef" -> None,
+    "sp aces" -> None,
+    "without" -> None,
+    "" -> None,
   )
 
   it("extracts the file suffixes correctly") {
-    val suffixes = names.map(FileSuffix.getSuffix)
+    val suffixes = names.keys.toList.map(FileSuffix.getSuffix)
 
-    suffixes shouldBe List(
-      Some("txt"),
-      Some("txt"),
-      Some("png"),
-      None,
-      Some("bmp"),
-      None,
-      None,
-      Some("jif"),
-      Some("scala")
-    )
+    suffixes shouldBe names.values.toList
   }
 }

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/services/FileSuffixTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/services/FileSuffixTest.scala
@@ -24,7 +24,7 @@ class FileSuffixTest
     ".abcdef" -> None,
     "sp aces" -> None,
     "without" -> None,
-    "" -> None,
+    "" -> None
   )
 
   it("extracts the file suffixes correctly") {


### PR DESCRIPTION
Some mappings tweaks for the bag indexer: 

- Use storage provider id, instead of toString classname
- Files is a nested field
- Clarify file suffix extraction