### PR TITLE
Don't log an entire document when it fails to index

### DIFF
--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagIndexer.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagIndexer.scala
@@ -14,7 +14,7 @@ class BagIndexer(val client: ElasticClient, val index: Index)(
   val encoder: Encoder[IndexedStorageManifest]
 ) extends Indexer[StorageManifest, IndexedStorageManifest] {
 
-  override protected def id(storageManifest: StorageManifest): String =
+  override def id(storageManifest: StorageManifest): String =
     storageManifest.id.toString
 
   override protected def toDisplay(

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/Indexer.scala
@@ -20,7 +20,7 @@ trait Indexer[Document, DisplayDocument] extends Logging {
   implicit val indexable: Indexable[DisplayDocument] =
     (displayDocument: DisplayDocument) => toJson(displayDocument).get
 
-  protected def id(doc: Document): String
+  def id(doc: Document): String
   protected def toDisplay(doc: Document): DisplayDocument
   protected def version(doc: Document): Long
 

--- a/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/IndexerWorker.scala
+++ b/indexer/common/src/main/scala/uk/ac/wellcome/platform/archive/indexer/elasticsearch/IndexerWorker.scala
@@ -53,7 +53,7 @@ abstract class IndexerWorker[SourceT, T, IndexedT](
         Left(
           RetryableIndexingError(
             payload = t,
-            cause = new Exception(s"Error indexing $t")
+            cause = new Exception(s"Error indexing ${indexer.id(t)}")
           )
         )
     }

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/IngestIndexer.scala
@@ -14,7 +14,7 @@ class IngestIndexer(val client: ElasticClient, val index: Index)(
   val encoder: Encoder[IndexedIngest]
 ) extends Indexer[Ingest, IndexedIngest] {
 
-  override protected def id(ingest: Ingest): String =
+  override def id(ingest: Ingest): String =
     ingest.id.underlying.toString
 
   override protected def toDisplay(ingest: Ingest): IndexedIngest =


### PR DESCRIPTION
If the document is large, it completely spams the logging and makes it hard to find the actual error.

Spotted by @kenoir as part of https://github.com/wellcomecollection/platform/issues/4571