### PR TITLE
Bump scala-storage to 8.6.0

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -23,9 +23,9 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
 import scala.concurrent.{ExecutionContext, Future}
 
 class Register(
-  bagReader: BagReader[_],
+  bagReader: BagReader,
   bagTrackerClient: BagTrackerClient,
-  storageManifestService: StorageManifestService[_]
+  storageManifestService: StorageManifestService
 )(
   implicit ec: ExecutionContext
 ) extends Logging {

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/bags/BagReplicator.scala
@@ -11,9 +11,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{
   ReplicationSucceeded
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
@@ -21,8 +19,7 @@ import scala.util.{Failure, Success, Try}
 class BagReplicator(
   replicator: Replicator
 )(
-  implicit
-  streamStore: StreamStore[ObjectLocation, InputStreamWithLengthAndMetadata]
+  implicit streamStore: StreamStore[ObjectLocation]
 ) {
 
   def replicateBag(

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.StorageClass
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
 import uk.ac.wellcome.storage.listing.s3.{
   S3ObjectLocationListing,
@@ -21,8 +20,7 @@ class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
   // Things like the bag-info.txt and tag manifest are tiny, and it's more expensive
   // to store them as Standard-IA than Standard.
   //
-  implicit val prefixTransfer: S3PrefixTransfer =
-    S3PrefixTransfer(storageClass = StorageClass.Standard)
+  implicit val prefixTransfer: S3PrefixTransfer = S3PrefixTransfer()
 
   implicit val s3ObjectSummaryListing: S3ObjectSummaryListing =
     new S3ObjectSummaryListing()

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -29,7 +29,6 @@ import uk.ac.wellcome.storage.locking.{
   LockingService
 }
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.Try
@@ -54,7 +53,7 @@ class BagReplicatorWorker[
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[VersionedBagRootPayload],
-  streamStore: StreamStore[ObjectLocation, InputStreamWithLengthAndMetadata]
+  streamStore: StreamStore[ObjectLocation]
 ) extends IngestStepWorker[
       VersionedBagRootPayload,
       BagReplicationSummary[_]

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
@@ -5,10 +5,7 @@ import java.io.InputStream
 import uk.ac.wellcome.platform.archive.bagunpacker.services.Unpacker
 import uk.ac.wellcome.storage.{ObjectLocation, StorageError}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
-import uk.ac.wellcome.storage.streaming.{
-  InputStreamWithLength,
-  InputStreamWithLengthAndMetadata
-}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[ObjectLocation])
     extends Unpacker {
@@ -21,13 +18,7 @@ class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[ObjectLocation])
     location: ObjectLocation
   )(inputStream: InputStreamWithLength): Either[StorageError, Unit] =
     streamStore
-      .put(location)(
-        new InputStreamWithLengthAndMetadata(
-          inputStream,
-          length = inputStream.length,
-          metadata = Map.empty
-        )
-      )
+      .put(location)(inputStream)
       .map { _ =>
         ()
       }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -12,10 +12,7 @@ import uk.ac.wellcome.platform.archive.bagunpacker.services.{
 }
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.{
-  InputStreamWithLength,
-  InputStreamWithLengthAndMetadata
-}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 class S3Unpacker(
   bufferSize: Long = 128 * FileUtils.ONE_MB
@@ -34,9 +31,7 @@ class S3Unpacker(
     location: ObjectLocation
   )(inputStream: InputStreamWithLength): Either[StorageError, Unit] =
     s3StreamStore
-      .put(location)(
-        InputStreamWithLengthAndMetadata(inputStream, metadata = Map.empty)
-      )
+      .put(location)(inputStream)
       .map { _ =>
         ()
       }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
@@ -36,7 +36,7 @@ trait CompressFixture[Namespace]
     namespace: Namespace,
     archiveFile: File
   )(testWith: TestWith[ObjectLocation, R])(
-    implicit streamStore: StreamStore[ObjectLocation, InputStreamWithLength]
+    implicit streamStore: StreamStore[ObjectLocation]
   ): R = {
     val location = createObjectLocationWith(
       namespace = namespace,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -16,10 +16,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.{
-  InputStreamWithLength,
-  StreamAssertions
-}
+import uk.ac.wellcome.storage.streaming.StreamAssertions
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.Random
@@ -34,9 +31,7 @@ trait UnpackerTestCases[Namespace]
 
   def withNamespace[R](testWith: TestWith[Namespace, R]): R
 
-  def withStreamStore[R](
-    testWith: TestWith[StreamStore[ObjectLocation, InputStreamWithLength], R]
-  ): R
+  def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R
 
   it("unpacks a tgz archive") {
     val (archiveFile, filesInArchive, _) = createTgzArchiveWithRandomFiles()
@@ -206,7 +201,7 @@ trait UnpackerTestCases[Namespace]
   }
 
   def assertEqual(prefix: ObjectLocationPrefix, expectedFiles: Seq[File])(
-    implicit store: StreamStore[ObjectLocation, InputStreamWithLength]
+    implicit store: StreamStore[ObjectLocation]
   ): Seq[Assertion] = {
     expectedFiles.map { file =>
       val name = Paths

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -18,10 +18,7 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ClientFactory
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.{
-  InputStreamWithLength,
-  InputStreamWithLengthAndMetadata
-}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 
 import scala.util.Try
@@ -34,13 +31,12 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
       testWith(bucket)
     }
 
-  // TODO: Add covariance to StreamStore
   override def withStreamStore[R](
-    testWith: TestWith[StreamStore[ObjectLocation, InputStreamWithLength], R]
+    testWith: TestWith[StreamStore[ObjectLocation], R]
   ): R = {
     val s3StreamStore = new S3StreamStore()
 
-    val store = new StreamStore[ObjectLocation, InputStreamWithLength] {
+    val store = new StreamStore[ObjectLocation] {
       override def get(location: ObjectLocation): ReadEither =
         s3StreamStore
           .get(location)
@@ -56,22 +52,17 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
 
       override def put(
         location: ObjectLocation
-      )(is: InputStreamWithLength): WriteEither =
+      )(inputStream: InputStreamWithLength): WriteEither =
         s3StreamStore
-          .put(location)(
-            new InputStreamWithLengthAndMetadata(
-              is,
-              length = is.length,
-              metadata = Map.empty
-            )
-          )
-          .map { is =>
-            is.copy(
-              identifiedT = new InputStreamWithLength(
-                is.identifiedT,
-                length = is.identifiedT.length
+          .put(location)(inputStream)
+          .map {
+            identified: Identified[ObjectLocation, InputStreamWithLength] =>
+              identified.copy(
+                identifiedT = new InputStreamWithLength(
+                  identified.identifiedT,
+                  length = identified.identifiedT.length
+                )
               )
-            )
           }
     }
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -58,7 +58,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val s3ObjectVerifier: S3ObjectVerifier =
       new S3ObjectVerifier()
 
-    implicit val bagReader: BagReader[_] =
+    implicit val bagReader: BagReader =
       new S3BagReader()
 
     implicit val s3Resolvable: S3Resolvable =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -20,9 +20,9 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import scala.util.{Failure, Success, Try}
 
 class BagVerifier(namespace: String)(
-  implicit bagReader: BagReader[_],
+  implicit bagReader: BagReader,
   resolvable: Resolvable[ObjectLocation],
-  verifier: Verifier[_],
+  verifier: Verifier,
   listing: Listing[ObjectLocationPrefix, ObjectLocation]
 ) extends Logging {
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -60,7 +60,7 @@ trait BagVerifierFixtures
 
   def withVerifier[R](bucket: Bucket)(testWith: TestWith[BagVerifier, R]): R =
     withMaterializer { implicit mat =>
-      implicit val _bagReader: BagReader[_] =
+      implicit val _bagReader: BagReader =
         new S3BagReader()
 
       implicit val _s3ObjectVerifier: S3ObjectVerifier =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
@@ -17,11 +17,10 @@ import uk.ac.wellcome.storage.{
   ObjectLocationPrefix
 }
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.util.{Failure, Success, Try}
 
-trait BagReader[IS <: InputStreamWithLength] {
+trait BagReader {
   protected val bagFetch = BagPath("fetch.txt")
   protected val bagInfo = BagPath("bag-info.txt")
   protected val fileManifest =
@@ -29,7 +28,7 @@ trait BagReader[IS <: InputStreamWithLength] {
   protected val tagManifest =
     (a: HashingAlgorithm) => BagPath(s"tagmanifest-${a.pathRepr}.txt")
 
-  implicit val streamStore: StreamStore[ObjectLocation, IS]
+  implicit val streamStore: StreamStore[ObjectLocation]
 
   type Stream[T] = InputStream => Try[T]
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReader.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.platform.archive.common.bagit.services.memory
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class MemoryBagReader()(
   implicit val streamStore: MemoryStreamStore[ObjectLocation]
-) extends BagReader[InputStreamWithLengthAndMetadata]
+) extends BagReader

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReader.scala
@@ -3,10 +3,8 @@ package uk.ac.wellcome.platform.archive.common.bagit.services.s3
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
-class S3BagReader()(implicit s3Client: AmazonS3)
-    extends BagReader[InputStreamWithLengthAndMetadata] {
+class S3BagReader()(implicit s3Client: AmazonS3) extends BagReader {
   override implicit val streamStore: S3StreamStore =
     new S3StreamStore()
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -10,7 +10,7 @@ import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
 import uk.ac.wellcome.storage.ObjectLocationPrefix
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.concurrent.duration.Duration
 
@@ -51,10 +51,9 @@ trait LargeResponses extends Logging {
           .getDataBytes()
           .runWith(converter, materializer)
 
-        val content = new InputStreamWithLengthAndMetadata(
+        val content = new InputStreamWithLength(
           inputStream = inputStream,
-          length = length,
-          metadata = Map.empty
+          length = length
         )
 
         val uploaded = s3Uploader.uploadAndGetURL(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.streaming.Codec.stringCodec
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage._
 
 import scala.concurrent.duration.Duration
@@ -29,7 +29,7 @@ class S3Uploader(implicit val s3Client: AmazonS3) {
   // overwriting existing content will change what previously generated URLs return
   def uploadAndGetURL(
     location: ObjectLocation,
-    content: InputStreamWithLengthAndMetadata,
+    content: InputStreamWithLength,
     expiryLength: Duration,
     checkExists: Boolean
   ): Either[StorageError, URL] =
@@ -55,8 +55,7 @@ class S3Uploader(implicit val s3Client: AmazonS3) {
       inputStream <- stringCodec.toStream(content)
       result <- uploadAndGetURL(
         location = location,
-        content =
-          InputStreamWithLengthAndMetadata(inputStream, metadata = Map.empty),
+        content = inputStream,
         expiryLength = expiryLength,
         checkExists = checkExists
       )

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStoreEntry}
+import uk.ac.wellcome.storage.store.memory.MemoryStore
 
 import scala.util.Try
 
@@ -11,12 +11,11 @@ trait SizeFinder {
 }
 
 class MemorySizeFinder(
-  memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry]
+  memoryStore: MemoryStore[ObjectLocation, Array[Byte]]
 ) extends SizeFinder {
   override def getSize(location: ObjectLocation): Try[Long] = Try {
     memoryStore.entries
       .getOrElse(location, throw new Throwable(s"No such entry $location!"))
-      .bytes
       .length
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import java.io.InputStream
 import java.time.Instant
 
 import grizzled.slf4j.Logging
@@ -15,7 +14,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.store.Readable
-import uk.ac.wellcome.storage.streaming.HasLength
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
@@ -26,12 +25,12 @@ class StorageManifestException(message: String)
 class BadFetchLocationException(message: String)
     extends StorageManifestException(message)
 
-class StorageManifestService[IS <: InputStream with HasLength](
+class StorageManifestService(
   sizeFinder: SizeFinder
 )(
-  implicit streamReader: Readable[ObjectLocation, IS]
+  implicit streamReader: Readable[ObjectLocation, InputStreamWithLength]
 ) extends Logging {
-  private val tagManifestFileFinder = new TagManifestFileFinder[IS]()
+  private val tagManifestFileFinder = new TagManifestFileFinder()
 
   def createManifest(
     ingestId: IngestID,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import java.io.InputStream
-
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
 import uk.ac.wellcome.platform.archive.common.verify.{Hasher, HashingAlgorithm}
 import uk.ac.wellcome.storage.store.Readable
-import uk.ac.wellcome.storage.streaming.HasLength
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{
   DoesNotExistError,
   ObjectLocation,
@@ -22,8 +20,8 @@ import scala.util.{Failure, Success, Try}
   * This class creates the `StorageManifestFile` entries for BagIt tag manifest files.
   *
   */
-class TagManifestFileFinder[IS <: InputStream with HasLength](
-  implicit streamReader: Readable[ObjectLocation, IS]
+class TagManifestFileFinder(
+  implicit streamReader: Readable[ObjectLocation, InputStreamWithLength]
 ) {
 
   def getTagManifestFiles(
@@ -70,7 +68,7 @@ class TagManifestFileFinder[IS <: InputStream with HasLength](
           )
         )
 
-      case Left(err: DoesNotExistError) => None
+      case Left(_: DoesNotExistError) => None
 
       case Left(err) =>
         throw new RuntimeException(s"Error looking up $prefix/$name: $err")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDao.scala
@@ -105,7 +105,7 @@ class DynamoStorageManifestDao(
     val s3Results = locations.map { typedStore.get }
 
     val successes = s3Results.collect {
-      case Right(entry) => entry.identifiedT.t
+      case Right(entry) => entry.identifiedT
     }
     val errors = s3Results.collect { case Left(err) => err }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
@@ -5,7 +5,7 @@ import grizzled.slf4j.Logging
 object Verification extends Logging {
   implicit class Verify[Container](container: Container)(
     implicit verifiable: Verifiable[Container],
-    verifier: Verifier[_]
+    verifier: Verifier
   ) {
     def verify: VerificationResult = {
       debug(s"Verification: Attempting to verify $container")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.archive.common.verify
 
-import java.io.InputStream
 import java.net.URI
 
 import grizzled.slf4j.Logging
@@ -12,12 +11,12 @@ import uk.ac.wellcome.platform.archive.common.storage.{
 }
 import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation}
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.streaming.HasLength
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.util.{Failure, Success}
 
-trait Verifier[IS <: InputStream with HasLength] extends Logging {
-  protected val streamStore: StreamStore[ObjectLocation, IS]
+trait Verifier extends Logging {
+  protected val streamStore: StreamStore[ObjectLocation]
 
   def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation]
 
@@ -99,7 +98,7 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
   private def verifyChecksum(
     verifiableLocation: VerifiableLocation,
     objectLocation: ObjectLocation,
-    inputStream: IS,
+    inputStream: InputStreamWithLength,
     algorithm: HashingAlgorithm
   ): VerifiedLocation =
     Checksum.create(inputStream, algorithm) match {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
@@ -6,10 +6,9 @@ import uk.ac.wellcome.platform.archive.common.storage.LocateFailure
 import uk.ac.wellcome.platform.archive.common.verify.Verifier
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class MemoryVerifier(val streamStore: MemoryStreamStore[ObjectLocation])
-    extends Verifier[InputStreamWithLengthAndMetadata] {
+    extends Verifier {
   override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
     Right(
       ObjectLocation(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
@@ -9,17 +9,15 @@ import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class S3ObjectVerifier(implicit s3Client: AmazonS3)
-    extends Verifier[InputStreamWithLengthAndMetadata]
+    extends Verifier
     with Logging {
 
   import uk.ac.wellcome.platform.archive.common.storage.Locatable._
   import uk.ac.wellcome.platform.archive.common.storage.services.S3LocatableInstances._
 
-  override protected val streamStore
-    : StreamStore[ObjectLocation, InputStreamWithLengthAndMetadata] =
+  override protected val streamStore: StreamStore[ObjectLocation] =
     new S3StreamStore()
 
   override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.platform.archive.common.fixtures.{
   StorageRandomThings
 }
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.store.{TypedStore, TypedStoreEntry}
+import uk.ac.wellcome.storage.store.TypedStore
 
 trait BagReaderTestCases[Context, Namespace]
     extends AnyFunSpec
@@ -22,7 +22,7 @@ trait BagReaderTestCases[Context, Namespace]
     testWith: TestWith[TypedStore[ObjectLocation, String], R]
   )(implicit context: Context): R
 
-  def withBagReader[R](testWith: TestWith[BagReader[_], R])(
+  def withBagReader[R](testWith: TestWith[BagReader, R])(
     implicit context: Context
   ): R
 
@@ -35,9 +35,9 @@ trait BagReaderTestCases[Context, Namespace]
   def scrambleFile(root: ObjectLocationPrefix, path: String)(
     implicit typedStore: TypedStore[ObjectLocation, String]
   ): Assertion =
-    typedStore.put(root.asLocation(path))(
-      TypedStoreEntry(randomAlphanumeric, metadata = Map.empty)
-    ) shouldBe a[Right[_, _]]
+    typedStore.put(root.asLocation(path))(randomAlphanumeric) shouldBe a[
+      Right[_, _]
+    ]
 
   def withFixtures[R](
     testWith: TestWith[

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
@@ -26,7 +26,7 @@ class MemoryBagReaderTest
     )
 
   override def withBagReader[R](
-    testWith: TestWith[BagReader[_], R]
+    testWith: TestWith[BagReader, R]
   )(implicit context: MemoryStreamStore[ObjectLocation]): R =
     testWith(
       new MemoryBagReader()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
@@ -36,7 +36,7 @@ class S3BagReaderTest extends BagReaderTestCases[Unit, Bucket] with S3Fixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 
   override def withBagReader[R](
-    testWith: TestWith[BagReader[_], R]
+    testWith: TestWith[BagReader, R]
   )(implicit context: Unit): R =
     testWith(new S3BagReader())
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.store.{TypedStore, TypedStoreEntry}
+import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.streaming.Codec._
 
 import scala.util.Random
@@ -38,9 +38,7 @@ trait BagBuilderBase extends StorageSpaceGenerators with BagInfoGenerators {
     objects: Seq[BagObject]
   )(implicit typedStore: TypedStore[ObjectLocation, String]): Unit =
     objects.foreach { bagObj =>
-      typedStore.put(bagObj.location)(
-        TypedStoreEntry(bagObj.contents, metadata = Map.empty)
-      ) shouldBe a[Right[_, _]]
+      typedStore.put(bagObj.location)(bagObj.contents) shouldBe a[Right[_, _]]
     }
 
   protected def getFetchEntryCount(payloadFileCount: Int): Int =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestDaoFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestDaoFixture.scala
@@ -31,7 +31,7 @@ trait StorageManifestDaoFixture extends EitherValues {
 
   def createTypedStore: StorageManifestTypedStore = {
     val memoryStoreForStreamStore =
-      new MemoryStore[String, MemoryStreamStoreEntry](Map.empty)
+      new MemoryStore[String, Array[Byte]](Map.empty)
     implicit val streamStore: MemoryStreamStore[String] =
       new MemoryStreamStore[String](memoryStoreForStreamStore)
     new MemoryTypedStore[String, StorageManifest](Map.empty)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExistsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectExistsTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.generators.RandomThings
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+import uk.ac.wellcome.storage.streaming.Codec
 import uk.ac.wellcome.storage.{ObjectLocation, StorageError}
 
 class S3ObjectExistsTest
@@ -22,17 +22,9 @@ class S3ObjectExistsTest
       it("returns true") {
         withLocalS3Bucket { bucket =>
           val objectLocation = createObjectLocationWith(bucket.name)
-          val byteLength = randomInt(100, 200)
-          val randomData = randomInputStream(byteLength)
+          val inputStream = Codec.bytesCodec.toStream(randomBytes()).right.value
 
-          putStream(
-            objectLocation,
-            new InputStreamWithLengthAndMetadata(
-              randomData,
-              byteLength,
-              Map.empty
-            )
-          )
+          putStream(location = objectLocation, inputStream = inputStream)
 
           objectLocation.exists.right.value shouldBe true
         }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
@@ -11,7 +11,6 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 import scala.util.Failure
 
@@ -84,10 +83,8 @@ class MemorySizeFinderTest
     location: ObjectLocation,
     contents: String
   )(implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit = {
-    val is = stringCodec.toStream(contents).right.value
-    streamStore.put(location)(
-      InputStreamWithLengthAndMetadata(is, metadata = Map.empty)
-    )
+    val inputStream = stringCodec.toStream(contents).right.value
+    streamStore.put(location)(inputStream)
   }
 }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
@@ -15,10 +15,7 @@ import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStoreFixtures
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.{
-  InputStreamWithLength,
-  InputStreamWithLengthAndMetadata
-}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 class TagManifestFileFinderTest
     extends AnyFunSpec
@@ -30,17 +27,14 @@ class TagManifestFileFinderTest
 
   def withTagManifestFileFinder[R](
     entries: Map[ObjectLocation, String]
-  )(testWith: TestWith[TagManifestFileFinder[_], R]): R =
+  )(testWith: TestWith[TagManifestFileFinder, R]): R =
     withStreamStoreContext { memoryStore =>
       val initialEntries = entries
         .map {
-          case (loc, str) =>
-            val is = InputStreamWithLengthAndMetadata(
-              stringCodec.toStream(str).right.value,
-              metadata = Map.empty
-            )
+          case (location, str) =>
+            val inputStream = stringCodec.toStream(str).right.value
 
-            (loc, is)
+            (location, inputStream)
         }
 
       withMemoryStreamStoreImpl(memoryStore, initialEntries = initialEntries) {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -22,7 +22,7 @@ trait VerifierTestCases[Namespace, Context]
     implicit context: Context
   ): Unit
 
-  def withVerifier[R](testWith: TestWith[Verifier[_], R])(
+  def withVerifier[R](testWith: TestWith[Verifier, R])(
     implicit context: Context
   ): R
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
@@ -11,7 +11,6 @@ import uk.ac.wellcome.platform.archive.common.verify.{
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class MemoryVerifierTest
     extends VerifierTestCases[String, MemoryStreamStore[ObjectLocation]]
@@ -25,16 +24,13 @@ class MemoryVerifierTest
 
   override def putString(location: ObjectLocation, contents: String)(
     implicit streamStore: MemoryStreamStore[ObjectLocation]
-  ): Unit =
-    streamStore.put(location)(
-      InputStreamWithLengthAndMetadata(
-        stringCodec.toStream(contents).right.value,
-        metadata = Map.empty
-      )
-    ) shouldBe a[Right[_, _]]
+  ): Unit = {
+    val inputStream = stringCodec.toStream(contents).right.value
+    streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
+  }
 
   override def withVerifier[R](
-    testWith: TestWith[Verifier[_], R]
+    testWith: TestWith[Verifier, R]
   )(implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
     testWith(
       new MemoryVerifier(streamStore)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -29,7 +29,7 @@ class S3ObjectVerifierTest
     )
 
   override def withVerifier[R](
-    testWith: TestWith[Verifier[_], R]
+    testWith: TestWith[Verifier, R]
   )(implicit context: Unit): R =
     testWith(new S3ObjectVerifier())
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json = "2.3.0"
     val messaging = "9.3.0"
     val monitoring = "4.0.0"
-    val storage = "8.2.0"
+    val storage = "8.6.0"
     val typesafe = "2.0.0"
   }
 


### PR DESCRIPTION
8.5.0 removed all the metadata-handling code in favour of tags, so this patch strips out all the unused metadata handling code from the storage service.