### PR TITLE
Use consistent messaging names for indexer

### DIFF
--- a/indexer/reindex_bags_backlog.py
+++ b/indexer/reindex_bags_backlog.py
@@ -28,13 +28,13 @@ ES_SECRETS = {
 
 STAGE_CONFIG = {
     "table_name": "vhs-storage-staging-manifests",
-    "topic_arn": "arn:aws:sns:eu-west-1:975596993436:storage_staging_bag_reindexer_output_topic",
+    "topic_arn": "arn:aws:sns:eu-west-1:975596993436:storage_staging_bag_reindexer_output",
     "es_index": "storage_stage_bags",
 }
 
 PROD_CONFIG = {
     "table_name": "vhs-storage-manifests",
-    "topic_arn": "arn:aws:sns:eu-west-1:975596993436:storage_prod_bag_reindexer_output_topic",
+    "topic_arn": "arn:aws:sns:eu-west-1:975596993436:storage_prod_bag_reindexer_output",
     "es_index": "storage_bags",
 }
 

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -394,7 +394,7 @@ module "registered_bag_notifications_queue" {
 module "bag_reindexer_output_topic" {
   source = "../topic"
 
-  name = "${var.namespace}_bag_reindexer_output_topic"
+  name = "${var.namespace}_bag_reindexer_output"
 
   role_names = []
 }
@@ -402,10 +402,10 @@ module "bag_reindexer_output_topic" {
 module "bag_indexer_input_queue" {
   source = "../queue"
 
-  name = "${var.namespace}_bag_indexer_input_queue"
+  name = "${var.namespace}_bag_indexer_input"
 
   topic_arns = [
-    module.bag_register_output_topic.arn,
+    module.registered_bag_notifications_topic.arn,
     module.bag_reindexer_output_topic.arn
   ]
 


### PR DESCRIPTION
To stay in line with the messaging scheme elsewhere in the storage service.