### PR TITLE
Bag verifier uses tags to cache verification results, but for realsies

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -34,3 +34,9 @@ case class FileFixityCouldNotGetChecksum(
   objectLocation: ObjectLocation,
   e: Throwable
 ) extends FileFixityError
+
+case class FileFixityCouldNotWriteTag(
+  expectedFileFixity: ExpectedFileFixity,
+  objectLocation: ObjectLocation,
+  e: Throwable
+) extends FileFixityError

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -190,30 +190,6 @@ trait FixityChecker extends Logging {
     fixityResult
   }
 
-  private def handleReadErrors[T](
-    t: Either[ReadError, T],
-    expectedFileFixity: ExpectedFileFixity
-  ): Either[FileFixityCouldNotRead, T] =
-    t match {
-      case Right(value) => Right(value)
-
-      case Left(_: DoesNotExistError) =>
-        Left(
-          FileFixityCouldNotRead(
-            expectedFileFixity = expectedFileFixity,
-            e = LocationNotFound(expectedFileFixity, "Location not available!")
-          )
-        )
-
-      case Left(readError) =>
-        Left(
-          FileFixityCouldNotRead(
-            expectedFileFixity = expectedFileFixity,
-            e = LocationError(expectedFileFixity, readError.e.getMessage)
-          )
-        )
-    }
-
   private def writeFixityTags(
     expectedFileFixity: ExpectedFileFixity,
     location: ObjectLocation,
@@ -247,4 +223,28 @@ trait FixityChecker extends Logging {
           )
         )
       }
+
+  private def handleReadErrors[T](
+    t: Either[ReadError, T],
+    expectedFileFixity: ExpectedFileFixity
+  ): Either[FileFixityCouldNotRead, T] =
+    t match {
+      case Right(value) => Right(value)
+
+      case Left(_: DoesNotExistError) =>
+        Left(
+          FileFixityCouldNotRead(
+            expectedFileFixity = expectedFileFixity,
+            e = LocationNotFound(expectedFileFixity, "Location not available!")
+          )
+        )
+
+      case Left(readError) =>
+        Left(
+          FileFixityCouldNotRead(
+            expectedFileFixity = expectedFileFixity,
+            e = LocationError(expectedFileFixity, readError.e.getMessage)
+          )
+        )
+    }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -89,7 +89,8 @@ trait FixityChecker extends Logging {
 
   private def getExistingTags(
     expectedFileFixity: ExpectedFileFixity,
-    location: ObjectLocation): Either[FileFixityCouldNotRead, Map[String, String]] =
+    location: ObjectLocation
+  ): Either[FileFixityCouldNotRead, Map[String, String]] =
     handleReadErrors(
       tags.get(location),
       expectedFileFixity = expectedFileFixity
@@ -138,7 +139,8 @@ trait FixityChecker extends Logging {
     size: Long
   ): Either[FileFixityError, FileFixityCorrect] =
     existingTags.get(fixityTagName(expectedFileFixity)) match {
-      case Some(cachedFixityValue) if cachedFixityValue == fixityTagValue(expectedFileFixity) =>
+      case Some(cachedFixityValue)
+          if cachedFixityValue == fixityTagValue(expectedFileFixity) =>
         Right(
           FileFixityCorrect(
             expectedFileFixity = expectedFileFixity,
@@ -256,15 +258,16 @@ trait FixityChecker extends Logging {
 
         Right(existingTags ++ fixityTags)
       } match {
-        case Right(_)         => Right(())
-        case Left(writeError) => Left(
+      case Right(_) => Right(())
+      case Left(writeError) =>
+        Left(
           FileFixityCouldNotWriteTag(
             expectedFileFixity = expectedFileFixity,
             objectLocation = location,
             e = writeError.e
           )
         )
-      }
+    }
 
   // e.g. Content-MD5, Content-SHA256
   private def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -14,8 +14,8 @@ import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityChecker(
   val streamStore: MemoryStreamStore[ObjectLocation],
-  val tags: MemoryTags[ObjectLocation])
-    extends FixityChecker {
+  val tags: MemoryTags[ObjectLocation]
+) extends FixityChecker {
 
   override protected val sizeFinder: SizeFinder =
     new MemorySizeFinder(streamStore.memoryStore)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -10,8 +10,11 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
 }
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
-class MemoryFixityChecker(val streamStore: MemoryStreamStore[ObjectLocation])
+class MemoryFixityChecker(
+  val streamStore: MemoryStreamStore[ObjectLocation],
+  val tags: MemoryTags[ObjectLocation])
     extends FixityChecker {
 
   override protected val sizeFinder: SizeFinder =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -13,6 +13,8 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
+import uk.ac.wellcome.storage.tags.Tags
+import uk.ac.wellcome.storage.tags.s3.S3Tags
 
 class S3FixityChecker(implicit s3Client: AmazonS3)
     extends FixityChecker
@@ -25,6 +27,8 @@ class S3FixityChecker(implicit s3Client: AmazonS3)
     new S3StreamStore()
 
   override protected val sizeFinder: SizeFinder = new S3SizeFinder()
+
+  override val tags: Tags[ObjectLocation] = new S3Tags()
 
   override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
     uri.locate

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -13,8 +13,9 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
-trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[ObjectLocation]]
-    extends AnyFunSpec
+trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
+  ObjectLocation
+]] extends AnyFunSpec
     with Matchers
     with EitherValues
     with NamespaceFixtures[ObjectLocation, Namespace]
@@ -28,13 +29,15 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
     implicit context: Context
   ): Unit
 
-  def withFixityChecker[R](
-    streamStore: StreamStoreImpl)(
-    testWith: TestWith[FixityChecker, R])(
+  def withFixityChecker[R](streamStore: StreamStoreImpl)(
+    testWith: TestWith[FixityChecker, R]
+  )(
     implicit context: Context
   ): R
 
-  def withStreamStore[R](testWith: TestWith[StreamStoreImpl, R])(implicit context: Context): R
+  def withStreamStore[R](testWith: TestWith[StreamStoreImpl, R])(
+    implicit context: Context
+  ): R
 
   def withFixityChecker[R](testWith: TestWith[FixityChecker, R])(
     implicit context: Context
@@ -264,7 +267,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
           )
 
           withFixityChecker { fixityChecker =>
-            fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+            fixityChecker.check(expectedFileFixity) shouldBe a[
+              FileFixityCorrect
+            ]
 
             fixityChecker.tags.get(location).right.value shouldBe Map(
               "Content-MD5" -> checksumString
@@ -289,7 +294,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
             val spyStore: StreamStoreImpl = Mockito.spy(streamStore)
 
             withFixityChecker(spyStore) { fixityChecker =>
-              fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+              fixityChecker.check(expectedFileFixity) shouldBe a[
+                FileFixityCorrect
+              ]
 
               // StreamStore.get() should have been called to read the object so
               // it can be verified.
@@ -297,7 +304,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
 
               // It shouldn't be read a second time, because we see the tag written by
               // the previous verification.
-              fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+              fixityChecker.check(expectedFileFixity) shouldBe a[
+                FileFixityCorrect
+              ]
               verify(spyStore, times(1)).get(location)
             }
           }
@@ -326,7 +335,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
             val spyStore: StreamStoreImpl = Mockito.spy(streamStore)
 
             withFixityChecker(spyStore) { fixityChecker =>
-              fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+              fixityChecker.check(expectedFileFixity) shouldBe a[
+                FileFixityCorrect
+              ]
 
               // StreamStore.get() should have been called to read the object so
               // it can be verified.
@@ -336,7 +347,12 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
               // the previous verification.
               val result = fixityChecker.check(badExpectedFixity)
               result shouldBe a[FileFixityMismatch]
-              result.asInstanceOf[FileFixityMismatch].e.getMessage should startWith("Cached verification tag doesn't match expected checksum")
+              result
+                .asInstanceOf[FileFixityMismatch]
+                .e
+                .getMessage should startWith(
+                "Cached verification tag doesn't match expected checksum"
+              )
               verify(spyStore, times(1)).get(location)
             }
           }
@@ -363,7 +379,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
             val spyStore: StreamStoreImpl = Mockito.spy(streamStore)
 
             withFixityChecker(spyStore) { fixityChecker =>
-              fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+              fixityChecker.check(expectedFileFixity) shouldBe a[
+                FileFixityCorrect
+              ]
 
               // StreamStore.get() should have been called to read the object so
               // it can be verified.
@@ -373,7 +391,10 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
               // the previous verification.
               val result = fixityChecker.check(badExpectedFixity)
               result shouldBe a[FileFixityMismatch]
-              result.asInstanceOf[FileFixityMismatch].e.getMessage should startWith("Lengths do not match")
+              result
+                .asInstanceOf[FileFixityMismatch]
+                .e
+                .getMessage should startWith("Lengths do not match")
               verify(spyStore, times(1)).get(location)
             }
           }
@@ -392,7 +413,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
           )
 
           withFixityChecker { fixityChecker =>
-            fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityMismatch]
+            fixityChecker.check(expectedFileFixity) shouldBe a[
+              FileFixityMismatch
+            ]
 
             fixityChecker.tags.get(location).right.value shouldBe Map.empty
           }
@@ -405,8 +428,16 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
 
       val allChecksums = Seq(
         Checksum(MD5, ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")),
-        Checksum(SHA1, ChecksumValue("db8ac1c259eb89d4a131b253bacfca5f319d54f2")),
-        Checksum(SHA256, ChecksumValue("872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4")),
+        Checksum(
+          SHA1,
+          ChecksumValue("db8ac1c259eb89d4a131b253bacfca5f319d54f2")
+        ),
+        Checksum(
+          SHA256,
+          ChecksumValue(
+            "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
+          )
+        )
       )
 
       withContext { implicit context =>
@@ -421,7 +452,9 @@ trait FixityCheckerTestCases[Namespace, Context, StreamStoreImpl <: StreamStore[
                 checksum = checksum
               )
 
-              fixityChecker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+              fixityChecker.check(expectedFileFixity) shouldBe a[
+                FileFixityCorrect
+              ]
             }
 
             fixityChecker.tags.get(location).right.value shouldBe Map(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -228,4 +228,30 @@ trait FixityCheckerTestCases[Namespace, Context]
       }
     }
   }
+
+  describe("handles tags") {
+    it("sets a tag on a successfully-verified object") {
+      true shouldBe false
+    }
+
+    it("skips checking if there's a matching tag from a previous verification") {
+      true shouldBe false
+    }
+
+    it("errors if there's a mismatched tag from a previous verification") {
+      true shouldBe false
+    }
+
+    it("errors if there's a matching tag but the size is wrong") {
+      true shouldBe false
+    }
+
+    it("doesn't set a tag if the verification fails") {
+      true shouldBe false
+    }
+
+    it("adds one tag per checksum algorithm") {
+      true shouldBe false
+    }
+  }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -9,8 +9,15 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
-import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationParsingError}
-import uk.ac.wellcome.platform.archive.common.verify.{Checksum, ChecksumValue, MD5}
+import uk.ac.wellcome.platform.archive.common.storage.{
+  LocateFailure,
+  LocationParsingError
+}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  Checksum,
+  ChecksumValue,
+  MD5
+}
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
 import uk.ac.wellcome.storage.streaming.Codec.stringCodec
@@ -81,21 +88,27 @@ class FixityCheckerTests
       val streamStore = MemoryStreamStore[ObjectLocation]()
 
       val tags = new MemoryTags[ObjectLocation](initialTags = Map.empty) {
-        override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+        override def get(
+          location: ObjectLocation
+        ): Either[ReadError, Map[String, String]] =
           super.get(location) match {
-            case Right(t)                => Right(t)
+            case Right(t)                   => Right(t)
             case Left(_: DoesNotExistError) => Right(Map[String, String]())
             case Left(err)                  => Left(err)
           }
 
-        override protected def put(location: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+        override protected def put(
+          location: ObjectLocation,
+          tags: Map[String, String]
+        ): Either[WriteError, Map[String, String]] =
           Left(
             StoreWriteError(new Throwable("BOOM!"))
           )
       }
 
       val contentString = "HelloWorld"
-      val checksum = Checksum(MD5, ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6"))
+      val checksum =
+        Checksum(MD5, ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6"))
 
       val location = createObjectLocation
 
@@ -103,7 +116,8 @@ class FixityCheckerTests
       streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
 
       val expectedFileFixity = createExpectedFileFixityWith(
-        location = location, checksum = checksum
+        location = location,
+        checksum = checksum
       )
 
       val checker = new MemoryFixityChecker(streamStore, tags) {
@@ -198,7 +212,9 @@ class FixityCheckerTests
 
   def createMemoryTags: MemoryTags[ObjectLocation] =
     new MemoryTags[ObjectLocation](initialTags = Map.empty) {
-      override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+      override def get(
+        location: ObjectLocation
+      ): Either[ReadError, Map[String, String]] =
         super.get(location) match {
           case Right(tags)                => Right(tags)
           case Left(_: DoesNotExistError) => Right(Map[String, String]())

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -20,6 +20,7 @@ import uk.ac.wellcome.platform.archive.common.verify.{
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
 import uk.ac.wellcome.storage.streaming.{Codec, InputStreamWithLength}
+import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class FixityCheckerTests
     extends AnyFunSpec
@@ -31,8 +32,9 @@ class FixityCheckerTests
   describe("handles errors correctly") {
     it("turns an error in locate() into a FileFixityCouldNotRead") {
       val streamStore = MemoryStreamStore[ObjectLocation]()
+      val tags = new MemoryTags[ObjectLocation](initialTags = Map.empty)
 
-      val brokenChecker = new MemoryFixityChecker(streamStore) {
+      val brokenChecker = new MemoryFixityChecker(streamStore, tags) {
         override def locate(
           uri: URI
         ): Either[LocateFailure[URI], ObjectLocation] =
@@ -67,7 +69,9 @@ class FixityCheckerTests
 
       val expectedFileFixity = createExpectedFileFixityWith(length = None)
 
-      val checker = new MemoryFixityChecker(streamStore) {
+      val tags = new MemoryTags[ObjectLocation](initialTags = Map.empty)
+
+      val checker = new MemoryFixityChecker(streamStore, tags) {
         override protected val sizeFinder: SizeFinder =
           (_: ObjectLocation) => Right(closedStream.length)
       }
@@ -110,7 +114,9 @@ class FixityCheckerTests
 
       val expectedFileFixity = createExpectedFileFixityWith(checksum = checksum)
 
-      val checker = new MemoryFixityChecker(streamStore) {
+      val tags = new MemoryTags[ObjectLocation](initialTags = Map.empty)
+
+      val checker = new MemoryFixityChecker(streamStore, tags) {
         override protected val sizeFinder: SizeFinder =
           (_: ObjectLocation) => Right(inputStream.length)
       }
@@ -144,7 +150,9 @@ class FixityCheckerTests
 
       val expectedFileFixity = createExpectedFileFixity
 
-      val checker = new MemoryFixityChecker(streamStore) {
+      val tags = new MemoryTags[ObjectLocation](initialTags = Map.empty)
+
+      val checker = new MemoryFixityChecker(streamStore, tags) {
         override protected val sizeFinder: SizeFinder =
           (_: ObjectLocation) => Right(inputStream.length)
       }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -8,33 +8,52 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityChecker,
   FixityCheckerTestCases
 }
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  ObjectLocation,
+  ReadError
+}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityCheckerTest
-    extends FixityCheckerTestCases[String, MemoryStreamStore[ObjectLocation]]
+    extends FixityCheckerTestCases[String, (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])]
     with EitherValues {
+  type MemoryContext = (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])
+
+  def createMemoryTags: MemoryTags[ObjectLocation] =
+    new MemoryTags[ObjectLocation](initialTags = Map.empty) {
+      override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+        super.get(location) match {
+          case Right(tags)                => Right(tags)
+          case Left(_: DoesNotExistError) => Right(Map[String, String]())
+          case Left(err)                  => Left(err)
+        }
+    }
+
   override def withContext[R](
-    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]
+    testWith: TestWith[MemoryContext, R]
   ): R =
-    testWith(
-      MemoryStreamStore[ObjectLocation]()
-    )
+    testWith((
+      MemoryStreamStore[ObjectLocation](),
+      createMemoryTags
+    ))
 
   override def putString(location: ObjectLocation, contents: String)(
-    implicit streamStore: MemoryStreamStore[ObjectLocation]
+    implicit context: MemoryContext
   ): Unit = {
+    val (streamStore, _) = context
     val inputStream = stringCodec.toStream(contents).right.value
     streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
   }
 
   override def withFixityChecker[R](
     testWith: TestWith[FixityChecker, R]
-  )(implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
-    testWith(
-      new MemoryFixityChecker(streamStore)
-    )
+  )(implicit context: MemoryContext): R = {
+    val (streamStore, tags) = context
+    testWith(new MemoryFixityChecker(streamStore, tags))
+  }
 
   override def createObjectLocationWith(namespace: String): ObjectLocation =
     ObjectLocation(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityCheckerTest
-    extends FixityCheckerTestCases[String, (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])]
+    extends FixityCheckerTestCases[String, (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation]), MemoryStreamStore[ObjectLocation]]
     with EitherValues {
   type MemoryContext = (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])
 
@@ -48,11 +48,16 @@ class MemoryFixityCheckerTest
     streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
   }
 
-  override def withFixityChecker[R](
-    testWith: TestWith[FixityChecker, R]
-  )(implicit context: MemoryContext): R = {
-    val (streamStore, tags) = context
-    testWith(new MemoryFixityChecker(streamStore, tags))
+  override def withStreamStore[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R])(implicit context: MemoryContext): R = {
+    val (streamStore, _) = context
+    testWith(streamStore)
+  }
+
+  override def withFixityChecker[R](streamStore: MemoryStreamStore[ObjectLocation])(testWith: TestWith[FixityChecker, R])(implicit context: MemoryContext): R = {
+    val (_, tags) = context
+    testWith(
+      new MemoryFixityChecker(streamStore, tags)
+    )
   }
 
   override def createObjectLocationWith(namespace: String): ObjectLocation =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -8,23 +8,26 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityChecker,
   FixityCheckerTestCases
 }
-import uk.ac.wellcome.storage.{
-  DoesNotExistError,
-  ObjectLocation,
-  ReadError
-}
+import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ReadError}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityCheckerTest
-    extends FixityCheckerTestCases[String, (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation]), MemoryStreamStore[ObjectLocation]]
+    extends FixityCheckerTestCases[
+      String,
+      (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation]),
+      MemoryStreamStore[ObjectLocation]
+    ]
     with EitherValues {
-  type MemoryContext = (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])
+  type MemoryContext =
+    (MemoryStreamStore[ObjectLocation], MemoryTags[ObjectLocation])
 
   def createMemoryTags: MemoryTags[ObjectLocation] =
     new MemoryTags[ObjectLocation](initialTags = Map.empty) {
-      override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+      override def get(
+        location: ObjectLocation
+      ): Either[ReadError, Map[String, String]] =
         super.get(location) match {
           case Right(tags)                => Right(tags)
           case Left(_: DoesNotExistError) => Right(Map[String, String]())
@@ -35,10 +38,12 @@ class MemoryFixityCheckerTest
   override def withContext[R](
     testWith: TestWith[MemoryContext, R]
   ): R =
-    testWith((
-      MemoryStreamStore[ObjectLocation](),
-      createMemoryTags
-    ))
+    testWith(
+      (
+        MemoryStreamStore[ObjectLocation](),
+        createMemoryTags
+      )
+    )
 
   override def putString(location: ObjectLocation, contents: String)(
     implicit context: MemoryContext
@@ -48,12 +53,18 @@ class MemoryFixityCheckerTest
     streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
   }
 
-  override def withStreamStore[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R])(implicit context: MemoryContext): R = {
+  override def withStreamStore[R](
+    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]
+  )(implicit context: MemoryContext): R = {
     val (streamStore, _) = context
     testWith(streamStore)
   }
 
-  override def withFixityChecker[R](streamStore: MemoryStreamStore[ObjectLocation])(testWith: TestWith[FixityChecker, R])(implicit context: MemoryContext): R = {
+  override def withFixityChecker[R](
+    streamStore: MemoryStreamStore[ObjectLocation]
+  )(
+    testWith: TestWith[FixityChecker, R]
+  )(implicit context: MemoryContext): R = {
     val (_, tags) = context
     testWith(
       new MemoryFixityChecker(streamStore, tags)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -34,7 +34,9 @@ class S3FixityCheckerTest
       contents
     )
 
-  override def withStreamStore[R](testWith: TestWith[S3StreamStore, R])(implicit context: Unit): R =
+  override def withStreamStore[R](
+    testWith: TestWith[S3StreamStore, R]
+  )(implicit context: Unit): R =
     testWith(
       new S3StreamStore()
     )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -15,10 +15,12 @@ import uk.ac.wellcome.platform.archive.common.storage.{
 }
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.fixtures.BucketNamespaceFixtures
+import uk.ac.wellcome.storage.store.s3.S3StreamStore
 
 class S3FixityCheckerTest
-    extends FixityCheckerTestCases[Bucket, Unit]
+    extends FixityCheckerTestCases[Bucket, Unit, S3StreamStore]
     with BucketNamespaceFixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
@@ -32,10 +34,19 @@ class S3FixityCheckerTest
       contents
     )
 
+  override def withStreamStore[R](testWith: TestWith[S3StreamStore, R])(implicit context: Unit): R =
+    testWith(
+      new S3StreamStore()
+    )
+
   override def withFixityChecker[R](
+    s3Store: S3StreamStore
+  )(
     testWith: TestWith[FixityChecker, R]
   )(implicit context: Unit): R =
-    testWith(new S3FixityChecker())
+    testWith(new S3FixityChecker() {
+      override val streamStore: StreamStore[ObjectLocation] = s3Store
+    })
 
   implicit val context: Unit = ()
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,7 @@ lazy val bag_verifier = setupProject(
   project,
   folder = "bag_verifier",
   localDependencies = Seq(common),
-  externalDependencies =
-    ExternalDependencies.mockitoDependencies
+  externalDependencies = ExternalDependencies.mockitoDependencies
 )
 
 lazy val bag_unpacker = setupProject(

--- a/build.sbt
+++ b/build.sbt
@@ -75,8 +75,13 @@ lazy val bag_tracker = setupProject(
   localDependencies = Seq(common)
 )
 
-lazy val bag_verifier =
-  setupProject(project, "bag_verifier", localDependencies = Seq(common))
+lazy val bag_verifier = setupProject(
+  project,
+  folder = "bag_verifier",
+  localDependencies = Seq(common),
+  externalDependencies =
+    ExternalDependencies.mockitoDependencies
+)
 
 lazy val bag_unpacker = setupProject(
   project,


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/storage-service/pull/581. For https://github.com/wellcomecollection/platform/issues/4562

Now it's been refactored, you can see how new methods `getExistingTags()`, `verifyChecksum()` and `writeFixityTags()` drop into the fixity checker.