### PR TITLE
Add logic for deciding what objects in a bag should be tagged

### DIFF
--- a/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/BagTaggerWorker.scala
+++ b/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/BagTaggerWorker.scala
@@ -24,8 +24,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import uk.ac.wellcome.typesafe.Runnable
 
-case class BagTaggerOutput(foo: String)
-
 class BagTaggerWorker(
   val config: AlpakkaSQSWorkerConfig,
   val metricsNamespace: String

--- a/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
+++ b/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.storage.bag_tagger.services
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+
+/** Given a storage manifest, decide what tags (if any) should be applied to the
+  * objects in the bag.
+  *
+  */
+object TagRules {
+  def chooseTags(manifest: StorageManifest): Map[BagPath, Map[String, String]] =
+    contentTypeForMxfMasters(manifest)
+
+  // We keep high-resolution MXF masters in the digitised space.
+  //
+  // We keep them around in case we need to reencode the access copies in
+  // future, but we don't need immediate access to them.  We apply a tag
+  // so they can be lifecycled to a cold storage tier.
+  private def contentTypeForMxfMasters(manifest: StorageManifest): Map[BagPath, Map[String, String]] =
+    manifest.space.underlying match {
+      case "digitised" =>
+        manifest.manifest.files
+          .filter { _.path.toLowerCase.endsWith(".mxf") }
+          .map { manifestFile => BagPath(manifestFile.name) -> Map("Content-Type" -> "application/mxf") }
+          .toMap
+
+      case _ => Map.empty
+    }
+}

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.storage.bag_tagger.services
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
+import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+
+class TagRulesTest extends AnyFunSpec with Matchers with StorageManifestGenerators {
+  describe("Content-Type=application/mxf for MXF video masters") {
+    describe("it applies a tag") {
+      it("for MXFs in the digitised space") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(createStorageManifestFileWith(name = "b1234.mxf"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe Map(
+          BagPath("b1234.mxf") -> Map("Content-Type" -> "application/mxf")
+        )
+      }
+
+      it("whose file extension is uppercase") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(createStorageManifestFileWith(name = "b1234.MXF"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe Map(
+          BagPath("b1234.MXF") -> Map("Content-Type" -> "application/mxf")
+        )
+      }
+    }
+
+    describe("it does not apply a tag") {
+      it("to non-MXF files") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(createStorageManifestFileWith(name = "b1234.mp4"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe empty
+      }
+
+      it("to MXF files outside the digitised space") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("born-digital"),
+          files = Seq(createStorageManifestFileWith(name = "b1234.mxf"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe empty
+      }
+    }
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -51,7 +51,7 @@ trait StorageManifestGenerators
     version: BagVersion = createBagVersion,
     fileCount: Int = 3,
     createdDate: Instant = Instant.now,
-    files: List[StorageManifestFile] = Nil
+    files: Seq[StorageManifestFile] = Nil
   ): StorageManifest = {
 
     val pathPrefix = DestinationBuilder


### PR DESCRIPTION
I imagine we might add more tagging rules in the future, but I didn’t want to include any code for that until we do it. (`foldLeft … getOrElse … merge` ick). I think this approach is broadly extensible, if we do end up doing that – add more methods on `TagRules` as we need them.

Part of https://github.com/wellcomecollection/platform/issues/4570