### PR TITLE
Move S3BagLocator into the bag root finder; use new S3 Locations

### DIFF
--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
@@ -9,9 +9,8 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepResult,
   IngestStepSucceeded
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.storage.bag_root_finder.models._
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
 
@@ -27,7 +26,7 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
     Try {
       val startTime = Instant.now()
 
-      s3BagLocator.locateBagRoot(unpackLocation) match {
+      s3BagLocator.locateBagRoot(S3ObjectLocationPrefix(unpackLocation)) match {
         case Success(rootLocation) =>
           IngestStepSucceeded(
             RootFinderSuccessSummary(
@@ -35,7 +34,7 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
               startTime = startTime,
               endTime = Instant.now(),
               location = unpackLocation,
-              rootLocation = rootLocation
+              rootLocation = rootLocation.toObjectLocationPrefix
             )
           )
 

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocator.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocator.scala
@@ -40,8 +40,10 @@ class S3BagLocator(s3Client: AmazonS3) extends Logging {
     val bagInfoInDirectory = findBagInfoInDirectory(prefix)
 
     (bagInfoInRoot, bagInfoInDirectory) match {
-      case (Success(bagInfoKey), _) => Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
-      case (_, Success(bagInfoKey)) => Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
+      case (Success(bagInfoKey), _) =>
+        Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
+      case (_, Success(bagInfoKey)) =>
+        Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
       case (Failure(rootErr), Failure(dirError)) => {
         warn(s"Could not find bag in root: ${rootErr.getMessage}")
         warn(s"Could not find bag in subdir: ${dirError.getMessage}")
@@ -50,7 +52,9 @@ class S3BagLocator(s3Client: AmazonS3) extends Logging {
     }
   }
 
-  def locateBagRoot(prefix: S3ObjectLocationPrefix): Try[S3ObjectLocationPrefix] =
+  def locateBagRoot(
+    prefix: S3ObjectLocationPrefix
+  ): Try[S3ObjectLocationPrefix] =
     locateBagInfo(prefix).map { loc =>
       loc.copy(key = loc.key.stripSuffix("/bag-info.txt")).asPrefix
     }

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocator.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocator.scala
@@ -1,9 +1,9 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.storage.bag_root_finder.services
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsV2Request
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -35,13 +35,13 @@ import scala.util.{Failure, Success, Try}
   *
   */
 class S3BagLocator(s3Client: AmazonS3) extends Logging {
-  def locateBagInfo(prefix: ObjectLocationPrefix): Try[ObjectLocation] = {
+  def locateBagInfo(prefix: S3ObjectLocationPrefix): Try[S3ObjectLocation] = {
     val bagInfoInRoot = findBagInfoInRoot(prefix)
     val bagInfoInDirectory = findBagInfoInDirectory(prefix)
 
     (bagInfoInRoot, bagInfoInDirectory) match {
-      case (Success(path), _) => Success(prefix.copy(path = path).asLocation())
-      case (_, Success(path)) => Success(prefix.copy(path = path).asLocation())
+      case (Success(bagInfoKey), _) => Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
+      case (_, Success(bagInfoKey)) => Success(prefix.copy(keyPrefix = bagInfoKey).asLocation())
       case (Failure(rootErr), Failure(dirError)) => {
         warn(s"Could not find bag in root: ${rootErr.getMessage}")
         warn(s"Could not find bag in subdir: ${dirError.getMessage}")
@@ -50,23 +50,23 @@ class S3BagLocator(s3Client: AmazonS3) extends Logging {
     }
   }
 
-  def locateBagRoot(prefix: ObjectLocationPrefix): Try[ObjectLocationPrefix] =
+  def locateBagRoot(prefix: S3ObjectLocationPrefix): Try[S3ObjectLocationPrefix] =
     locateBagInfo(prefix).map { loc =>
-      loc.copy(path = loc.path.stripSuffix("/bag-info.txt")).asPrefix
+      loc.copy(key = loc.key.stripSuffix("/bag-info.txt")).asPrefix
     }
 
   /** Find a bag directly below a given ObjectLocation. */
-  private def findBagInfoInRoot(prefix: ObjectLocationPrefix): Try[String] =
+  private def findBagInfoInRoot(prefix: S3ObjectLocationPrefix): Try[String] =
     Try {
       val listObjectsResult = s3Client.listObjectsV2(
-        prefix.namespace,
-        createBagInfoPath(prefix.path)
+        prefix.bucket,
+        createBagInfoPath(prefix.keyPrefix)
       )
 
       val keyCount = listObjectsResult.getObjectSummaries.size()
 
       if (keyCount == 1) {
-        createBagInfoPath(prefix.path)
+        createBagInfoPath(prefix.keyPrefix)
       } else {
         throw new RuntimeException(s"No bag-info.txt inside $prefix")
       }
@@ -77,11 +77,11 @@ class S3BagLocator(s3Client: AmazonS3) extends Logging {
     *
     */
   private def findBagInfoInDirectory(
-    prefix: ObjectLocationPrefix
+    prefix: S3ObjectLocationPrefix
   ): Try[String] = Try {
     val listObjectsRequest = new ListObjectsV2Request()
-      .withBucketName(prefix.namespace)
-      .withPrefix(prefix.path + "/")
+      .withBucketName(prefix.bucket)
+      .withPrefix(prefix.keyPrefix + "/")
       .withDelimiter("/")
 
     val directoriesInBag =
@@ -89,7 +89,7 @@ class S3BagLocator(s3Client: AmazonS3) extends Logging {
 
     if (directoriesInBag.size == 1) {
       val directoryLocation = prefix.copy(
-        path = directoriesInBag.head
+        keyPrefix = directoriesInBag.head
       )
 
       findBagInfoInRoot(directoryLocation) match {

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocatorTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocatorTest.scala
@@ -1,15 +1,15 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.storage.bag_root_finder.services
 
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.storage.ObjectLocationPrefix
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 import scala.util.Success
 
-class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
+class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
   describe("locateBagInfo") {
     it("locates a bag-info.txt file in the root") {
       withLocalS3Bucket { bucket =>
@@ -20,10 +20,10 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/data/2.jpg"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
-          createObjectLocationWith(bucket, "bag123/bag-info.txt")
+          createS3ObjectLocationWith(bucket, key = "bag123/bag-info.txt")
         )
       }
     }
@@ -37,10 +37,10 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
-          createObjectLocationWith(bucket, "bag123/subdir/bag-info.txt")
+          createS3ObjectLocationWith(bucket, key = "bag123/subdir/bag-info.txt")
         )
       }
     }
@@ -55,10 +55,10 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
-          createObjectLocationWith(bucket, "bag123/bag-info.txt")
+          createS3ObjectLocationWith(bucket, key = "bag123/bag-info.txt")
         )
       }
     }
@@ -71,7 +71,7 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/subdir2/bag-info.txt"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
@@ -80,7 +80,7 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
       withLocalS3Bucket { bucket =>
         createObjectsWith(bucket, "bag123/subdir/1.jpg", "bag123/subdir/2.jpg")
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
@@ -89,20 +89,20 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
       withLocalS3Bucket { bucket =>
         createObjectsWith(bucket, "bag123/subdir/nesteddir/bag-info.txt")
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
 
     it("fails if it cannot find a bag-info.txt") {
       withLocalS3Bucket { bucket =>
-        val prefix = createObjectLocationPrefixWith(bucket, "doesnotexist")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
         assertFailsToFindBagIn(prefix)
       }
     }
 
     it("fails if the bucket does not exist") {
-      val prefix = createObjectLocationPrefixWith("doesnotexist")
+      val prefix = createS3ObjectLocationPrefixWith(bucket = createBucket)
       assertFailsToFindBagIn(prefix)
     }
   }
@@ -117,7 +117,7 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/data/2.jpg"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagRoot(prefix) shouldBe Success(prefix)
       }
@@ -132,17 +132,17 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createObjectLocationPrefixWith(bucket, "bag123")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagRoot(prefix) shouldBe Success(
-          createObjectLocationPrefixWith(bucket, "bag123/subdir")
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123/subdir")
         )
       }
     }
 
     it("fails if it cannot find a bag-info.txt") {
       withLocalS3Bucket { bucket =>
-        val prefix = createObjectLocationPrefixWith(bucket, "doesnotexist")
+        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
 
         val result = s3BagLocator.locateBagRoot(prefix)
         result.isFailure shouldBe true
@@ -154,7 +154,7 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with S3Fixtures {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   private def assertFailsToFindBagIn(
-    prefix: ObjectLocationPrefix
+    prefix: S3ObjectLocationPrefix
   ): Assertion = {
     val result = s3BagLocator.locateBagInfo(prefix)
     result.isFailure shouldBe true

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocatorTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/S3BagLocatorTest.scala
@@ -20,7 +20,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/data/2.jpg"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
           createS3ObjectLocationWith(bucket, key = "bag123/bag-info.txt")
@@ -37,7 +38,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
           createS3ObjectLocationWith(bucket, key = "bag123/subdir/bag-info.txt")
@@ -55,7 +57,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagInfo(prefix) shouldBe Success(
           createS3ObjectLocationWith(bucket, key = "bag123/bag-info.txt")
@@ -71,7 +74,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/subdir2/bag-info.txt"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
@@ -80,7 +84,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
       withLocalS3Bucket { bucket =>
         createObjectsWith(bucket, "bag123/subdir/1.jpg", "bag123/subdir/2.jpg")
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
@@ -89,14 +94,16 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
       withLocalS3Bucket { bucket =>
         createObjectsWith(bucket, "bag123/subdir/nesteddir/bag-info.txt")
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
         assertFailsToFindBagIn(prefix)
       }
     }
 
     it("fails if it cannot find a bag-info.txt") {
       withLocalS3Bucket { bucket =>
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
         assertFailsToFindBagIn(prefix)
       }
     }
@@ -117,7 +124,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/data/2.jpg"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagRoot(prefix) shouldBe Success(prefix)
       }
@@ -132,7 +140,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
           "bag123/subdir/data/2.jpg"
         )
 
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123")
 
         s3BagLocator.locateBagRoot(prefix) shouldBe Success(
           createS3ObjectLocationPrefixWith(bucket, keyPrefix = "bag123/subdir")
@@ -142,7 +151,8 @@ class S3BagLocatorTest extends AnyFunSpec with Matchers with NewS3Fixtures {
 
     it("fails if it cannot find a bag-info.txt") {
       withLocalS3Bucket { bucket =>
-        val prefix = createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
+        val prefix =
+          createS3ObjectLocationPrefixWith(bucket, keyPrefix = "doesnotexist")
 
         val result = s3BagLocator.locateBagRoot(prefix)
         result.isFailure shouldBe true

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -16,6 +16,12 @@ case class S3ObjectLocation(
       namespace = this.bucket,
       path = this.key
     )
+
+  def asPrefix: S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = this.bucket,
+      keyPrefix = this.key
+    )
 }
 
 case object S3ObjectLocation {
@@ -34,5 +40,19 @@ case class S3ObjectLocationPrefix(
     S3ObjectLocation(
       bucket = bucket,
       key = Paths.get(keyPrefix, parts: _*).normalize().toString
+    )
+
+  def toObjectLocationPrefix: ObjectLocationPrefix =
+    ObjectLocationPrefix(
+      namespace = this.bucket,
+      path = this.keyPrefix
+    )
+}
+
+case object S3ObjectLocationPrefix {
+  def apply(location: ObjectLocationPrefix): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = location.namespace,
+      keyPrefix = location.path
     )
 }

--- a/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
@@ -10,22 +10,24 @@ import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 trait NewS3Fixtures extends S3Fixtures {
   def createS3ObjectLocationWith(
-    bucket: Bucket = createBucket
+    bucket: Bucket = createBucket,
+    key: String = randomAlphanumeric
   ): S3ObjectLocation =
     S3ObjectLocation(
       bucket = bucket.name,
-      key = randomAlphanumeric
+      key = key
     )
 
   def createS3ObjectLocation: S3ObjectLocation =
     createS3ObjectLocationWith()
 
   def createS3ObjectLocationPrefixWith(
-    bucket: Bucket = createBucket
+    bucket: Bucket = createBucket,
+    keyPrefix: String = randomAlphanumeric
   ): S3ObjectLocationPrefix =
     S3ObjectLocationPrefix(
       bucket = bucket.name,
-      keyPrefix = randomAlphanumeric
+      keyPrefix = keyPrefix
     )
 
   def createS3ObjectLocationPrefix: S3ObjectLocationPrefix =


### PR DESCRIPTION
The bag root finder is now using S3ObjectLocation internally; swapping the inter-app payloads is a bit more dicey and should be done separately.

Part of wellcomecollection/platform#4596