### PR TITLE
Clarify bag_indexer messaging

### DIFF
--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -95,7 +95,7 @@ module "bag_indexer" {
   service_name = "${var.namespace}-bag-indexer"
 
   environment = {
-    queue_url          = module.bag_register_output_queue.url
+    queue_url          = module.bag_indexer_input_queue.url
     metrics_namespace  = local.bag_indexer_service_name
     bags_tracker_host  = "http://${module.bags_api.name}.${var.namespace}:8080"
     es_bags_index_name = var.es_bags_index_name

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -411,7 +411,7 @@ module "bag_reindexer_output_topic" {
 module "bag_indexer_input_queue" {
   source = "../queue"
 
-  name = "${var.namespace}_bag_register_output"
+  name = "${var.namespace}_bag_indexer_input_queue"
 
   topic_arns = [
     module.bag_register_output_topic.arn,

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -374,7 +374,7 @@ module "bag_register_output_queue" {
   name = "${var.namespace}_bag_register_output"
 
   topic_arns = [
-    module.bag_reindexer_output_topic.arn
+    module.bag_register_output_topic.arn,
   ]
 
   role_names = [module.bag_indexer.task_role_name]

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -374,7 +374,7 @@ module "bag_register_output_queue" {
   name = "${var.namespace}_bag_register_output"
 
   topic_arns = [
-    module.bag_register_output_topic.arn
+    module.bag_reindexer_output_topic.arn
   ]
 
   role_names = [module.bag_indexer.task_role_name]
@@ -389,7 +389,7 @@ module "registered_bag_notifications_queue" {
   name = "${var.namespace}_registered_bag_notifications"
 
   topic_arns = [
-    module.registered_bag_notifications_topic.arn,
+    module.registered_bag_notifications_topic.arn
   ]
 
   role_names = []
@@ -406,4 +406,20 @@ module "bag_reindexer_output_topic" {
   name = "${var.namespace}_bag_reindexer_output_topic"
 
   role_names = []
+}
+
+module "bag_indexer_input_queue" {
+  source = "../queue"
+
+  name = "${var.namespace}_bag_register_output"
+
+  topic_arns = [
+    module.bag_register_output_topic.arn,
+    module.bag_reindexer_output_topic.arn
+  ]
+
+  role_names = [module.bag_indexer.task_role_name]
+
+  aws_region    = var.aws_region
+  dlq_alarm_arn = var.dlq_alarm_arn
 }


### PR DESCRIPTION
Use a dedicated queue for the bag_indexer, subscribed to the reindex script and bag_register ouput topics.