### PR TITLE
Disambiguate the creation of S3 bags in our tests

### DIFF
--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.bags.models.PrimaryBagReplicationRequest
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.common.ReplicaResultPayload
-import uk.ac.wellcome.platform.archive.common.fixtures.S3BagBuilder
+import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.storage.models.PrimaryStorageLocation
@@ -22,7 +22,8 @@ class BagReplicatorFeatureTest
     with Eventually
     with BagReplicatorFixtures
     with IngestUpdateAssertions
-    with PayloadGenerators {
+    with PayloadGenerators
+    with S3BagBuilder {
 
   it("replicates a bag successfully and updates both topics") {
     withLocalS3Bucket { srcBucket =>
@@ -32,9 +33,7 @@ class BagReplicatorFeatureTest
         val ingests = new MemoryMessageSender()
         val outgoing = new MemoryMessageSender()
 
-        val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
-          bucket = srcBucket
-        )
+        val (srcBagRoot, _) = createS3BagWith(bucket = srcBucket)
 
         val payload = createVersionedBagRootPayloadWith(
           bagRoot = srcBagRoot

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -24,7 +24,7 @@ import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
@@ -147,10 +147,10 @@ trait BagReplicatorFixtures
   private val listing = new S3ObjectSummaryListing()
 
   def verifyObjectsCopied(
-    srcPrefix: ObjectLocationPrefix,
+    srcPrefix: S3ObjectLocationPrefix,
     dstPrefix: ObjectLocationPrefix
   ): Assertion = {
-    val sourceItems = listing.list(srcPrefix).right.value
+    val sourceItems = listing.list(srcPrefix.toObjectLocationPrefix).right.value
     val sourceKeyEtags = sourceItems.map {
       _.getETag
     }

--- a/bag_root_finder/src/test/resources/logback-test.xml
+++ b/bag_root_finder/src/test/resources/logback-test.xml
@@ -8,4 +8,8 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.BagRootPayload
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
-import uk.ac.wellcome.platform.archive.common.fixtures.{S3BagBuilder, S3BagBuilderBase}
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -4,11 +4,17 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.BagRootPayload
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bag_root_finder.fixtures.BagRootFinderFixtures
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
@@ -73,7 +79,8 @@ class BagRootFinderFeatureTest
         )(
           implicit namespace: String
         ): S3ObjectLocationPrefix = {
-          val rootDirectory = super.createBagRoot(space, externalIdentifier, version)
+          val rootDirectory =
+            super.createBagRoot(space, externalIdentifier, version)
 
           rootDirectory.copy(
             keyPrefix = Seq(rootDirectory.keyPrefix, "subdir").mkString("/")

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -17,7 +17,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bag_root_finder.fixtures.BagRootFinderFixtures
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 class BagRootFinderFeatureTest
     extends AnyFunSpec
@@ -72,19 +71,15 @@ class BagRootFinderFeatureTest
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
       val builder = new S3BagBuilder {
-        override protected def createBagRoot(
+        override protected def createBagRootPath(
           space: StorageSpace,
           externalIdentifier: ExternalIdentifier,
           version: BagVersion
-        )(
-          implicit namespace: String
-        ): S3ObjectLocationPrefix = {
-          val rootDirectory =
-            super.createBagRoot(space, externalIdentifier, version)
+        ): String = {
+          val rootPath =
+            super.createBagRootPath(space, externalIdentifier, version)
 
-          rootDirectory.copy(
-            keyPrefix = Seq(rootDirectory.keyPrefix, "subdir").mkString("/")
-          )
+          Seq(rootPath, "subdir").mkString("/")
         }
       }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -7,10 +7,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  S3BagBuilder,
-  S3BagBuilderBase
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
@@ -29,7 +26,8 @@ class BagVerifierFeatureTest
     with IntegrationPatience
     with IngestUpdateAssertions
     with BagVerifierFixtures
-    with PayloadGenerators {
+    with PayloadGenerators
+    with S3BagBuilder {
 
   it(
     "updates the ingests service and sends an outgoing notification if verification succeeds"
@@ -56,8 +54,7 @@ class BagVerifierFeatureTest
             stepName = "verification"
           ) { _ =>
             val space = createStorageSpace
-            val (bagRoot, bagInfo) =
-              S3BagBuilder.createS3BagWith(bucket, space = space)
+            val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
             val payload = createVersionedBagRootPayloadWith(
               context = createPipelineContextWith(
@@ -105,7 +102,7 @@ class BagVerifierFeatureTest
             bucket = bucket,
             stepName = "verification"
           ) { _ =>
-            val badBuilder: S3BagBuilderBase = new S3BagBuilderBase {
+            val badBuilder: S3BagBuilder = new S3BagBuilder {
               override protected def createPayloadManifest(
                 entries: Seq[PayloadEntry]
               ): Option[String] =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -4,16 +4,34 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, OptionValues, TryValues}
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FailedChecksumNoMatch, FileFixityCorrect}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FailedChecksumNoMatch,
+  FileFixityCorrect
+}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary, VerificationSummary}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  VerificationFailureSummary,
+  VerificationIncompleteSummary,
+  VerificationSuccessSummary,
+  VerificationSummary
+}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocationNotFound
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagPath, ExternalIdentifier, PayloadOxum}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagPath,
+  ExternalIdentifier,
+  PayloadOxum
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.StorageSpaceGenerators
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -1,41 +1,20 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
-import org.scalatest.{Assertion, OptionValues, TryValues}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FailedChecksumNoMatch,
-  FileFixityCorrect
-}
+import org.scalatest.{Assertion, OptionValues, TryValues}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FailedChecksumNoMatch, FileFixityCorrect}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{
-  VerificationFailureSummary,
-  VerificationIncompleteSummary,
-  VerificationSuccessSummary,
-  VerificationSummary
-}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary, VerificationSummary}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocationNotFound
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  BagPath,
-  ExternalIdentifier,
-  PayloadOxum
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagPath, ExternalIdentifier, PayloadOxum}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  S3BagBuilder,
-  S3BagBuilderBase
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.StorageSpaceGenerators
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepResult,
-  IngestStepSucceeded,
-  StorageSpace
-}
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 class BagVerifierTest
@@ -45,7 +24,8 @@ class BagVerifierTest
     with TryValues
     with OptionValues
     with BagVerifierFixtures
-    with StorageSpaceGenerators {
+    with StorageSpaceGenerators
+    with S3BagBuilder {
 
   type StringTuple = List[(String, String)]
 
@@ -60,7 +40,7 @@ class BagVerifierTest
   it("passes a bag with correct checksum values") {
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
-      val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(
+      val (bagRoot, bagInfo) = createS3BagWith(
         bucket,
         space = space,
         payloadFileCount = payloadFileCount
@@ -70,7 +50,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot,
+            root = bagRoot.toObjectLocationPrefix,
             space = space,
             externalIdentifier = bagInfo.externalIdentifier
           )
@@ -93,7 +73,7 @@ class BagVerifierTest
   }
 
   it("fails a bag with an incorrect checksum in the file manifest") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createPayloadManifest(
         entries: Seq[PayloadEntry]
       ): Option[String] =
@@ -125,7 +105,7 @@ class BagVerifierTest
   }
 
   it("fails a bag with an incorrect checksum in the tag manifest") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createTagManifest(
         entries: Seq[ManifestFile]
       ): Option[String] =
@@ -153,7 +133,7 @@ class BagVerifierTest
   }
 
   it("fails a bag with multiple incorrect checksums in the file manifest") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createPayloadManifest(
         entries: Seq[PayloadEntry]
       ): Option[String] =
@@ -171,7 +151,7 @@ class BagVerifierTest
   }
 
   it("fails a bag if the file manifest refers to a non-existent file") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createPayloadManifest(
         entries: Seq[PayloadEntry]
       ): Option[String] =
@@ -207,7 +187,7 @@ class BagVerifierTest
   }
 
   it("fails a bag if the file manifest does not exist") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createPayloadManifest(
         entries: Seq[PayloadEntry]
       ): Option[String] =
@@ -226,7 +206,7 @@ class BagVerifierTest
   }
 
   it("fails a bag if the tag manifest does not exist") {
-    val badBuilder = new S3BagBuilderBase {
+    val badBuilder = new S3BagBuilder {
       override protected def createTagManifest(
         entries: Seq[ManifestFile]
       ): Option[String] =
@@ -253,7 +233,7 @@ class BagVerifierTest
       ExternalIdentifier(externalIdentifier + "_payload")
 
     withLocalS3Bucket { bucket =>
-      val (bagRoot, _) = S3BagBuilder.createS3BagWith(
+      val (bagRoot, _) = createS3BagWith(
         bucket,
         externalIdentifier = bagInfoExternalIdentifier
       )
@@ -262,7 +242,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot,
+            root = bagRoot.toObjectLocationPrefix,
             space = space,
             externalIdentifier = payloadExternalIdentifier
           )
@@ -281,7 +261,7 @@ class BagVerifierTest
 
   describe("checks the fetch file") {
     it("fails if the fetch file refers to a file not in the manifest") {
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override protected def createFetchFile(
           entries: Seq[PayloadEntry]
         )(implicit namespace: String): Option[String] =
@@ -307,7 +287,7 @@ class BagVerifierTest
     }
 
     it("fails if the fetch file refers to a file with the wrong URI scheme") {
-      val wrongSchemeBuilder = new S3BagBuilderBase {
+      val wrongSchemeBuilder = new S3BagBuilder {
         override protected def buildFetchEntryLine(
           entry: PayloadEntry
         )(implicit namespace: String): String =
@@ -330,7 +310,7 @@ class BagVerifierTest
     }
 
     it("fails if the fetch file refers to a file in a different namespace") {
-      val wrongBucketFetchBuilder = new S3BagBuilderBase {
+      val wrongBucketFetchBuilder = new S3BagBuilder {
         override protected def buildFetchEntryLine(
           entry: PayloadEntry
         )(implicit namespace: String): String =
@@ -353,7 +333,7 @@ class BagVerifierTest
     }
 
     it("fails if the fetch file refers to a file in the wrong space") {
-      val bagSpaceFetchBuilder = new S3BagBuilderBase {
+      val bagSpaceFetchBuilder = new S3BagBuilder {
         override protected def buildFetchEntryLine(
           entry: PayloadEntry
         )(implicit namespace: String): String =
@@ -382,7 +362,7 @@ class BagVerifierTest
     it(
       "fails if the fetch file refers to a file with the wrong external identifier"
     ) {
-      val badExternalIdentifierFetchBuilder = new S3BagBuilderBase {
+      val badExternalIdentifierFetchBuilder = new S3BagBuilder {
         override protected def buildFetchEntryLine(
           entry: PayloadEntry
         )(implicit namespace: String): String =
@@ -411,13 +391,13 @@ class BagVerifierTest
 
   describe("checks for unreferenced files") {
     it("fails if there is one unreferenced file") {
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override def createS3BagWith(
           bucket: Bucket,
           space: StorageSpace,
           externalIdentifier: ExternalIdentifier,
           payloadFileCount: Int
-        ): (ObjectLocationPrefix, BagInfo) = {
+        ): (S3ObjectLocationPrefix, BagInfo) = {
           val (bagRoot, bagInfo) =
             super.createS3BagWith(
               bucket = bucket,
@@ -428,8 +408,8 @@ class BagVerifierTest
 
           val location = bagRoot.asLocation("unreferencedfile.txt")
           s3Client.putObject(
-            location.namespace,
-            location.path,
+            location.bucket,
+            location.key,
             randomAlphanumeric
           )
 
@@ -449,13 +429,13 @@ class BagVerifierTest
     }
 
     it("fails if there are multiple unreferenced files") {
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override def createS3BagWith(
           bucket: Bucket,
           space: StorageSpace,
           externalIdentifier: ExternalIdentifier,
           payloadFileCount: Int
-        ): (ObjectLocationPrefix, BagInfo) = {
+        ): (S3ObjectLocationPrefix, BagInfo) = {
           val (bagRoot, bagInfo) =
             super.createS3BagWith(
               bucket = bucket,
@@ -468,8 +448,8 @@ class BagVerifierTest
             val location = bagRoot.asLocation(s"unreferencedfile_$i.txt")
 
             s3Client.putObject(
-              location.namespace,
-              location.path,
+              location.bucket,
+              location.key,
               randomAlphanumeric
             )
           }
@@ -491,7 +471,7 @@ class BagVerifierTest
     }
 
     it("fails if a file in the fetch.txt also appears in the bag") {
-      val alwaysWriteAsFetchBuilder = new S3BagBuilderBase {
+      val alwaysWriteAsFetchBuilder = new S3BagBuilder {
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
 
@@ -500,7 +480,7 @@ class BagVerifierTest
           space: StorageSpace,
           externalIdentifier: ExternalIdentifier,
           payloadFileCount: Int
-        ): (ObjectLocationPrefix, BagInfo) = {
+        ): (S3ObjectLocationPrefix, BagInfo) = {
           val (bagRoot, bagInfo) =
             super.createS3BagWith(
               bucket = bucket,
@@ -509,15 +489,18 @@ class BagVerifierTest
               payloadFileCount = payloadFileCount
             )
 
-          val bag = new S3BagReader().get(bagRoot).right.value
+          val bag = new S3BagReader()
+            .get(bagRoot.toObjectLocationPrefix)
+            .right
+            .value
 
           // Write one of the fetch.txt entries as a concrete file
           val badFetchPath: BagPath = bag.fetch.get.paths.head
           val badFetchLocation = bagRoot.asLocation(badFetchPath.value)
 
           s3Client.putObject(
-            badFetchLocation.namespace,
-            badFetchLocation.path,
+            badFetchLocation.bucket,
+            badFetchLocation.key,
             randomAlphanumeric
           )
 
@@ -540,14 +523,13 @@ class BagVerifierTest
     it("passes a bag that includes an extra manifest/tag manifest") {
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRoot, bagInfo) =
-          S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
         val location = bagRoot.asLocation("tagmanifest-sha512.txt")
 
         s3Client.putObject(
-          location.namespace,
-          location.path,
+          location.bucket,
+          location.key,
           "<empty SHA512 tag manifest>"
         )
 
@@ -555,7 +537,7 @@ class BagVerifierTest
           withVerifier(bucket) {
             _.verify(
               ingestId = createIngestID,
-              root = bagRoot,
+              root = bagRoot.toObjectLocationPrefix,
               space = space,
               externalIdentifier = bagInfo.externalIdentifier
             )
@@ -568,7 +550,7 @@ class BagVerifierTest
 
   describe("checks the Payload-Oxum") {
     it("fails if the Payload-Oxum has the wrong file count") {
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override protected def createPayloadOxum(
           entries: Seq[PayloadEntry]
         ): PayloadOxum = {
@@ -586,7 +568,7 @@ class BagVerifierTest
     }
 
     it("fails if the Payload-Oxum has the wrong octet count") {
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override protected def createPayloadOxum(
           entries: Seq[PayloadEntry]
         ): PayloadOxum = {
@@ -619,7 +601,7 @@ class BagVerifierTest
   // Given a builder that fails to create a valid bag for some reason, ensure that
   // it is caught correctly by the verifier.
   private def assertBagResultFails(
-    badBuilder: S3BagBuilderBase
+    badBuilder: S3BagBuilder
   )(assertion: IngestStepResult[VerificationSummary] => Assertion): Assertion =
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
@@ -633,7 +615,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot,
+            root = bagRoot.toObjectLocationPrefix,
             space = space,
             externalIdentifier = bagInfo.externalIdentifier
           )
@@ -646,7 +628,7 @@ class BagVerifierTest
       assertion(result)
     }
 
-  private def assertBagFails(badBuilder: S3BagBuilderBase)(
+  private def assertBagFails(badBuilder: S3BagBuilder)(
     assertion: (
       IngestFailed[VerificationFailureSummary],
       VerificationFailureSummary
@@ -662,7 +644,7 @@ class BagVerifierTest
       assertion(failedResult, summary)
     }
 
-  private def assertBagIncomplete(badBuilder: S3BagBuilderBase)(
+  private def assertBagIncomplete(badBuilder: S3BagBuilder)(
     assertion: (
       IngestFailed[VerificationIncompleteSummary],
       VerificationIncompleteSummary

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -8,17 +8,11 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  S3BagBuilder,
-  S3BagBuilderBase
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.{
-  BagRootLocationPayload,
-  VersionedBagRootPayload
-}
+import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, VersionedBagRootPayload}
 
 import scala.util.{Failure, Success, Try}
 
@@ -28,7 +22,8 @@ class BagVerifierWorkerTest
     with IngestUpdateAssertions
     with IntegrationPatience
     with BagVerifierFixtures
-    with PayloadGenerators {
+    with PayloadGenerators
+    with S3BagBuilder {
 
   val dataFileCount: Int = randomInt(from = 2, to = 10)
 
@@ -41,15 +36,14 @@ class BagVerifierWorkerTest
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
 
-      val (bagRootLocation, bagInfo) =
-        S3BagBuilder.createS3BagWith(bucket, space = space)
+      val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier,
           storageSpace = space
         ),
-        bagRoot = bagRootLocation
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(
@@ -81,15 +75,14 @@ class BagVerifierWorkerTest
 
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRootLocation, bagInfo) =
-          S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
         val payload = createVersionedBagRootPayloadWith(
           context = createPipelineContextWith(
             externalIdentifier = bagInfo.externalIdentifier,
             storageSpace = space
           ),
-          bagRoot = bagRootLocation
+          bagRoot = bagRoot
         )
 
         withBagVerifierWorker(
@@ -113,8 +106,7 @@ class BagVerifierWorkerTest
 
       withLocalS3Bucket { bucket =>
         val space = createStorageSpace
-        val (bagRoot, bagInfo) =
-          S3BagBuilder.createS3BagWith(bucket, space = space)
+        val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
         val payload = createBagRootLocationPayloadWith(
           context = createPipelineContextWith(
@@ -143,7 +135,7 @@ class BagVerifierWorkerTest
     val outgoing = new MemoryMessageSender()
 
     withLocalS3Bucket { bucket =>
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override protected def createPayloadManifest(
           entries: Seq[PayloadEntry]
         ): Option[String] =
@@ -152,13 +144,13 @@ class BagVerifierWorkerTest
           )
       }
 
-      val (bagRootLocation, bagInfo) = badBuilder.createS3BagWith(bucket)
+      val (bagRoot, bagInfo) = badBuilder.createS3BagWith(bucket)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRoot = bagRootLocation
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(
@@ -188,20 +180,20 @@ class BagVerifierWorkerTest
     val outgoing = new MemoryMessageSender()
 
     withLocalS3Bucket { bucket =>
-      val badBuilder = new S3BagBuilderBase {
+      val badBuilder = new S3BagBuilder {
         override protected def createPayloadManifest(
           entries: Seq[PayloadEntry]
         ): Option[String] =
           None
       }
 
-      val (bagRootLocation, bagInfo) = badBuilder.createS3BagWith(bucket)
+      val (bagRoot, bagInfo) = badBuilder.createS3BagWith(bucket)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRoot = bagRootLocation
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(
@@ -237,7 +229,7 @@ class BagVerifierWorkerTest
       ExternalIdentifier(externalIdentifier + "_payload")
 
     withLocalS3Bucket { bucket =>
-      val (bagRootLocation, _) = S3BagBuilder.createS3BagWith(
+      val (bagRoot, _) = createS3BagWith(
         bucket,
         externalIdentifier = bagInfoExternalIdentifier
       )
@@ -246,7 +238,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = payloadExternalIdentifier
         ),
-        bagRoot = bagRootLocation
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(
@@ -281,15 +273,14 @@ class BagVerifierWorkerTest
 
     withLocalS3Bucket { bucket =>
       val space = createStorageSpace
-      val (bagRootLocation, bagInfo) =
-        S3BagBuilder.createS3BagWith(bucket, space = space)
+      val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
       val payload = createVersionedBagRootPayloadWith(
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier,
           storageSpace = space
         ),
-        bagRoot = bagRootLocation
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -12,7 +12,10 @@ import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, VersionedBagRootPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootLocationPayload,
+  VersionedBagRootPayload
+}
 
 import scala.util.{Failure, Success, Try}
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
@@ -17,6 +17,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAsser
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.VersionedBagRootPayload
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.BagVersionerFixtures
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 class BagVersionerFeatureTest
@@ -28,10 +29,11 @@ class BagVersionerFeatureTest
     with ExternalIdentifierGenerators
     with StorageSpaceGenerators
     with Eventually
-    with IntegrationPatience {
+    with IntegrationPatience
+    with NewS3Fixtures {
 
   it("assigns a version for a new bag") {
-    val bagRoot = createObjectLocationPrefix
+    val bagRoot = createS3ObjectLocationPrefix
     val storageSpace = createStorageSpace
 
     val payload = createBagRootLocationPayloadWith(

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -65,22 +65,22 @@ case class MemoryLocation(
   namespace: String,
   path: String
 ) extends Location {
-    override def toObjectLocation: ObjectLocation =
-      ObjectLocation(
-        namespace = namespace,
-        path = path
-      )
+  override def toObjectLocation: ObjectLocation =
+    ObjectLocation(
+      namespace = namespace,
+      path = path
+    )
 }
 
 case class MemoryLocationPrefix(
   namespace: String,
   pathPrefix: String
 ) extends Prefix[MemoryLocation] {
-    override def asLocation(parts: String*): MemoryLocation =
-      MemoryLocation(
-        namespace = namespace,
-        path = Paths.get(pathPrefix, parts: _*).normalize().toString
-      )
+  override def asLocation(parts: String*): MemoryLocation =
+    MemoryLocation(
+      namespace = namespace,
+      path = Paths.get(pathPrefix, parts: _*).normalize().toString
+    )
 
   override def toObjectLocationPrefix: ObjectLocationPrefix =
     ObjectLocationPrefix(

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -1,10 +1,14 @@
 package uk.ac.wellcome.storage
 import java.nio.file.Paths
 
-trait Location
+trait Location {
+  def toObjectLocation: ObjectLocation
+}
 
 trait Prefix[OfLocation <: Location] {
   def asLocation(parts: String*): OfLocation
+
+  def toObjectLocationPrefix: ObjectLocationPrefix
 }
 
 case class S3ObjectLocation(
@@ -54,5 +58,33 @@ case object S3ObjectLocationPrefix {
     S3ObjectLocationPrefix(
       bucket = location.namespace,
       keyPrefix = location.path
+    )
+}
+
+case class MemoryLocation(
+  namespace: String,
+  path: String
+) extends Location {
+    override def toObjectLocation: ObjectLocation =
+      ObjectLocation(
+        namespace = namespace,
+        path = path
+      )
+}
+
+case class MemoryLocationPrefix(
+  namespace: String,
+  pathPrefix: String
+) extends Prefix[MemoryLocation] {
+    override def asLocation(parts: String*): MemoryLocation =
+      MemoryLocation(
+        namespace = namespace,
+        path = Paths.get(pathPrefix, parts: _*).normalize().toString
+      )
+
+  override def toObjectLocationPrefix: ObjectLocationPrefix =
+    ObjectLocationPrefix(
+      namespace = namespace,
+      path = pathPrefix
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3StreamStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3StreamStore.scala
@@ -5,15 +5,20 @@ import uk.ac.wellcome.storage.{Identified, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
-class NewS3StreamStore(implicit val s3Client: AmazonS3) extends StreamStore[S3ObjectLocation] {
+class NewS3StreamStore(implicit val s3Client: AmazonS3)
+    extends StreamStore[S3ObjectLocation] {
   private val underlying = new S3StreamStore()
 
   override def get(location: S3ObjectLocation): ReadEither =
     underlying
       .get(location.toObjectLocation)
-      .map { case Identified(_, inputStream) => Identified(location, inputStream) }
+      .map {
+        case Identified(_, inputStream) => Identified(location, inputStream)
+      }
 
-  override def put(location: S3ObjectLocation)(inputStream: InputStreamWithLength): WriteEither =
+  override def put(
+    location: S3ObjectLocation
+  )(inputStream: InputStreamWithLength): WriteEither =
     underlying
       .put(location.toObjectLocation)(inputStream)
       .map { case Identified(_, t) => Identified(location, t) }

--- a/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3StreamStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3StreamStore.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.storage.store.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.storage.{Identified, S3ObjectLocation}
+import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
+
+class NewS3StreamStore(implicit val s3Client: AmazonS3) extends StreamStore[S3ObjectLocation] {
+  private val underlying = new S3StreamStore()
+
+  override def get(location: S3ObjectLocation): ReadEither =
+    underlying
+      .get(location.toObjectLocation)
+      .map { case Identified(_, inputStream) => Identified(location, inputStream) }
+
+  override def put(location: S3ObjectLocation)(inputStream: InputStreamWithLength): WriteEither =
+    underlying
+      .put(location.toObjectLocation)(inputStream)
+      .map { case Identified(_, t) => Identified(location, t) }
+}

--- a/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3TypedStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3TypedStore.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.storage.store.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.storage.S3ObjectLocation
+import uk.ac.wellcome.storage.store.TypedStore
+import uk.ac.wellcome.storage.streaming.Codec
+
+class NewS3TypedStore[T](
+  implicit val codec: Codec[T],
+  val streamStore: NewS3StreamStore
+) extends TypedStore[S3ObjectLocation, T]
+
+object NewS3TypedStore {
+  def apply[T](implicit codec: Codec[T],
+               s3Client: AmazonS3): NewS3TypedStore[T] = {
+    implicit val streamStore: NewS3StreamStore = new NewS3StreamStore()
+
+    new NewS3TypedStore[T]()
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3TypedStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/store/s3/NewS3TypedStore.scala
@@ -11,8 +11,10 @@ class NewS3TypedStore[T](
 ) extends TypedStore[S3ObjectLocation, T]
 
 object NewS3TypedStore {
-  def apply[T](implicit codec: Codec[T],
-               s3Client: AmazonS3): NewS3TypedStore[T] = {
+  def apply[T](
+    implicit codec: Codec[T],
+    s3Client: AmazonS3
+  ): NewS3TypedStore[T] = {
     implicit val streamStore: NewS3StreamStore = new NewS3StreamStore()
 
     new NewS3TypedStore[T]()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -1,0 +1,269 @@
+package uk.ac.wellcome.platform.archive.common.fixtures
+
+import java.security.MessageDigest
+
+import uk.ac.wellcome.platform.archive.common.bagit.models._
+import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.{Location, Prefix}
+import uk.ac.wellcome.storage.store.TypedStore
+
+import scala.util.Random
+
+trait BagBuilder[
+  BagLocation <: Location,
+  BagLocationPrefix <: Prefix[BagLocation]]
+    extends StorageSpaceGenerators
+      with BagInfoGenerators {
+
+  case class PayloadEntry(bagPath: BagPath, path: String, contents: String)
+
+  case class ManifestFile(name: String, contents: String)
+
+  def createBagRoot(
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    version: BagVersion
+  )(
+    implicit namespace: String
+  ): BagLocationPrefix
+
+  def createBagLocation(bagRoot: BagLocationPrefix, path: String): BagLocation
+
+  def uploadBagObjects(
+    objects: Map[BagLocation, String]
+  )(implicit typedStore: TypedStore[BagLocation, String]): Unit =
+    objects.foreach { case (location, contents) =>
+      typedStore.put(location)(contents) shouldBe a[Right[_, _]]
+    }
+
+  protected def getFetchEntryCount(payloadFileCount: Int): Int =
+    randomInt(from = 0, to = payloadFileCount)
+
+  def createBagContentsWith(
+    space: StorageSpace = createStorageSpace,
+    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
+    payloadFileCount: Int = randomInt(from = 5, to = 50)
+  )(
+    implicit namespace: String
+  ): (Map[BagLocation, String], BagLocationPrefix, BagInfo) = {
+    val fetchEntryCount = getFetchEntryCount(payloadFileCount)
+
+    val payloadFiles = createPayloadFiles(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version,
+      payloadFileCount = payloadFileCount - fetchEntryCount
+    )
+
+    val fetchEntries = createPayloadFiles(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version.copy(underlying = version.underlying - 1),
+      payloadFileCount = fetchEntryCount
+    )
+
+    val payloadManifest =
+      createPayloadManifest(payloadFiles ++ fetchEntries)
+        .map { contents =>
+          ManifestFile(
+            name = s"manifest-sha256.txt",
+            contents = contents
+          )
+        }
+
+    val bagInfo = createBagInfoWith(
+      payloadOxum = createPayloadOxum(payloadFiles ++ fetchEntries),
+      externalIdentifier = externalIdentifier
+    )
+
+    val bagItFile =
+      ManifestFile(
+        name = s"bagit.txt",
+        contents = """
+                     |BagIt-Version: 0.97
+                     |Tag-File-Character-Encoding: UTF-8
+                   """.stripMargin.trim
+      )
+
+    val bagInfoFile =
+      createBagInfo(bagInfo)
+        .map { contents =>
+          ManifestFile(
+            name = s"bag-info.txt",
+            contents = contents
+          )
+        }
+
+    val fetchFile = createFetchFile(fetchEntries)
+      .map { contents =>
+        ManifestFile(
+          name = "fetch.txt",
+          contents = contents
+        )
+      }
+
+    val tagManifestFiles: List[ManifestFile] =
+      payloadManifest.toList ++
+        bagInfoFile.toList ++
+        fetchFile.toList ++ List(bagItFile)
+
+    val tagManifest = createTagManifest(tagManifestFiles)
+      .map { contents =>
+        ManifestFile(
+          name = "tagmanifest-sha256.txt",
+          contents = contents
+        )
+      }
+
+    val bagRootPath = createBagRootPath(space, externalIdentifier, version)
+
+    val bagRoot = createBagRoot(space, externalIdentifier, version)
+
+    val manifestObjects =
+      (tagManifestFiles ++ tagManifest.toList)
+        .map { manifestFile =>
+          bagRoot.asLocation(manifestFile.name) -> manifestFile.contents
+        }
+        .toMap
+
+    val payloadObjects =
+      (payloadFiles ++ fetchEntries)
+        .map { payloadEntry =>
+          createBagLocation(bagRoot, path = payloadEntry.path) -> payloadEntry.contents
+        }
+        .toMap
+
+    (manifestObjects ++ payloadObjects, bagRoot, bagInfo)
+  }
+
+  protected def createFetchFile(
+    entries: Seq[PayloadEntry]
+  )(implicit namespace: String): Option[String] =
+    if (entries.isEmpty) {
+      None
+    } else {
+      Some(
+        entries
+          .map { buildFetchEntryLine }
+          .mkString("\n")
+      )
+    }
+
+  protected def buildFetchEntryLine(
+    entry: PayloadEntry
+  )(implicit namespace: String): String = {
+    val displaySize =
+      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
+
+    s"""bag://$namespace/${entry.path} $displaySize ${entry.bagPath}"""
+  }
+
+  protected def createPayloadOxum(entries: Seq[PayloadEntry]): PayloadOxum =
+    PayloadOxum(
+      payloadBytes = entries.map { _.contents.getBytes.length }.sum,
+      numberOfPayloadFiles = entries.size
+    )
+
+  protected def createPayloadManifest(
+                                       entries: Seq[PayloadEntry]
+                                     ): Option[String] =
+    Some(
+      createManifest(
+        entries.map { entry =>
+          (entry.bagPath.value, createDigest(entry.contents))
+        }
+      )
+    )
+
+  protected def createTagManifest(entries: Seq[ManifestFile]): Option[String] =
+    Some(
+      createManifest(
+        entries.map { entry =>
+          (entry.name, createDigest(entry.contents))
+        }
+      )
+    )
+
+  protected def createBagInfo(bagInfo: BagInfo): Option[String] = {
+    def optionalLine[T](maybeValue: Option[T], fieldName: String): String =
+      maybeValue.map(value => s"$fieldName: $value").getOrElse("")
+
+    val sourceOrganisationLine =
+      optionalLine(bagInfo.sourceOrganisation, "Source-Organization")
+    val descriptionLine =
+      optionalLine(bagInfo.externalDescription, "External-Description")
+    val internalSenderIdentifierLine =
+      optionalLine(
+        bagInfo.internalSenderIdentifier,
+        "Internal-Sender-Identifier"
+      )
+    val internalSenderDescriptionLine =
+      optionalLine(
+        bagInfo.internalSenderDescription,
+        "Internal-Sender-Description"
+      )
+
+    Some(
+      s"""External-Identifier: ${bagInfo.externalIdentifier}
+         |Payload-Oxum: ${bagInfo.payloadOxum.payloadBytes}.${bagInfo.payloadOxum.numberOfPayloadFiles}
+         |Bagging-Date: ${bagInfo.baggingDate.toString}
+         |$sourceOrganisationLine
+         |$descriptionLine
+         |$internalSenderIdentifierLine
+         |$internalSenderDescriptionLine
+        """.stripMargin.trim
+    )
+  }
+
+  private def createManifest(entries: Seq[(String, String)]): String =
+    entries
+      .map { case (name, digest) => s"""$digest  $name""" }
+      .mkString("\n")
+
+  protected def createBagRootPath(
+                               space: StorageSpace,
+                               externalIdentifier: ExternalIdentifier,
+                               version: BagVersion
+                             ): String =
+  // This mimics the structure of bags stored by the replicator
+    s"$space/$externalIdentifier/$version"
+
+  private def createPayloadFiles(
+                                  space: StorageSpace,
+                                  externalIdentifier: ExternalIdentifier,
+                                  version: BagVersion,
+                                  payloadFileCount: Int
+                                ): Seq[PayloadEntry] = {
+    val bagRoot = createBagRootPath(space, externalIdentifier, version)
+
+    (1 to payloadFileCount).map { _ =>
+      val bagPath = BagPath(s"data/$randomPath")
+      PayloadEntry(
+        bagPath = bagPath,
+        path = s"$bagRoot/$bagPath",
+        contents = Random.nextString(length = randomInt(1, 256))
+      )
+    }
+  }
+
+  private def randomPath: String =
+    (1 to randomInt(from = 1, to = 5))
+      .map { _ =>
+        randomAlphanumeric
+      }
+      .mkString("/")
+
+  private def createDigest(string: String): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(string.getBytes)
+      .map(0xFF & _)
+      .map {
+        "%02x".format(_)
+      }
+      .foldLeft("") {
+        _ + _
+      }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -117,8 +117,6 @@ trait BagBuilder[
         )
       }
 
-    val bagRootPath = createBagRootPath(space, externalIdentifier, version)
-
     val bagRoot = createBagRoot(space, externalIdentifier, version)
 
     val manifestObjects =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -277,36 +277,3 @@ trait BagBuilderBase extends StorageSpaceGenerators with BagInfoGenerators {
 }
 
 object BagBuilder extends BagBuilderBase
-
-trait S3BagBuilderBase extends BagBuilderBase with S3Fixtures with Logging {
-  def createS3BagWith(
-    bucket: Bucket,
-    space: StorageSpace = createStorageSpace,
-    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
-    payloadFileCount: Int = randomInt(from = 5, to = 50)
-  ): (ObjectLocationPrefix, BagInfo) = {
-    implicit val namespace: String = bucket.name
-
-    val (bagObjects, bagRoot, bagInfo) = createBagContentsWith(
-      space = space,
-      externalIdentifier = externalIdentifier,
-      payloadFileCount = payloadFileCount
-    )
-
-    implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
-    uploadBagObjects(bagObjects)
-
-    (bagRoot, bagInfo)
-  }
-
-  override protected def buildFetchEntryLine(
-    entry: PayloadEntry
-  )(implicit namespace: String): String = {
-    val displaySize =
-      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
-
-    s"""s3://$namespace/${entry.path} $displaySize ${entry.bagPath}"""
-  }
-}
-
-object S3BagBuilder extends S3BagBuilderBase

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -2,25 +2,14 @@ package uk.ac.wellcome.platform.archive.common.fixtures
 
 import java.security.MessageDigest
 
-import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  BagPath,
-  BagVersion,
-  ExternalIdentifier,
-  PayloadOxum
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models._
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagInfoGenerators,
   StorageSpaceGenerators
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.TypedStore
-import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.Random
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BetterBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BetterBagBuilder.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.store.TypedStore
 
 import scala.util.Random
 
-trait BagBuilder[
+trait BetterBagBuilder[
   BagLocation <: Location,
   BagLocationPrefix <: Prefix[BagLocation]]
     extends StorageSpaceGenerators

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BetterBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BetterBagBuilder.scala
@@ -3,18 +3,20 @@ package uk.ac.wellcome.platform.archive.common.fixtures
 import java.security.MessageDigest
 
 import uk.ac.wellcome.platform.archive.common.bagit.models._
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.{Location, Prefix}
 import uk.ac.wellcome.storage.store.TypedStore
 
 import scala.util.Random
 
-trait BetterBagBuilder[
-  BagLocation <: Location,
-  BagLocationPrefix <: Prefix[BagLocation]]
-    extends StorageSpaceGenerators
-      with BagInfoGenerators {
+trait BetterBagBuilder[BagLocation <: Location, BagLocationPrefix <: Prefix[
+  BagLocation
+]] extends StorageSpaceGenerators
+    with BagInfoGenerators {
 
   case class PayloadEntry(bagPath: BagPath, path: String, contents: String)
 
@@ -33,8 +35,9 @@ trait BetterBagBuilder[
   def uploadBagObjects(
     objects: Map[BagLocation, String]
   )(implicit typedStore: TypedStore[BagLocation, String]): Unit =
-    objects.foreach { case (location, contents) =>
-      typedStore.put(location)(contents) shouldBe a[Right[_, _]]
+    objects.foreach {
+      case (location, contents) =>
+        typedStore.put(location)(contents) shouldBe a[Right[_, _]]
     }
 
   protected def getFetchEntryCount(payloadFileCount: Int): Int =
@@ -120,18 +123,14 @@ trait BetterBagBuilder[
     val bagRoot = createBagRoot(space, externalIdentifier, version)
 
     val manifestObjects =
-      (tagManifestFiles ++ tagManifest.toList)
-        .map { manifestFile =>
-          bagRoot.asLocation(manifestFile.name) -> manifestFile.contents
-        }
-        .toMap
+      (tagManifestFiles ++ tagManifest.toList).map { manifestFile =>
+        bagRoot.asLocation(manifestFile.name) -> manifestFile.contents
+      }.toMap
 
     val payloadObjects =
-      (payloadFiles ++ fetchEntries)
-        .map { payloadEntry =>
-          createBagLocation(bagRoot, path = payloadEntry.path) -> payloadEntry.contents
-        }
-        .toMap
+      (payloadFiles ++ fetchEntries).map { payloadEntry =>
+        createBagLocation(bagRoot, path = payloadEntry.path) -> payloadEntry.contents
+      }.toMap
 
     (manifestObjects ++ payloadObjects, bagRoot, bagInfo)
   }
@@ -165,8 +164,8 @@ trait BetterBagBuilder[
     )
 
   protected def createPayloadManifest(
-                                       entries: Seq[PayloadEntry]
-                                     ): Option[String] =
+    entries: Seq[PayloadEntry]
+  ): Option[String] =
     Some(
       createManifest(
         entries.map { entry =>
@@ -221,19 +220,19 @@ trait BetterBagBuilder[
       .mkString("\n")
 
   protected def createBagRootPath(
-                               space: StorageSpace,
-                               externalIdentifier: ExternalIdentifier,
-                               version: BagVersion
-                             ): String =
-  // This mimics the structure of bags stored by the replicator
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    version: BagVersion
+  ): String =
+    // This mimics the structure of bags stored by the replicator
     s"$space/$externalIdentifier/$version"
 
   private def createPayloadFiles(
-                                  space: StorageSpace,
-                                  externalIdentifier: ExternalIdentifier,
-                                  version: BagVersion,
-                                  payloadFileCount: Int
-                                ): Seq[PayloadEntry] = {
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    version: BagVersion,
+    payloadFileCount: Int
+  ): Seq[PayloadEntry] = {
     val bagRoot = createBagRootPath(space, externalIdentifier, version)
 
     (1 to payloadFileCount).map { _ =>

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.fixtures.s3
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.BetterBagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
@@ -12,7 +16,7 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import scala.util.Random
 
 trait S3BagBuilder
-  extends BetterBagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
+    extends BetterBagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
     with NewS3Fixtures {
 
   override def createBagRoot(
@@ -24,10 +28,14 @@ trait S3BagBuilder
   ): S3ObjectLocationPrefix =
     S3ObjectLocationPrefix(
       bucket = namespace,
-      keyPrefix = DestinationBuilder.buildPath(space, externalIdentifier, version)
+      keyPrefix =
+        DestinationBuilder.buildPath(space, externalIdentifier, version)
     )
 
-  def createBagLocation(bagRoot: S3ObjectLocationPrefix, path: String): S3ObjectLocation =
+  def createBagLocation(
+    bagRoot: S3ObjectLocationPrefix,
+    path: String
+  ): S3ObjectLocation =
     S3ObjectLocation(
       bucket = bagRoot.bucket,
       key = path

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.fixtures.s3
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
+import uk.ac.wellcome.platform.archive.common.fixtures.BetterBagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
@@ -12,7 +12,7 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import scala.util.Random
 
 trait S3BagBuilder
-  extends BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
+  extends BetterBagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
     with NewS3Fixtures {
 
   override def createBagRoot(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -1,11 +1,15 @@
 package uk.ac.wellcome.platform.archive.common.fixtures.s3
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.s3.NewS3TypedStore
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
+
+import scala.util.Random
 
 trait S3BagBuilder
   extends BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
@@ -28,4 +32,33 @@ trait S3BagBuilder
       bucket = bagRoot.bucket,
       key = path
     )
+
+  override protected def buildFetchEntryLine(
+    entry: PayloadEntry
+  )(implicit namespace: String): String = {
+    val displaySize =
+      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
+
+    s"""s3://$namespace/${entry.path} $displaySize ${entry.bagPath}"""
+  }
+
+  def createS3BagWith(
+    bucket: Bucket,
+    space: StorageSpace = createStorageSpace,
+    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    payloadFileCount: Int = randomInt(from = 5, to = 50)
+  ): (S3ObjectLocationPrefix, BagInfo) = {
+    implicit val namespace: String = bucket.name
+
+    val (bagObjects, bagRoot, bagInfo) = createBagContentsWith(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      payloadFileCount = payloadFileCount
+    )
+
+    implicit val typedStore: NewS3TypedStore[String] = NewS3TypedStore[String]
+    uploadBagObjects(bagObjects)
+
+    (bagRoot, bagInfo)
+  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.BetterBagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.s3.NewS3TypedStore
@@ -28,8 +27,7 @@ trait S3BagBuilder
   ): S3ObjectLocationPrefix =
     S3ObjectLocationPrefix(
       bucket = namespace,
-      keyPrefix =
-        DestinationBuilder.buildPath(space, externalIdentifier, version)
+      keyPrefix = createBagRootPath(space, externalIdentifier, version)
     )
 
   def createBagLocation(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.archive.common.fixtures.s3
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
+
+trait S3BagBuilder
+  extends BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix]
+    with NewS3Fixtures {
+
+  override def createBagRoot(
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    version: BagVersion
+  )(
+    implicit namespace: String
+  ): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = namespace,
+      keyPrefix = DestinationBuilder.buildPath(space, externalIdentifier, version)
+    )
+
+  def createBagLocation(bagRoot: S3ObjectLocationPrefix, path: String): S3ObjectLocation =
+    S3ObjectLocation(
+      bucket = bagRoot.bucket,
+      key = path
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -9,12 +9,14 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocationPrefix}
 
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
-    with StorageLocationGenerators {
+    with StorageLocationGenerators
+    with NewS3Fixtures {
 
   def randomIngestType: IngestType =
     chooseFrom(
@@ -95,12 +97,12 @@ trait PayloadGenerators
 
   def createVersionedBagRootPayloadWith(
     context: PipelineContext = createPipelineContext,
-    bagRoot: ObjectLocationPrefix = createObjectLocationPrefix,
+    bagRoot: S3ObjectLocationPrefix = createS3ObjectLocationPrefix,
     version: BagVersion = createBagVersion
   ): VersionedBagRootPayload =
     VersionedBagRootPayload(
       context = context,
-      bagRoot = bagRoot,
+      bagRoot = bagRoot.toObjectLocationPrefix,
       version = version
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocationPrefix}
 
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
@@ -56,14 +56,14 @@ trait PayloadGenerators
     createSourceLocationPayloadWith()
 
   def createUnpackedBagLocationPayloadWith(
-    unpackedBagLocation: ObjectLocationPrefix = createObjectLocationPrefix,
+    unpackedBagLocation: S3ObjectLocationPrefix = createS3ObjectLocationPrefix,
     storageSpace: StorageSpace = createStorageSpace
   ): UnpackedBagLocationPayload =
     UnpackedBagLocationPayload(
       context = createPipelineContextWith(
         storageSpace = storageSpace
       ),
-      unpackedBagLocation = unpackedBagLocation
+      unpackedBagLocation = unpackedBagLocation.toObjectLocationPrefix
     )
 
   def createKnownReplicas = KnownReplicas(
@@ -111,11 +111,11 @@ trait PayloadGenerators
 
   def createBagRootLocationPayloadWith(
     context: PipelineContext = createPipelineContext,
-    bagRoot: ObjectLocationPrefix = createObjectLocationPrefix
+    bagRoot: S3ObjectLocationPrefix = createS3ObjectLocationPrefix
   ): BagRootLocationPayload =
     BagRootLocationPayload(
       context = context,
-      bagRoot = bagRoot
+      bagRoot = bagRoot.toObjectLocationPrefix
     )
 
   def createReplicaResultPayload: ReplicaResultPayload =

--- a/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/fixtures/NewS3Fixtures.scala
@@ -43,4 +43,7 @@ trait NewS3Fixtures extends S3Fixtures {
 
   def createInvalidBucket: Bucket =
     Bucket(createInvalidBucketName)
+
+  def deleteObject(location: S3ObjectLocation): Unit =
+    s3Client.deleteObject(location.bucket, location.key)
 }


### PR DESCRIPTION
The BagBuilder code was a bit of a mess – a mix of being called as a mixin and as an object. This standardises it as a trait that gets mixed in like everything else, and enforces a Location/Prefix hierarchy.

Sorting out the in-memory versions is harder, because you have to fiddle with stores a bit – separate patch.

The big diff is because I've duplicated BagBuilderBase; a subsequent PR will remove one of the copies to bring the line count back down.

Part of wellcomecollection/platform#4596