### PR TITLE
Disambiguate more S3 locations

### DIFF
--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.storage.bags.api
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
@@ -13,11 +13,8 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.LargeResponses
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.storage.bags.api.responses.{
-  LookupBag,
-  LookupBagVersions
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.storage.bags.api.responses.{LookupBag, LookupBagVersions}
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 import scala.concurrent.duration._
 
@@ -75,10 +72,10 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
             case id if id == chemistAndDruggist =>
               val url = s3Uploader
                 .getPresignedGetURL(
-                  location = ObjectLocation(
-                    namespace =
+                  location = S3ObjectLocation(
+                    bucket =
                       "wellcomecollection-storage-prod-large-response-cache",
-                    path = "responses/digitised/b19974760/v1"
+                    key = "responses/digitised/b19974760/v1"
                   ),
                   expiryLength = 1 days
                 )

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.LargeResponses
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.storage.bags.api.responses.{LookupBag, LookupBagVersions}
+import uk.ac.wellcome.platform.storage.bags.api.responses.{
+  LookupBag,
+  LookupBagVersions
+}
 import uk.ac.wellcome.storage.S3ObjectLocation
 
 import scala.concurrent.duration._

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.platform.archive.common.config.builders._
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.http.{HttpMetrics, WellcomeHttpApp}
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -54,9 +54,9 @@ object Main extends WellcomeTypesafeApp {
       namespace = "responses"
     )
 
-    val locationPrefix = ObjectLocationPrefix(
-      s3Config.bucketName,
-      "responses"
+    val locationPrefix = S3ObjectLocationPrefix(
+      bucket = s3Config.bucketName,
+      keyPrefix = "responses"
     )
 
     val router: BagsApi = new BagsApi {
@@ -71,8 +71,9 @@ object Main extends WellcomeTypesafeApp {
         )
 
       override val s3Uploader: S3Uploader = uploader
+      override val s3Prefix: S3ObjectLocationPrefix = locationPrefix
+
       override val maximumResponseByteLength: Long = defaultMaxByteLength
-      override val prefix: ObjectLocationPrefix = locationPrefix
       override val cacheDuration: Duration = defaultCacheDuration
       override implicit val materializer: Materializer = matMain
     }

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.platform.archive.bag_tracker.client.{
 }
 import uk.ac.wellcome.platform.archive.common.config.builders._
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.archive.common.http.{
+  HttpMetrics,
+  WellcomeHttpApp
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.typesafe.S3Builder

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -13,11 +13,8 @@ import uk.ac.wellcome.platform.archive.bag_tracker.client.{
 }
 import uk.ac.wellcome.platform.archive.common.config.builders._
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.{
-  HttpMetrics,
-  WellcomeHttpApp
-}
-import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
+import uk.ac.wellcome.platform.archive.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -118,7 +118,7 @@ class LookupBagApiTest
       withLocalS3Bucket { bucket =>
         withConfiguredApp(
           initialManifests = Seq(storageManifest),
-          locationPrefix = createObjectLocationPrefixWith(bucket.name),
+          locationPrefix = createS3ObjectLocationPrefixWith(bucket),
           maxResponseByteLength = 1000
         ) {
           case (_, metrics, baseUrl) =>
@@ -154,7 +154,7 @@ class LookupBagApiTest
       withLocalS3Bucket { bucket =>
         withConfiguredApp(
           initialManifests = Seq(storageManifest),
-          locationPrefix = createObjectLocationPrefixWith(bucket.name),
+          locationPrefix = createS3ObjectLocationPrefixWith(bucket),
           maxResponseByteLength = 1000
         ) {
           case (_, metrics, baseUrl) =>

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -76,7 +76,7 @@ trait BagsApiFixture
 
             override val s3Uploader: S3Uploader = uploader
             override val cacheDuration: Duration = 1 days
-            override val prefix: ObjectLocationPrefix = locationPrefix
+            override val s3Prefix: ObjectLocationPrefix = locationPrefix
 
             override implicit val materializer: Materializer = mat
             override val maximumResponseByteLength: Long = maxResponseByteLength

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -29,7 +29,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
 }
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
@@ -41,7 +41,7 @@ trait BagsApiFixture
     extends StorageRandomThings
     with ScalaFutures
     with StorageManifestDaoFixture
-    with S3Fixtures
+    with NewS3Fixtures
     with HttpFixtures
     with BagTrackerFixtures {
 
@@ -54,7 +54,7 @@ trait BagsApiFixture
   private def withApp[R](
     metrics: MemoryMetrics[Unit],
     maxResponseByteLength: Long,
-    locationPrefix: ObjectLocationPrefix,
+    locationPrefix: S3ObjectLocationPrefix,
     storageManifestDao: StorageManifestDao,
     uploader: S3Uploader
   )(testWith: TestWith[WellcomeHttpApp, R]): R =
@@ -75,9 +75,9 @@ trait BagsApiFixture
             override val bagTrackerClient: BagTrackerClient = trackerClient
 
             override val s3Uploader: S3Uploader = uploader
-            override val cacheDuration: Duration = 1 days
-            override val s3Prefix: ObjectLocationPrefix = locationPrefix
+            override val s3Prefix: S3ObjectLocationPrefix = locationPrefix
 
+            override val cacheDuration: Duration = 1 days
             override implicit val materializer: Materializer = mat
             override val maximumResponseByteLength: Long = maxResponseByteLength
           }
@@ -99,7 +99,7 @@ trait BagsApiFixture
 
   def withConfiguredApp[R](
     initialManifests: Seq[StorageManifest] = Seq.empty,
-    locationPrefix: ObjectLocationPrefix = createObjectLocationPrefix,
+    locationPrefix: S3ObjectLocationPrefix = createS3ObjectLocationPrefix,
     maxResponseByteLength: Long = 1048576
   )(
     testWith: TestWith[(StorageManifestDao, MemoryMetrics[Unit], String), R]
@@ -155,7 +155,7 @@ trait BagsApiFixture
 
     val metrics = new MemoryMetrics[Unit]()
     val maxResponseByteLength = 1048576
-    val prefix = createObjectLocationPrefix
+    val prefix = createS3ObjectLocationPrefix
     val uploader = new S3Uploader()
 
     withApp(metrics, maxResponseByteLength, prefix, brokenDao, uploader) { _ =>

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -22,9 +22,9 @@ import uk.ac.wellcome.platform.archive.common.http.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
+import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
 import uk.ac.wellcome.platform.archive.common.storage.services.{
   EmptyMetadata,
-  S3Uploader,
   StorageManifestDao
 }
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
-import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocation}
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.concurrent.duration.Duration
@@ -21,8 +21,9 @@ trait LargeResponses extends Logging {
   import akka.stream.scaladsl.StreamConverters
 
   val s3Uploader: S3Uploader
+  val s3Prefix: S3ObjectLocationPrefix
+
   val maximumResponseByteLength: Long
-  val prefix: ObjectLocationPrefix
   val cacheDuration: Duration
 
   private val converter = StreamConverters.asInputStream()
@@ -45,7 +46,7 @@ trait LargeResponses extends Logging {
             s"Attempting to return large object ($length > $maximumResponseByteLength): assigning key $storageKey"
         )
 
-        val objectLocation = prefix.asLocation(storageKey)
+        val objectLocation = s3Prefix.asLocation(storageKey)
 
         val inputStream = response.entity
           .getDataBytes()
@@ -57,7 +58,7 @@ trait LargeResponses extends Logging {
         )
 
         val uploaded = s3Uploader.uploadAndGetURL(
-          location = S3ObjectLocation(objectLocation),
+          location = objectLocation,
           content = content,
           expiryLength = cacheDuration,
           checkExists = true

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Directives.mapResponse
 import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
+import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocation}
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.concurrent.duration.Duration
@@ -57,7 +57,7 @@ trait LargeResponses extends Logging {
         )
 
         val uploaded = s3Uploader.uploadAndGetURL(
-          location = objectLocation,
+          location = S3ObjectLocation(objectLocation),
           content = content,
           expiryLength = cacheDuration,
           checkExists = true

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/ObjectExists.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import uk.ac.wellcome.storage.{ObjectLocation, StorageError}
+import uk.ac.wellcome.storage.StorageError
 
-trait ObjectExists {
-  def exists(objectLocation: ObjectLocation): Either[StorageError, Boolean]
+trait ObjectExists[Ident] {
+  def exists(id: Ident): Either[StorageError, Boolean]
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/ObjectExists.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.platform.archive.common.storage.services
+
+import uk.ac.wellcome.storage.{ObjectLocation, StorageError}
+
+trait ObjectExists {
+  def exists(objectLocation: ObjectLocation): Either[StorageError, Boolean]
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success, Try}
   * https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURLJavaSDK.html
   */
 class S3Uploader(implicit val s3Client: AmazonS3) {
-  import S3ObjectExists._
+  import s3.S3ObjectExists._
 
   private val s3StreamStore: S3StreamStore = new S3StreamStore()
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -34,7 +34,7 @@ class S3Uploader(implicit val s3Client: AmazonS3) {
     checkExists: Boolean
   ): Either[StorageError, URL] =
     for {
-      exists <- location.exists
+      exists <- S3ObjectLocation(location).exists
 
       _ <- if (!exists || !checkExists) {
         s3StreamStore.put(location)(content)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
@@ -2,19 +2,14 @@ package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.common.storage.services.ObjectExists
-import uk.ac.wellcome.storage.{ObjectLocation, StoreReadError}
+import uk.ac.wellcome.storage.{S3ObjectLocation, StoreReadError}
 
 import scala.util.{Failure, Success, Try}
 
-class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists[ObjectLocation] {
-  override def exists(
-    objectLocation: ObjectLocation
-  ): Either[StoreReadError, Boolean] =
+class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists[S3ObjectLocation] {
+  override def exists(location: S3ObjectLocation): Either[StoreReadError, Boolean] =
     Try {
-      s3Client.doesObjectExist(
-        objectLocation.namespace,
-        objectLocation.path
-      )
+      s3Client.doesObjectExist(location.bucket, location.key)
     } match {
       case Success(exists) => Right(exists)
       case Failure(e)      => Left(StoreReadError(e))
@@ -22,12 +17,12 @@ class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists[ObjectLocation] {
 }
 
 object S3ObjectExists {
-  implicit class S3ObjectExistsImplicit(objectLocation: ObjectLocation)(
+  implicit class S3ObjectExistsImplicit(location: S3ObjectLocation)(
     implicit s3Client: AmazonS3
   ) {
     val s3ObjectExists = new S3ObjectExists(s3Client)
 
     def exists: Either[StoreReadError, Boolean] =
-      s3ObjectExists.exists(objectLocation)
+      s3ObjectExists.exists(location)
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
@@ -6,8 +6,11 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, StoreReadError}
 
 import scala.util.{Failure, Success, Try}
 
-class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists[S3ObjectLocation] {
-  override def exists(location: S3ObjectLocation): Either[StoreReadError, Boolean] =
+class S3ObjectExists(s3Client: AmazonS3)
+    extends ObjectExists[S3ObjectLocation] {
+  override def exists(
+    location: S3ObjectLocation
+  ): Either[StoreReadError, Boolean] =
     Try {
       s3Client.doesObjectExist(location.bucket, location.key)
     } match {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.storage.{ObjectLocation, StoreReadError}
 
 import scala.util.{Failure, Success, Try}
 
-class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists {
+class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists[ObjectLocation] {
   override def exists(
     objectLocation: ObjectLocation
   ): Either[StoreReadError, Boolean] =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExists.scala
@@ -1,13 +1,10 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.storage.{ObjectLocation, StorageError, StoreReadError}
+import uk.ac.wellcome.platform.archive.common.storage.services.ObjectExists
+import uk.ac.wellcome.storage.{ObjectLocation, StoreReadError}
 
 import scala.util.{Failure, Success, Try}
-
-trait ObjectExists {
-  def exists(objectLocation: ObjectLocation): Either[StorageError, Boolean]
-}
 
 class S3ObjectExists(s3Client: AmazonS3) extends ObjectExists {
   override def exists(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3Uploader.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import java.net.URL
 import java.util
@@ -6,10 +6,11 @@ import java.util
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
+import uk.ac.wellcome.platform.archive.common.storage.services.s3
+import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.streaming.Codec.stringCodec
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage._
 
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -1,6 +1,11 @@
 package uk.ac.wellcome.storage
+import java.nio.file.Paths
 
 trait Location
+
+trait Prefix[OfLocation <: Location] {
+  def asLocation(parts: String*): OfLocation
+}
 
 case class S3ObjectLocation(
   bucket: String,
@@ -20,3 +25,14 @@ case object S3ObjectLocation {
       key = location.path
     )
 }
+
+case class S3ObjectLocationPrefix(
+  bucket: String,
+  keyPrefix: String
+) extends Prefix[S3ObjectLocation] {
+    override def asLocation(parts: String*): S3ObjectLocation =
+      S3ObjectLocation(
+        bucket = bucket,
+        key = Paths.get(keyPrefix, parts: _*).normalize().toString
+      )
+  }

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -5,7 +5,13 @@ trait Location
 case class S3ObjectLocation(
   bucket: String,
   key: String
-) extends Location
+) extends Location {
+  def toObjectLocation: ObjectLocation =
+    ObjectLocation(
+      namespace = this.bucket,
+      path = this.key
+    )
+}
 
 case object S3ObjectLocation {
   def apply(location: ObjectLocation): S3ObjectLocation =

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -30,9 +30,9 @@ case class S3ObjectLocationPrefix(
   bucket: String,
   keyPrefix: String
 ) extends Prefix[S3ObjectLocation] {
-    override def asLocation(parts: String*): S3ObjectLocation =
-      S3ObjectLocation(
-        bucket = bucket,
-        key = Paths.get(keyPrefix, parts: _*).normalize().toString
-      )
-  }
+  override def asLocation(parts: String*): S3ObjectLocation =
+    S3ObjectLocation(
+      bucket = bucket,
+      key = Paths.get(keyPrefix, parts: _*).normalize().toString
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -17,8 +17,8 @@ import akka.stream.scaladsl.StreamConverters
 import org.apache.commons.io.IOUtils
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.fixtures.{TestWith}
-import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -19,7 +19,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.generators.RandomThings
@@ -176,15 +176,17 @@ class LargeResponsesTest
 
     val uploader = new S3Uploader()
 
-    val objectLocationPrefix =
-      ObjectLocationPrefix(bucket.name, prefix)
-
     val duration = 30 seconds
 
     val largeResponder = new LargeResponses {
       override val s3Uploader: S3Uploader = uploader
+      override val s3Prefix: S3ObjectLocationPrefix =
+        S3ObjectLocationPrefix(
+          bucket = bucket.name,
+          keyPrefix = prefix
+        )
+
       override val maximumResponseByteLength: Long = maxBytes
-      override val prefix: ObjectLocationPrefix = objectLocationPrefix
       override val cacheDuration: Duration = duration
       override implicit val materializer: Materializer = mat
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExistsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExistsTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExistsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3ObjectExistsTest.scala
@@ -5,10 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.storage.StorageError
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
-class S3ObjectExistsTest
-    extends AnyFunSpec
-    with Matchers
-    with NewS3Fixtures {
+class S3ObjectExistsTest extends AnyFunSpec with Matchers with NewS3Fixtures {
 
   import S3ObjectExists._
 
@@ -50,9 +47,9 @@ class S3ObjectExistsTest
       it("with a broken s3 client") {
         val location = createS3ObjectLocation
 
-        val existsCheck = new S3ObjectExists
-          .S3ObjectExistsImplicit(location)(brokenS3Client)
-          .exists
+        val existsCheck = new S3ObjectExists.S3ObjectExistsImplicit(location)(
+          brokenS3Client
+        ).exists
 
         existsCheck.left.value shouldBe a[StorageError]
       }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
@@ -13,10 +13,7 @@ import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import scala.concurrent.duration._
 import scala.io.Source
 
-class S3UploaderTest
-    extends AnyFunSpec
-    with Matchers
-    with NewS3Fixtures {
+class S3UploaderTest extends AnyFunSpec with Matchers with NewS3Fixtures {
   val uploader = new S3Uploader()
 
   it("creates a pre-signed URL for an object") {
@@ -35,8 +32,6 @@ class S3UploaderTest
       getUrl(url) shouldBe content
     }
   }
-
-
 
   it("will not update an existing stored object if instructed so") {
     val content = randomAlphanumeric

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import java.io.IOException
 import java.net.URL

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3UploaderTest.scala
@@ -2,13 +2,13 @@ package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
 import java.io.IOException
 import java.net.URL
+import java.util.Date
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
-import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 import scala.concurrent.duration._
 import scala.io.Source
@@ -16,8 +16,7 @@ import scala.io.Source
 class S3UploaderTest
     extends AnyFunSpec
     with Matchers
-    with S3Fixtures
-    with EitherValues {
+    with NewS3Fixtures {
   val uploader = new S3Uploader()
 
   it("creates a pre-signed URL for an object") {
@@ -26,7 +25,7 @@ class S3UploaderTest
     withLocalS3Bucket { bucket =>
       val url = uploader
         .uploadAndGetURL(
-          location = createObjectLocationWith(bucket),
+          location = createS3ObjectLocationWith(bucket),
           content = content,
           expiryLength = 5.minutes
         )
@@ -37,27 +36,24 @@ class S3UploaderTest
     }
   }
 
+
+
   it("will not update an existing stored object if instructed so") {
     val content = randomAlphanumeric
 
     withLocalS3Bucket { bucket =>
-      val objectLocation = createObjectLocationWith(bucket)
+      val location = createS3ObjectLocationWith(bucket)
 
       val url = uploader
         .uploadAndGetURL(
-          location = objectLocation,
+          location = location,
           content = content,
           expiryLength = 5.minutes
         )
         .right
         .value
 
-      val lastModified = s3Client
-        .getObjectMetadata(
-          objectLocation.namespace,
-          objectLocation.path
-        )
-        .getLastModified()
+      val lastModified = getLastModified(location)
 
       getUrl(url) shouldBe content
 
@@ -65,7 +61,7 @@ class S3UploaderTest
 
       val newUrl = uploader
         .uploadAndGetURL(
-          location = objectLocation,
+          location = location,
           content = content,
           expiryLength = 5.minutes,
           checkExists = true
@@ -73,12 +69,7 @@ class S3UploaderTest
         .right
         .value
 
-      val newLastModified = s3Client
-        .getObjectMetadata(
-          objectLocation.namespace,
-          objectLocation.path
-        )
-        .getLastModified()
+      val newLastModified = getLastModified(location)
 
       newUrl shouldNot equal(url)
       lastModified shouldBe newLastModified
@@ -91,23 +82,18 @@ class S3UploaderTest
     val content = randomAlphanumeric
 
     withLocalS3Bucket { bucket =>
-      val objectLocation = createObjectLocationWith(bucket)
+      val location = createS3ObjectLocationWith(bucket)
 
       val url = uploader
         .uploadAndGetURL(
-          location = objectLocation,
+          location = location,
           content = content,
           expiryLength = 5.minutes
         )
         .right
         .value
 
-      val lastModified = s3Client
-        .getObjectMetadata(
-          objectLocation.namespace,
-          objectLocation.path
-        )
-        .getLastModified()
+      val lastModified = getLastModified(location)
 
       getUrl(url) shouldBe content
 
@@ -115,19 +101,14 @@ class S3UploaderTest
 
       val newUrl = uploader
         .uploadAndGetURL(
-          location = objectLocation,
+          location = location,
           content = content,
           expiryLength = 5.minutes
         )
         .right
         .value
 
-      val newLastModified = s3Client
-        .getObjectMetadata(
-          objectLocation.namespace,
-          objectLocation.path
-        )
-        .getLastModified()
+      val newLastModified = getLastModified(location)
 
       newUrl shouldNot equal(url)
 
@@ -149,7 +130,7 @@ class S3UploaderTest
       // consider bumping the expiryLength.
       val url = uploader
         .uploadAndGetURL(
-          location = createObjectLocationWith(bucket),
+          location = createS3ObjectLocationWith(bucket),
           content = content,
           expiryLength = 3.seconds
         )
@@ -173,7 +154,7 @@ class S3UploaderTest
   it("fails if it cannot upload to the bucket") {
     val err = uploader
       .uploadAndGetURL(
-        location = createObjectLocationWith(createBucket),
+        location = createS3ObjectLocation,
         content = randomAlphanumeric,
         expiryLength = 5.minutes
       )
@@ -190,4 +171,12 @@ class S3UploaderTest
 
   def getUrl(url: URL): String =
     Source.fromURL(url).mkString
+
+  def getLastModified(location: S3ObjectLocation): Date =
+    s3Client
+      .getObjectMetadata(
+        location.bucket,
+        location.key
+      )
+      .getLastModified
 }

--- a/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.storage.fixtures
 
-import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  ObjectLocation,
+  S3ObjectLocation,
+  S3ObjectLocationPrefix
+}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
@@ -27,11 +31,12 @@ trait NewS3Fixtures extends S3Fixtures {
   def createS3ObjectLocationPrefix: S3ObjectLocationPrefix =
     createS3ObjectLocationPrefixWith()
 
-  def putS3Object(
-    location: S3ObjectLocation): Unit =
+  def putS3Object(location: S3ObjectLocation): Unit =
     putStream(
-      location = ObjectLocation(namespace = location.bucket, path = location.key),
-      inputStream = new InputStreamWithLength(randomInputStream(length = 20), length = 20)
+      location =
+        ObjectLocation(namespace = location.bucket, path = location.key),
+      inputStream =
+        new InputStreamWithLength(randomInputStream(length = 20), length = 20)
     )
 
   def createInvalidBucket: Bucket =

--- a/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.storage.fixtures
 
-import uk.ac.wellcome.storage.S3ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocation}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 trait NewS3Fixtures extends S3Fixtures {
   def createS3ObjectLocationWith(
@@ -14,4 +15,14 @@ trait NewS3Fixtures extends S3Fixtures {
 
   def createS3ObjectLocation: S3ObjectLocation =
     createS3ObjectLocationWith()
+
+  def putS3Object(
+    location: S3ObjectLocation): Unit =
+    putStream(
+      location = ObjectLocation(namespace = location.bucket, path = location.key),
+      inputStream = new InputStreamWithLength(randomInputStream(length = 20), length = 20)
+    )
+
+  def createInvalidBucket: Bucket =
+    Bucket(createInvalidBucketName)
 }

--- a/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.storage.fixtures
 
-import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocation}
+import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
@@ -15,6 +15,17 @@ trait NewS3Fixtures extends S3Fixtures {
 
   def createS3ObjectLocation: S3ObjectLocation =
     createS3ObjectLocationWith()
+
+  def createS3ObjectLocationPrefixWith(
+    bucket: Bucket = createBucket
+  ): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = bucket.name,
+      keyPrefix = randomAlphanumeric
+    )
+
+  def createS3ObjectLocationPrefix: S3ObjectLocationPrefix =
+    createS3ObjectLocationPrefixWith()
 
   def putS3Object(
     location: S3ObjectLocation): Unit =


### PR DESCRIPTION
Part of wellcomecollection/platform#4596; follows #600

This patch:

* Disambiguates ObjectExists and S3ObjectExists (which could be upstreamed)
* Starts to introduce the Prefix/Location hierarchy
* Enforces S3-only in S3Uploader and LargeResponses