### PR TITLE
More abstraction and testing in the bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -28,3 +28,9 @@ case class FileFixityCouldNotRead(
   expectedFileFixity: ExpectedFileFixity,
   e: Throwable
 ) extends FileFixityError
+
+case class FileFixityCouldNotGetChecksum(
+  expectedFileFixity: ExpectedFileFixity,
+  objectLocation: ObjectLocation,
+  e: Throwable
+) extends FileFixityError

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -54,7 +54,9 @@ trait FixityChecker extends Logging {
     }
   }
 
-  private def parseLocation(expectedFileFixity: ExpectedFileFixity): Either[FileFixityCouldNotRead, ObjectLocation] =
+  private def parseLocation(
+    expectedFileFixity: ExpectedFileFixity
+  ): Either[FileFixityCouldNotRead, ObjectLocation] =
     locate(expectedFileFixity.uri) match {
       case Right(location) => Right(location)
       case Left(locateError) =>
@@ -66,7 +68,10 @@ trait FixityChecker extends Logging {
         )
     }
 
-  private def openInputStream(expectedFileFixity: ExpectedFileFixity, location: ObjectLocation): Either[FileFixityCouldNotRead, InputStreamWithLength] =
+  private def openInputStream(
+    expectedFileFixity: ExpectedFileFixity,
+    location: ObjectLocation
+  ): Either[FileFixityCouldNotRead, InputStreamWithLength] =
     streamStore.get(location) match {
       case Right(stream) => Right(stream.identifiedT)
 
@@ -90,7 +95,8 @@ trait FixityChecker extends Logging {
   private def verifySize(
     expectedFileFixity: ExpectedFileFixity,
     location: ObjectLocation,
-    inputStream: InputStreamWithLength): Either[FileFixityMismatch, Unit] =
+    inputStream: InputStreamWithLength
+  ): Either[FileFixityMismatch, Unit] =
     expectedFileFixity.length match {
       case Some(expectedLength) if expectedLength != inputStream.length =>
         Left(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -1,45 +1,19 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
-import java.net.URI
-
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
 trait FixityCheckerTestCases[Namespace, Context]
     extends AnyFunSpec
     with Matchers
     with NamespaceFixtures[ObjectLocation, Namespace]
-    with StorageRandomThings
-    with ObjectLocationGenerators {
-
-  def randomChecksum = Checksum(SHA256, randomChecksumValue)
-  def badChecksum = Checksum(MD5, randomChecksumValue)
-
-  def createExpectedFileFixity: ExpectedFileFixity =
-    createExpectedFileFixityWith()
-
-  def resolve(location: ObjectLocation): URI
-
-  def createExpectedFileFixityWith(
-    location: ObjectLocation = createObjectLocation,
-    checksum: Checksum = randomChecksum,
-    length: Option[Long] = None
-  ): ExpectedFileFixity = {
-    ExpectedFileFixity(
-      uri = resolve(location),
-      path = BagPath(randomAlphanumeric),
-      checksum = checksum,
-      length = length
-    )
-  }
+    with FixityGenerators {
 
   def withContext[R](testWith: TestWith[Context, R]): R
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.archive.bagverifier.fixity
+
+import java.net.URI
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
+import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
+import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationParsingError}
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+
+class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators {
+  override def resolve(location: ObjectLocation): URI =
+    new URI(s"mem://${location.namespace}/${location.path}")
+
+  describe("handles errors correctly") {
+    it("turns an error in locate() into a FileFixityCouldNotRead") {
+      val streamStore = MemoryStreamStore[ObjectLocation]()
+
+      val brokenChecker = new MemoryFixityChecker(streamStore) {
+        override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
+          Left(LocationParsingError(uri, msg = "BOOM!"))
+      }
+
+      val expectedFileFixity = createExpectedFileFixity
+      brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead]
+    }
+  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
+import java.io.FilterInputStream
 import java.net.URI
 
 import org.scalatest.funspec.AnyFunSpec
@@ -7,8 +8,9 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationParsingError}
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.{Identified, ObjectLocation}
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators {
   override def resolve(location: ObjectLocation): URI =
@@ -25,6 +27,33 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
 
       val expectedFileFixity = createExpectedFileFixity
       brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead]
+    }
+
+    it("handles an error when trying to checksum the object") {
+      val badStream = new FilterInputStream(randomInputStream()) {
+        override def read(b: Array[Byte], off: Int, len: Int): Int =
+          throw new Throwable("BOOM!")
+      }
+
+      val closedStream = new InputStreamWithLength(
+        badStream,
+        length = randomInt(from = 1, to = 10)
+      )
+
+      closedStream.close()
+
+      val streamStore = new MemoryStreamStore[ObjectLocation](
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+      ) {
+        override def get(location: ObjectLocation): this.ReadEither =
+          Right(Identified(location, closedStream))
+      }
+
+      val expectedFileFixity = createExpectedFileFixityWith(length = None)
+
+      val checker = new MemoryFixityChecker(streamStore)
+
+      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotGetChecksum]
     }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -8,9 +8,10 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationParsingError}
+import uk.ac.wellcome.platform.archive.common.verify.{Checksum, ChecksumValue, MD5}
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
-import uk.ac.wellcome.storage.streaming.InputStreamWithLength
+import uk.ac.wellcome.storage.streaming.{Codec, InputStreamWithLength}
 
 class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators {
   override def resolve(location: ObjectLocation): URI =
@@ -54,6 +55,72 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       val checker = new MemoryFixityChecker(streamStore)
 
       checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotGetChecksum]
+    }
+  }
+
+  describe("it closes the InputStream when it's done reading") {
+    it("if the checksum is correct") {
+      val contentHashingAlgorithm = MD5
+      val contentString = "HelloWorld"
+      // md5("HelloWorld")
+      val contentStringChecksum = ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")
+      val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
+
+      var isClosed: Boolean = false
+
+      val inputStream: InputStreamWithLength = new InputStreamWithLength(
+        Codec.stringCodec.toStream(contentString).right.get,
+        length = contentString.length
+      ) {
+        override def close(): Unit = {
+          isClosed = true
+          super.close()
+        }
+      }
+
+      val streamStore = new MemoryStreamStore[ObjectLocation](
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+      ) {
+        override def get(location: ObjectLocation): this.ReadEither =
+          Right(Identified(location, inputStream))
+      }
+
+      val expectedFileFixity = createExpectedFileFixityWith(checksum = checksum)
+
+      val checker = new MemoryFixityChecker(streamStore)
+
+      checker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+
+      isClosed shouldBe true
+    }
+
+    it("if the checksum is incorrect") {
+      var isClosed: Boolean = false
+
+      val inputStream: InputStreamWithLength = new InputStreamWithLength(
+        randomInputStream(),
+        length = randomInt(from = 1, to = 50)
+      ) {
+        override def close(): Unit = {
+          isClosed = true
+          super.close()
+        }
+      }
+
+      val streamStore = new MemoryStreamStore[ObjectLocation](
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+      ) {
+        override def get(location: ObjectLocation): this.ReadEither =
+          Right(Identified(location, inputStream))
+      }
+
+      val expectedFileFixity = createExpectedFileFixity
+
+      val checker = new MemoryFixityChecker(streamStore)
+
+      checker.check(expectedFileFixity) shouldBe a[FileFixityMismatch]
+
+      isClosed shouldBe true
     }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -7,13 +7,23 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
-import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationParsingError}
-import uk.ac.wellcome.platform.archive.common.verify.{Checksum, ChecksumValue, MD5}
+import uk.ac.wellcome.platform.archive.common.storage.{
+  LocateFailure,
+  LocationParsingError
+}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  Checksum,
+  ChecksumValue,
+  MD5
+}
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
 import uk.ac.wellcome.storage.streaming.{Codec, InputStreamWithLength}
 
-class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators {
+class FixityCheckerTests
+    extends AnyFunSpec
+    with Matchers
+    with FixityGenerators {
   override def resolve(location: ObjectLocation): URI =
     new URI(s"mem://${location.namespace}/${location.path}")
 
@@ -22,7 +32,9 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       val streamStore = MemoryStreamStore[ObjectLocation]()
 
       val brokenChecker = new MemoryFixityChecker(streamStore) {
-        override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
+        override def locate(
+          uri: URI
+        ): Either[LocateFailure[URI], ObjectLocation] =
           Left(LocationParsingError(uri, msg = "BOOM!"))
       }
 
@@ -44,7 +56,9 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       closedStream.close()
 
       val streamStore = new MemoryStreamStore[ObjectLocation](
-        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](
+          initialEntries = Map.empty
+        )
       ) {
         override def get(location: ObjectLocation): this.ReadEither =
           Right(Identified(location, closedStream))
@@ -54,7 +68,9 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
 
       val checker = new MemoryFixityChecker(streamStore)
 
-      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotGetChecksum]
+      checker.check(expectedFileFixity) shouldBe a[
+        FileFixityCouldNotGetChecksum
+      ]
     }
   }
 
@@ -63,7 +79,8 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       val contentHashingAlgorithm = MD5
       val contentString = "HelloWorld"
       // md5("HelloWorld")
-      val contentStringChecksum = ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")
+      val contentStringChecksum =
+        ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")
       val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
       var isClosed: Boolean = false
@@ -79,7 +96,9 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       }
 
       val streamStore = new MemoryStreamStore[ObjectLocation](
-        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](
+          initialEntries = Map.empty
+        )
       ) {
         override def get(location: ObjectLocation): this.ReadEither =
           Right(Identified(location, inputStream))
@@ -108,7 +127,9 @@ class FixityCheckerTests extends AnyFunSpec with Matchers with FixityGenerators 
       }
 
       val streamStore = new MemoryStreamStore[ObjectLocation](
-        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](initialEntries = Map.empty)
+        memoryStore = new MemoryStore[ObjectLocation, Array[Byte]](
+          initialEntries = Map.empty
+        )
       ) {
         override def get(location: ObjectLocation): this.ReadEither =
           Right(Identified(location, inputStream))

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.archive.bagverifier.generators
+
+import java.net.URI
+
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.ExpectedFileFixity
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+
+trait FixityGenerators extends ObjectLocationGenerators with StorageRandomThings {
+  def randomChecksum = Checksum(SHA256, randomChecksumValue)
+  def badChecksum = Checksum(MD5, randomChecksumValue)
+
+  def resolve(location: ObjectLocation): URI
+
+  def createExpectedFileFixity: ExpectedFileFixity =
+    createExpectedFileFixityWith()
+
+  def createExpectedFileFixityWith(
+    location: ObjectLocation = createObjectLocation,
+    checksum: Checksum = randomChecksum,
+    length: Option[Long] = None
+  ): ExpectedFileFixity = {
+    ExpectedFileFixity(
+      uri = resolve(location),
+      path = BagPath(randomAlphanumeric),
+      checksum = checksum,
+      length = length
+    )
+  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -9,7 +9,9 @@ import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
-trait FixityGenerators extends ObjectLocationGenerators with StorageRandomThings {
+trait FixityGenerators
+    extends ObjectLocationGenerators
+    with StorageRandomThings {
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
 


### PR DESCRIPTION
Spun out of https://github.com/wellcomecollection/storage-service/pull/581, part of https://github.com/wellcomecollection/platform/issues/4562

This is a refactoring of the bag verifier to make it easier to change for the storage tiering work. There are also some new tests for edge cases we weren't previously covering. Plus a bit more logging, because this is a bit of the codebase where detailed tracing in the tests is super useful.

No outward-facing behaviour change in this PR.