### PR TITLE
Change SizeFinder to return an Either, not a Try

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -1,29 +1,44 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.storage.ObjectLocation
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import uk.ac.wellcome.storage.s3.S3Get
 import uk.ac.wellcome.storage.store.memory.MemoryStore
-
-import scala.util.Try
+import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ReadError, StoreReadError}
 
 trait SizeFinder {
-  def getSize(location: ObjectLocation): Try[Long]
+  def getSize(location: ObjectLocation): Either[ReadError, Long]
 }
 
 class MemorySizeFinder(
   memoryStore: MemoryStore[ObjectLocation, Array[Byte]]
 ) extends SizeFinder {
-  override def getSize(location: ObjectLocation): Try[Long] = Try {
-    memoryStore.entries
-      .getOrElse(location, throw new Throwable(s"No such entry $location!"))
-      .length
-  }
+  override def getSize(location: ObjectLocation): Either[ReadError, Long] =
+    memoryStore.entries.get(location) match {
+      case Some(entry) => Right(entry.length)
+      case None        => Left(DoesNotExistError(new Throwable(s"No such entry $location!")))
+    }
 }
 
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
-  def getSize(location: ObjectLocation): Try[Long] = Try {
-    s3Client
-      .getObjectMetadata(location.namespace, location.path)
-      .getContentLength
+  def getSize(location: ObjectLocation): Either[ReadError, Long] = {
+    val result =
+      S3Get
+        .get(location, maxRetries = 3) { location: ObjectLocation =>
+          s3Client
+            .getObjectMetadata(location.namespace, location.path)
+            .getContentLength
+        }
+
+    // The "Not Found" error message from GetObjectMetadata is different from
+    // that for GetObject, so S3Get doesn't know to wrap it as a DoesNotExistError.
+    //
+    // TODO: Upstream this change into scala-storage.
+    result match {
+      case Left(StoreReadError(exc: AmazonS3Exception)) if exc.getMessage.startsWith("Not Found") =>
+        Left(DoesNotExistError(exc))
+
+      case other => other
+    }
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -4,7 +4,12 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import uk.ac.wellcome.storage.s3.S3Get
 import uk.ac.wellcome.storage.store.memory.MemoryStore
-import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ReadError, StoreReadError}
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  ObjectLocation,
+  ReadError,
+  StoreReadError
+}
 
 trait SizeFinder {
   def getSize(location: ObjectLocation): Either[ReadError, Long]
@@ -16,7 +21,8 @@ class MemorySizeFinder(
   override def getSize(location: ObjectLocation): Either[ReadError, Long] =
     memoryStore.entries.get(location) match {
       case Some(entry) => Right(entry.length)
-      case None        => Left(DoesNotExistError(new Throwable(s"No such entry $location!")))
+      case None =>
+        Left(DoesNotExistError(new Throwable(s"No such entry $location!")))
     }
 }
 
@@ -35,7 +41,8 @@ class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
     //
     // TODO: Upstream this change into scala-storage.
     result match {
-      case Left(StoreReadError(exc: AmazonS3Exception)) if exc.getMessage.startsWith("Not Found") =>
+      case Left(StoreReadError(exc: AmazonS3Exception))
+          if exc.getMessage.startsWith("Not Found") =>
         Left(DoesNotExistError(exc))
 
       case other => other

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -218,10 +218,10 @@ class StorageManifestService(
           case Some(s) => s
           case None =>
             sizeFinder.getSize(location) match {
-              case Success(value) => value
-              case Failure(err) =>
+              case Right(value)    => value
+              case Left(readError) =>
                 throw new StorageManifestException(
-                  s"Error getting size of $location: $err"
+                  s"Error getting size of $location: ${readError.e}"
                 )
             }
         }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -218,7 +218,7 @@ class StorageManifestService(
           case Some(s) => s
           case None =>
             sizeFinder.getSize(location) match {
-              case Right(value)    => value
+              case Right(value) => value
               case Left(readError) =>
                 throw new StorageManifestException(
                   s"Error getting size of $location: ${readError.e}"

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -434,7 +434,9 @@ class StorageManifestServiceTest
       val err = new Throwable("BOOM!")
 
       val brokenSizeFinder = new SizeFinder {
-        override def getSize(location: ObjectLocation): Either[ReadError, Long] =
+        override def getSize(
+          location: ObjectLocation
+        ): Either[ReadError, Long] =
           Left(StoreReadError(err))
       }
 
@@ -479,7 +481,9 @@ class StorageManifestServiceTest
       var sizeCache: Map[ObjectLocation, Long] = Map.empty
 
       val cachingSizeFinder = new SizeFinder {
-        override def getSize(location: ObjectLocation): Either[ReadError, Long] = {
+        override def getSize(
+          location: ObjectLocation
+        ): Either[ReadError, Long] = {
           sizeCache = sizeCache + (location -> Random.nextLong())
           Right(sizeCache(location))
         }
@@ -535,7 +539,9 @@ class StorageManifestServiceTest
       val location = createPrimaryLocationWith(prefix = bagRoot)
 
       val brokenSizeFinder = new SizeFinder {
-        override def getSize(location: ObjectLocation): Either[ReadError, Long] =
+        override def getSize(
+          location: ObjectLocation
+        ): Either[ReadError, Long] =
           Left(StoreReadError(new Throwable("This should never be called!")))
       }
 
@@ -626,8 +632,7 @@ class StorageManifestServiceTest
     replicas: Seq[SecondaryStorageLocation] = Seq.empty,
     space: StorageSpace = createStorageSpace,
     version: BagVersion,
-    sizeFinder: SizeFinder = (_: ObjectLocation) =>
-      Right(Random.nextLong().abs)
+    sizeFinder: SizeFinder = (_: ObjectLocation) => Right(Random.nextLong().abs)
   )(
     implicit streamStore: MemoryStreamStore[ObjectLocation]
   ): StorageManifest = {
@@ -680,7 +685,8 @@ class StorageManifestServiceTest
     version: BagVersion = BagVersion(1)
   )(assertError: Throwable => Assertion): Assertion = {
     val sizeFinder = new SizeFinder {
-      override def getSize(location: ObjectLocation): Either[ReadError, Long] = Right(1)
+      override def getSize(location: ObjectLocation): Either[ReadError, Long] =
+        Right(1)
     }
 
     implicit val streamStore: MemoryStreamStore[ObjectLocation] =


### PR DESCRIPTION
Another piece building on #581, part of wellcomecollection/platform#4562

This gives us the nicer types from scala-storage, so we can distinguish between "does not exist" and "unexpected error".  Having this distinction allows us to use these classes in the bag verifier, when we want to look up the size of an object that's been cycled to Glacier.