### PR TITLE
Allow index settings and pass nested doc default

### DIFF
--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -46,7 +46,7 @@ object Main extends WellcomeTypesafeApp {
     val indexCreator = new ElasticsearchIndexCreator(
       elasticClient = elasticClient
     )
-    
+
     indexCreator.create(
       index = index,
       mappingDefinition = BagsIndexConfig.mapping,

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -47,21 +47,14 @@ object Main extends WellcomeTypesafeApp {
       elasticClient = elasticClient
     )
 
+    val maxExpectedFilesOnABag = 1000000
+
     indexCreator.create(
       index = index,
       mappingDefinition = BagsIndexConfig.mapping,
       settings = Map(
         // The largest number of files on a bag is ~ 970,000 (see b19974760, aka
-        // Chemist and Druggist)
-        //
-        // If we use the default limit, we get errors from Elasticsearch:
-        //
-        //      [illegal_argument_exception] The length of [files.path] field of
-        //      [digitised/b19974760] doc of [storage_bags] index has exceeded [1000000] -
-        //      maximum allowed to be analyzed for highlighting. This maximum can be
-        //      set by changing the [index.highlight.max_analyzed_offset] index level setting.
-        //      For large texts, indexing with offsets or term vectors is recommended!
-        //
+        // Chemist and Druggist). The default limit for nested docs is 10,000.
         "index.mapping.nested_objects.limit" -> 1000000
       )
     )

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -49,7 +49,11 @@ object Main extends WellcomeTypesafeApp {
 
     indexCreator.create(
       index = index,
-      mappingDefinition = BagsIndexConfig.mapping
+      mappingDefinition = BagsIndexConfig.mapping,
+      settings = Map(
+        // The largest number of files on a bag is ~ 970,000
+        "index.mapping.nested_objects.limit" -> 1000000
+      )
     )
 
     val bagIndexer = new BagIndexer(

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -51,7 +51,17 @@ object Main extends WellcomeTypesafeApp {
       index = index,
       mappingDefinition = BagsIndexConfig.mapping,
       settings = Map(
-        // The largest number of files on a bag is ~ 970,000
+        // The largest number of files on a bag is ~ 970,000 (see b19974760, aka
+        // Chemist and Druggist)
+        //
+        // If we use the default limit, we get errors from Elasticsearch:
+        //
+        //      [illegal_argument_exception] The length of [files.path] field of
+        //      [digitised/b19974760] doc of [storage_bags] index has exceeded [1000000] -
+        //      maximum allowed to be analyzed for highlighting. This maximum can be
+        //      set by changing the [index.highlight.max_analyzed_offset] index level setting.
+        //      For large texts, indexing with offsets or term vectors is recommended!
+        //
         "index.mapping.nested_objects.limit" -> 1000000
       )
     )

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -46,9 +46,7 @@ object Main extends WellcomeTypesafeApp {
     val indexCreator = new ElasticsearchIndexCreator(
       elasticClient = elasticClient
     )
-
-    val maxExpectedFilesOnABag = 1000000
-
+    
     indexCreator.create(
       index = index,
       mappingDefinition = BagsIndexConfig.mapping,

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/ElasticsearchIndexCreator.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/ElasticsearchIndexCreator.scala
@@ -15,7 +15,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class ElasticsearchIndexCreator(elasticClient: ElasticClient)(
   implicit ec: ExecutionContext
 ) extends Logging {
-  def create(index: Index, mappingDefinition: MappingDefinition, settings: Map[String, Any] = Map.empty): Future[Unit] =
+  def create(
+    index: Index,
+    mappingDefinition: MappingDefinition,
+    settings: Map[String, Any] = Map.empty
+  ): Future[Unit] =
     elasticClient
       .execute {
         createIndex(index.name)

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/ElasticsearchIndexCreator.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/ElasticsearchIndexCreator.scala
@@ -15,11 +15,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class ElasticsearchIndexCreator(elasticClient: ElasticClient)(
   implicit ec: ExecutionContext
 ) extends Logging {
-  def create(index: Index, mappingDefinition: MappingDefinition): Future[Unit] =
+  def create(index: Index, mappingDefinition: MappingDefinition, settings: Map[String, Any] = Map.empty): Future[Unit] =
     elasticClient
       .execute {
         createIndex(index.name)
           .mapping { mappingDefinition.dynamic(DynamicMapping.Strict) }
+          .settings(settings)
       }
       .flatMap { response: Response[CreateIndexResponse] =>
         if (response.isError) {


### PR DESCRIPTION
The files attribute on bag docs can have up to ~970000 nested docs!