### PR TITLE
Split SourceLocation into per-provider models

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -37,7 +37,7 @@ case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
     SourceLocationPayload(
       context = PipelineContext(ingest),
-      sourceLocation = ingest.sourceLocation.location
+      sourceLocation = ingest.sourceLocation.prefix.toObjectLocationPrefix.asLocation()
     )
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -37,7 +37,8 @@ case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
     SourceLocationPayload(
       context = PipelineContext(ingest),
-      sourceLocation = ingest.sourceLocation.prefix.toObjectLocationPrefix.asLocation()
+      sourceLocation =
+        ingest.sourceLocation.prefix.toObjectLocationPrefix.asLocation()
     )
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -7,12 +7,11 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.Prefix
 
 case class Ingest(
   id: IngestID,
   ingestType: IngestType,
-  sourceLocation: SourceLocation[_ <: Prefix[_]],
+  sourceLocation: SourceLocation,
   space: StorageSpace,
   callback: Option[Callback],
   status: Ingest.Status,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 case class Ingest(
   id: IngestID,
   ingestType: IngestType,
-  sourceLocation: SourceLocation,
+  sourceLocation: NewSourceLocation,
   space: StorageSpace,
   callback: Option[Callback],
   status: Ingest.Status,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -7,11 +7,12 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.Prefix
 
 case class Ingest(
   id: IngestID,
   ingestType: IngestType,
-  sourceLocation: NewSourceLocation,
+  sourceLocation: NewSourceLocation[_ <: Prefix[_]],
   space: StorageSpace,
   callback: Option[Callback],
   status: Ingest.Status,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.storage.Prefix
 case class Ingest(
   id: IngestID,
   ingestType: IngestType,
-  sourceLocation: NewSourceLocation[_ <: Prefix[_]],
+  sourceLocation: SourceLocation[_ <: Prefix[_]],
   space: StorageSpace,
   callback: Option[Callback],
   status: Ingest.Status,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -2,19 +2,19 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import uk.ac.wellcome.storage._
 
-sealed trait SourceLocation[SourcePrefix <: Prefix[_]] {
+sealed trait SourceLocation {
   val provider: StorageProvider
-  val prefix: SourcePrefix
+  val prefix: Prefix[_]
 }
 
 case class S3SourceLocation(
   prefix: S3ObjectLocationPrefix
-) extends SourceLocation[S3ObjectLocationPrefix] {
+) extends SourceLocation {
   val provider: StorageProvider = AmazonS3StorageProvider
 }
 
 case class AzureBlobSourceLocation(
   prefix: AzureBlobItemLocationPrefix
-) extends SourceLocation[AzureBlobItemLocationPrefix] {
+) extends SourceLocation {
   val provider: StorageProvider = AzureBlobStorageProvider
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -1,5 +1,20 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage._
 
-case class SourceLocation(provider: StorageProvider, location: ObjectLocation)
+sealed trait NewSourceLocation[SourcePrefix <: Prefix[_]] {
+  val provider: StorageProvider
+  val prefix: SourcePrefix
+}
+
+case class S3SourceLocation(
+  prefix: S3ObjectLocationPrefix
+) extends NewSourceLocation[S3ObjectLocationPrefix] {
+  val provider: StorageProvider = AmazonS3StorageProvider
+}
+
+case class AzureBlobSourceLocation(
+  prefix: AzureBlobItemLocationPrefix
+) extends NewSourceLocation[AzureBlobItemLocationPrefix] {
+  val provider: StorageProvider = AzureBlobStorageProvider
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -2,19 +2,19 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import uk.ac.wellcome.storage._
 
-sealed trait NewSourceLocation[SourcePrefix <: Prefix[_]] {
+sealed trait SourceLocation[SourcePrefix <: Prefix[_]] {
   val provider: StorageProvider
   val prefix: SourcePrefix
 }
 
 case class S3SourceLocation(
   prefix: S3ObjectLocationPrefix
-) extends NewSourceLocation[S3ObjectLocationPrefix] {
+) extends SourceLocation[S3ObjectLocationPrefix] {
   val provider: StorageProvider = AmazonS3StorageProvider
 }
 
 case class AzureBlobSourceLocation(
   prefix: AzureBlobItemLocationPrefix
-) extends NewSourceLocation[AzureBlobItemLocationPrefix] {
+) extends SourceLocation[AzureBlobItemLocationPrefix] {
   val provider: StorageProvider = AzureBlobStorageProvider
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -96,3 +96,31 @@ case class MemoryLocationPrefix(
       path = pathPrefix
     )
 }
+
+case class AzureBlobItemLocation(
+  container: String,
+  name: String
+) extends Location {
+  override def toObjectLocation: ObjectLocation =
+    ObjectLocation(
+      namespace = container,
+      path = name
+    )
+}
+
+case class AzureBlobItemLocationPrefix(
+  container: String,
+  namePrefix: String
+) extends Prefix[AzureBlobItemLocation] {
+    override def asLocation(parts: String*): AzureBlobItemLocation =
+      AzureBlobItemLocation(
+        container = container,
+        name = Paths.get(namePrefix, parts: _*).normalize().toString
+      )
+
+    override def toObjectLocationPrefix: ObjectLocationPrefix =
+      ObjectLocationPrefix(
+        namespace = container,
+        path = namePrefix
+      )
+  }

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -6,6 +6,9 @@ trait Location {
 }
 
 trait Prefix[OfLocation <: Location] {
+  val namespace: String
+  val path: String
+
   def asLocation(parts: String*): OfLocation
 
   def toObjectLocationPrefix: ObjectLocationPrefix
@@ -40,6 +43,9 @@ case class S3ObjectLocationPrefix(
   bucket: String,
   keyPrefix: String
 ) extends Prefix[S3ObjectLocation] {
+  val namespace: String = bucket
+  val path: String = keyPrefix
+
   override def asLocation(parts: String*): S3ObjectLocation =
     S3ObjectLocation(
       bucket = bucket,
@@ -84,6 +90,8 @@ case class MemoryLocationPrefix(
   namespace: String,
   pathPrefix: String
 ) extends Prefix[MemoryLocation] {
+  val path: String = pathPrefix
+
   override def asLocation(parts: String*): MemoryLocation =
     MemoryLocation(
       namespace = namespace,
@@ -112,15 +120,18 @@ case class AzureBlobItemLocationPrefix(
   container: String,
   namePrefix: String
 ) extends Prefix[AzureBlobItemLocation] {
-    override def asLocation(parts: String*): AzureBlobItemLocation =
-      AzureBlobItemLocation(
-        container = container,
-        name = Paths.get(namePrefix, parts: _*).normalize().toString
-      )
+  val namespace: String = container
+  val path: String = namePrefix
 
-    override def toObjectLocationPrefix: ObjectLocationPrefix =
-      ObjectLocationPrefix(
-        namespace = container,
-        path = namePrefix
-      )
-  }
+  override def asLocation(parts: String*): AzureBlobItemLocation =
+    AzureBlobItemLocation(
+      container = container,
+      name = Paths.get(namePrefix, parts: _*).normalize().toString
+    )
+
+  override def toObjectLocationPrefix: ObjectLocationPrefix =
+    ObjectLocationPrefix(
+      namespace = container,
+      path = namePrefix
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -9,19 +9,19 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   StorageSpaceGenerators
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 class SourceLocationPayloadTest
     extends AnyFunSpec
     with Matchers
     with ExternalIdentifierGenerators
-    with ObjectLocationGenerators
-    with StorageSpaceGenerators {
+    with StorageSpaceGenerators
+    with NewS3Fixtures {
 
   it("creates a payload from an ingest") {
     val ingestId = createIngestID
     val ingestType = CreateIngestType
-    val sourceLocation = createObjectLocation
+    val sourceLocation = createS3ObjectLocation
     val space = createStorageSpace
     val ingestDate = Instant.now()
     val externalIdentifier = createExternalIdentifier
@@ -29,8 +29,7 @@ class SourceLocationPayloadTest
     val ingest = Ingest(
       id = ingestId,
       ingestType = ingestType,
-      sourceLocation = SourceLocation(
-        provider = AmazonS3StorageProvider,
+      sourceLocation = S3SourceLocation(
         location = sourceLocation
       ),
       space = space,
@@ -48,7 +47,7 @@ class SourceLocationPayloadTest
         ingestDate = ingestDate,
         externalIdentifier = externalIdentifier
       ),
-      sourceLocation = sourceLocation
+      sourceLocation = sourceLocation.toObjectLocation
     )
 
     SourceLocationPayload(ingest) shouldBe expectedPayload

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -21,7 +21,7 @@ class SourceLocationPayloadTest
   it("creates a payload from an ingest") {
     val ingestId = createIngestID
     val ingestType = CreateIngestType
-    val sourceLocation = createS3ObjectLocation
+    val sourcePrefix = createS3ObjectLocationPrefix
     val space = createStorageSpace
     val ingestDate = Instant.now()
     val externalIdentifier = createExternalIdentifier
@@ -30,7 +30,7 @@ class SourceLocationPayloadTest
       id = ingestId,
       ingestType = ingestType,
       sourceLocation = S3SourceLocation(
-        location = sourceLocation
+        prefix = sourcePrefix
       ),
       space = space,
       createdDate = ingestDate,
@@ -47,7 +47,7 @@ class SourceLocationPayloadTest
         ingestDate = ingestDate,
         externalIdentifier = externalIdentifier
       ),
-      sourceLocation = sourceLocation.toObjectLocation
+      sourceLocation = sourcePrefix.asLocation().toObjectLocation
     )
 
     SourceLocationPayload(ingest) shouldBe expectedPayload

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -10,14 +10,13 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.Prefix
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 import scala.util.Random
 
 trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
 
-  def createSourceLocation: SourceLocation[_ <: Prefix[_]] =
+  def createSourceLocation: SourceLocation =
     S3SourceLocation(
       prefix = createS3ObjectLocationPrefix
     )
@@ -37,7 +36,7 @@ trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
   def createIngestWith(
     id: IngestID = createIngestID,
     ingestType: IngestType = CreateIngestType,
-    sourceLocation: SourceLocation[_ <: Prefix[_]] = createSourceLocation,
+    sourceLocation: SourceLocation = createSourceLocation,
     callback: Option[Callback] = Some(createCallback()),
     space: StorageSpace = createStorageSpace,
     status: Status = Ingest.Accepted,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -17,7 +17,7 @@ import scala.util.Random
 
 trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
 
-  def createSourceLocation: NewSourceLocation[_ <: Prefix[_]] =
+  def createSourceLocation: SourceLocation[_ <: Prefix[_]] =
     S3SourceLocation(
       prefix = createS3ObjectLocationPrefix
     )
@@ -37,7 +37,7 @@ trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
   def createIngestWith(
     id: IngestID = createIngestID,
     ingestType: IngestType = CreateIngestType,
-    sourceLocation: NewSourceLocation[_ <: Prefix[_]] = createSourceLocation,
+    sourceLocation: SourceLocation[_ <: Prefix[_]] = createSourceLocation,
     callback: Option[Callback] = Some(createCallback()),
     space: StorageSpace = createStorageSpace,
     status: Status = Ingest.Accepted,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -10,15 +10,16 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.Prefix
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 import scala.util.Random
 
 trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
 
-  def createSourceLocation: NewSourceLocation =
+  def createSourceLocation: NewSourceLocation[_ <: Prefix[_]] =
     S3SourceLocation(
-      location = createS3ObjectLocation
+      prefix = createS3ObjectLocationPrefix
     )
 
   def createIngest: Ingest = createIngestWith()
@@ -36,7 +37,7 @@ trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
   def createIngestWith(
     id: IngestID = createIngestID,
     ingestType: IngestType = CreateIngestType,
-    sourceLocation: NewSourceLocation = createSourceLocation,
+    sourceLocation: NewSourceLocation[_ <: Prefix[_]] = createSourceLocation,
     callback: Option[Callback] = Some(createCallback()),
     space: StorageSpace = createStorageSpace,
     status: Status = Ingest.Accepted,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -10,16 +10,15 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 import scala.util.Random
 
-trait IngestGenerators extends BagIdGenerators with ObjectLocationGenerators {
+trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
 
-  def createSourceLocation: SourceLocation =
-    SourceLocation(
-      provider = AmazonS3StorageProvider,
-      location = createObjectLocation
+  def createSourceLocation: NewSourceLocation =
+    S3SourceLocation(
+      location = createS3ObjectLocation
     )
 
   def createIngest: Ingest = createIngestWith()
@@ -37,7 +36,7 @@ trait IngestGenerators extends BagIdGenerators with ObjectLocationGenerators {
   def createIngestWith(
     id: IngestID = createIngestID,
     ingestType: IngestType = CreateIngestType,
-    sourceLocation: SourceLocation = createSourceLocation,
+    sourceLocation: NewSourceLocation = createSourceLocation,
     callback: Option[Callback] = Some(createCallback()),
     space: StorageSpace = createStorageSpace,
     status: Status = Ingest.Accepted,

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.display
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
-import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, Prefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, S3ObjectLocationPrefix}
 
 case class DisplayLocation(
   provider: DisplayProvider,
@@ -11,7 +11,7 @@ case class DisplayLocation(
   path: String,
   @JsonKey("type") ontologyType: String = "Location"
 ) {
-  def toSourceLocation: SourceLocation[_ <: Prefix[_]] =
+  def toSourceLocation: SourceLocation =
     provider.toStorageProvider match {
       case AmazonS3StorageProvider =>
         S3SourceLocation(
@@ -26,7 +26,7 @@ case class DisplayLocation(
 }
 
 object DisplayLocation {
-  def apply(location: SourceLocation[_]): DisplayLocation =
+  def apply(location: SourceLocation): DisplayLocation =
     location match {
       case S3SourceLocation(prefix) =>
         DisplayLocation(

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.display
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
-import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  AzureBlobItemLocationPrefix,
+  S3ObjectLocationPrefix
+}
 
 case class DisplayLocation(
   provider: DisplayProvider,
@@ -20,7 +23,8 @@ case class DisplayLocation(
 
       case AzureBlobStorageProvider =>
         AzureBlobSourceLocation(
-          prefix = AzureBlobItemLocationPrefix(container = bucket, namePrefix = path)
+          prefix =
+            AzureBlobItemLocationPrefix(container = bucket, namePrefix = path)
         )
     }
 }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -31,21 +31,11 @@ case class DisplayLocation(
 
 object DisplayLocation {
   def apply(location: SourceLocation): DisplayLocation =
-    location match {
-      case S3SourceLocation(prefix) =>
-        DisplayLocation(
-          provider = DisplayProvider(location.provider),
-          bucket = prefix.bucket,
-          path = prefix.keyPrefix
-        )
-
-      case AzureBlobSourceLocation(prefix) =>
-        DisplayLocation(
-          provider = DisplayProvider(location.provider),
-          bucket = prefix.container,
-          path = prefix.namePrefix
-        )
-    }
+    DisplayLocation(
+      provider = DisplayProvider(location.provider),
+      bucket = location.prefix.namespace,
+      path = location.prefix.path
+    )
 
   def apply(location: StorageLocation): DisplayLocation =
     DisplayLocation(

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -12,7 +12,7 @@ case class DisplayLocation(
   @JsonKey("type") ontologyType: String = "Location"
 ) {
   // TODO: Test this properly.
-  def toSourceLocation: NewSourceLocation[_] =
+  def toSourceLocation: SourceLocation[_] =
     provider.toStorageProvider match {
       case AmazonS3StorageProvider =>
         S3SourceLocation(
@@ -28,7 +28,7 @@ case class DisplayLocation(
 
 object DisplayLocation {
   // TODO: Test this properly
-  def apply(location: NewSourceLocation[_]): DisplayLocation =
+  def apply(location: SourceLocation[_]): DisplayLocation =
     location match {
       case S3SourceLocation(prefix) =>
         DisplayLocation(

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.archive.display
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.ingests.models.SourceLocation
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix}
 
 case class DisplayLocation(
   provider: DisplayProvider,
@@ -11,20 +11,39 @@ case class DisplayLocation(
   path: String,
   @JsonKey("type") ontologyType: String = "Location"
 ) {
-  def toSourceLocation: SourceLocation =
-    SourceLocation(
-      provider = provider.toStorageProvider,
-      location = ObjectLocation(bucket, path)
-    )
+  // TODO: Test this properly.
+  def toSourceLocation: NewSourceLocation[_] =
+    provider.toStorageProvider match {
+      case AmazonS3StorageProvider =>
+        S3SourceLocation(
+          prefix = S3ObjectLocationPrefix(bucket = bucket, keyPrefix = path)
+        )
+
+      case AzureBlobStorageProvider =>
+        AzureBlobSourceLocation(
+          prefix = AzureBlobItemLocationPrefix(container = bucket, namePrefix = path)
+        )
+    }
 }
 
 object DisplayLocation {
-  def apply(location: SourceLocation): DisplayLocation =
-    DisplayLocation(
-      provider = DisplayProvider(location.provider),
-      bucket = location.location.namespace,
-      path = location.location.path
-    )
+  // TODO: Test this properly
+  def apply(location: NewSourceLocation[_]): DisplayLocation =
+    location match {
+      case S3SourceLocation(prefix) =>
+        DisplayLocation(
+          provider = DisplayProvider(location.provider),
+          bucket = prefix.bucket,
+          path = prefix.keyPrefix
+        )
+
+      case AzureBlobSourceLocation(prefix) =>
+        DisplayLocation(
+          provider = DisplayProvider(location.provider),
+          bucket = prefix.container,
+          path = prefix.namePrefix
+        )
+    }
 
   def apply(location: StorageLocation): DisplayLocation =
     DisplayLocation(

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.display
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
-import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, Prefix, S3ObjectLocationPrefix}
 
 case class DisplayLocation(
   provider: DisplayProvider,
@@ -11,8 +11,7 @@ case class DisplayLocation(
   path: String,
   @JsonKey("type") ontologyType: String = "Location"
 ) {
-  // TODO: Test this properly.
-  def toSourceLocation: SourceLocation[_] =
+  def toSourceLocation: SourceLocation[_ <: Prefix[_]] =
     provider.toStorageProvider match {
       case AmazonS3StorageProvider =>
         S3SourceLocation(
@@ -27,7 +26,6 @@ case class DisplayLocation(
 }
 
 object DisplayLocation {
-  // TODO: Test this properly
   def apply(location: SourceLocation[_]): DisplayLocation =
     location match {
       case S3SourceLocation(prefix) =>

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
@@ -3,15 +3,27 @@ package uk.ac.wellcome.platform.archive.display
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import uk.ac.wellcome.platform.archive.common.ingests.models.{AzureBlobSourceLocation, S3SourceLocation}
-import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  AzureBlobSourceLocation,
+  S3SourceLocation
+}
+import uk.ac.wellcome.storage.{
+  AzureBlobItemLocationPrefix,
+  S3ObjectLocationPrefix
+}
 
-class DisplayLocationTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+class DisplayLocationTest
+    extends AnyFunSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
   val testCases = Table(
     ("internalLocation", "displayLocation"),
     (
       S3SourceLocation(
-        prefix = S3ObjectLocationPrefix(bucket = "my-bukkit", keyPrefix = "path/to/my/bag")
+        prefix = S3ObjectLocationPrefix(
+          bucket = "my-bukkit",
+          keyPrefix = "path/to/my/bag"
+        )
       ),
       DisplayLocation(
         provider = DisplayProvider("amazon-s3"),
@@ -21,7 +33,10 @@ class DisplayLocationTest extends AnyFunSpec with Matchers with TableDrivenPrope
     ),
     (
       AzureBlobSourceLocation(
-        prefix = AzureBlobItemLocationPrefix(container = "my-container", namePrefix = "path/to/my/bag")
+        prefix = AzureBlobItemLocationPrefix(
+          container = "my-container",
+          namePrefix = "path/to/my/bag"
+        )
       ),
       DisplayLocation(
         provider = DisplayProvider("azure-blob-storage"),
@@ -32,14 +47,16 @@ class DisplayLocationTest extends AnyFunSpec with Matchers with TableDrivenPrope
   )
 
   it("creates an internal SourceLocation") {
-    forAll(testCases) { case (internalLocation, displayLocation) =>
-      displayLocation.toSourceLocation shouldBe internalLocation
+    forAll(testCases) {
+      case (internalLocation, displayLocation) =>
+        displayLocation.toSourceLocation shouldBe internalLocation
     }
   }
 
   it("creates a DisplayLocation from an internalSourceLocation") {
-    forAll(testCases) { case (internalLocation, displayLocation) =>
-      DisplayLocation(internalLocation) shouldBe displayLocation
+    forAll(testCases) {
+      case (internalLocation, displayLocation) =>
+        DisplayLocation(internalLocation) shouldBe displayLocation
     }
   }
 }

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.archive.display
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import uk.ac.wellcome.platform.archive.common.ingests.models.{AzureBlobSourceLocation, S3SourceLocation}
+import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, S3ObjectLocationPrefix}
+
+class DisplayLocationTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+  val testCases = Table(
+    ("internalLocation", "displayLocation"),
+    (
+      S3SourceLocation(
+        prefix = S3ObjectLocationPrefix(bucket = "my-bukkit", keyPrefix = "path/to/my/bag")
+      ),
+      DisplayLocation(
+        provider = DisplayProvider("amazon-s3"),
+        bucket = "my-bukkit",
+        path = "path/to/my/bag"
+      )
+    ),
+    (
+      AzureBlobSourceLocation(
+        prefix = AzureBlobItemLocationPrefix(container = "my-container", namePrefix = "path/to/my/bag")
+      ),
+      DisplayLocation(
+        provider = DisplayProvider("azure-blob-storage"),
+        bucket = "my-container",
+        path = "path/to/my/bag"
+      )
+    )
+  )
+
+  it("creates an internal SourceLocation") {
+    forAll(testCases) { case (internalLocation, displayLocation) =>
+      displayLocation.toSourceLocation shouldBe internalLocation
+    }
+  }
+
+  it("creates a DisplayLocation from an internalSourceLocation") {
+    forAll(testCases) { case (internalLocation, displayLocation) =>
+      DisplayLocation(internalLocation) shouldBe displayLocation
+    }
+  }
+}

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -13,16 +13,14 @@ import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 class DisplayIngestTest
     extends AnyFunSpec
     with Matchers
     with BagIdGenerators
     with TimeTestFixture
-    with IngestGenerators
-    with ObjectLocationGenerators {
+    with IngestGenerators {
 
   private val id = createIngestID
   private val callbackUrl = "http://www.example.com/callback"
@@ -40,9 +38,8 @@ class DisplayIngestTest
       val ingest: Ingest = Ingest(
         id = id,
         ingestType = CreateIngestType,
-        sourceLocation = SourceLocation(
-          provider = AmazonS3StorageProvider,
-          location = ObjectLocation("bukkit", "key.txt")
+        sourceLocation = S3SourceLocation(
+          prefix = S3ObjectLocationPrefix("bukkit", "mybag")
         ),
         space = StorageSpace(spaceId),
         callback = Some(Callback(new URI(callbackUrl))),
@@ -58,7 +55,7 @@ class DisplayIngestTest
       displayIngest.sourceLocation shouldBe DisplayLocation(
         DisplayProvider(id = "amazon-s3"),
         bucket = "bukkit",
-        path = "key.txt"
+        path = "mybag"
       )
       displayIngest.callback shouldBe Some(
         DisplayCallback(
@@ -142,9 +139,8 @@ class DisplayIngestTest
       val ingest = ingestCreateRequest.toIngest
 
       ingest.id shouldBe a[IngestID]
-      ingest.sourceLocation shouldBe SourceLocation(
-        provider = AmazonS3StorageProvider,
-        location = ObjectLocation(bucket, path)
+      ingest.sourceLocation shouldBe S3SourceLocation(
+        prefix = S3ObjectLocationPrefix(bucket, path)
       )
       ingest.callback shouldBe Some(
         Callback(URI.create(ingestCreateRequest.callback.get.url))

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -378,6 +378,18 @@ class CreateIngestApiTest
         )
       }
 
+      it("the provider is not Amazon S3") {
+        val badJson = root.sourceLocation.provider.obj.modify {
+          _.add("id", Json.fromString("azure-blob-storage"))
+        }
+
+        assertCatchesMalformedRequest(
+          badJson(json).noSpaces,
+          expectedMessage =
+            "Forbidden value at .sourceLocation.provider.id: only amazon-s3 is supported for new bags."
+        )
+      }
+
       it("if the bucket field is missing") {
         val badJson = root.sourceLocation.obj.modify {
           _.remove("bucket")

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -23,7 +23,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.archive.display.ingests._
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsApiFixture
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 /** Tests for POST /ingests
   *
@@ -100,9 +100,8 @@ class CreateIngestApiTest
             val expectedIngest = Ingest(
               id = IngestID(id),
               ingestType = CreateIngestType,
-              sourceLocation = SourceLocation(
-                provider = AmazonS3StorageProvider,
-                location = ObjectLocation(bucketName, s3key)
+              sourceLocation = S3SourceLocation(
+                prefix = S3ObjectLocationPrefix(bucketName, s3key)
               ),
               space = StorageSpace(spaceName),
               callback = Some(Callback(testCallbackUri, Callback.Pending)),

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
@@ -73,8 +73,8 @@ class LookupIngestApiTest
                  |      "type": "Provider",
                  |      "id": "amazon-s3"
                  |    },
-                 |    "bucket": "${ingest.sourceLocation.location.namespace}",
-                 |    "path": "${ingest.sourceLocation.location.path}"
+                 |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
+                 |    "path": "${ingest.sourceLocation.prefix.path}"
                  |  },
                  |  "callback": {
                  |    "type": "Callback",

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
@@ -47,7 +47,7 @@ class IngestsTrackerApi[CallbackDestination, IngestsDestination](
             ingest =>
               ingestTracker.init(ingest) match {
                 case Right(_) =>
-                  info(s"Created ingest: ${ingest}")
+                  info(s"Created ingest: $ingest")
                   messagingService.send(ingest)
                   complete(StatusCodes.Created)
                 case Left(e: StateConflictError) =>

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -90,8 +90,8 @@ class NotifierFeatureTest
                  |      "type": "Provider",
                  |      "id": "amazon-s3"
                  |    },
-                 |    "bucket": "${ingest.sourceLocation.location.namespace}",
-                 |    "path": "${ingest.sourceLocation.location.path}"
+                 |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
+                 |    "path": "${ingest.sourceLocation.prefix.path}"
                  |  },
                  |  "callback": {
                  |    "type": "Callback",
@@ -201,8 +201,8 @@ class NotifierFeatureTest
                    |      "type": "Provider",
                    |      "id": "amazon-s3"
                    |    },
-                   |    "bucket": "${ingest.sourceLocation.location.namespace}",
-                   |    "path": "${ingest.sourceLocation.location.path}"
+                   |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
+                   |    "path": "${ingest.sourceLocation.prefix.path}"
                    |  },
                    |  "callback": {
                    |    "type": "Callback",

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -122,8 +122,8 @@ class CallbackUrlServiceTest
              |      "type": "Provider",
              |      "id": "amazon-s3"
              |    },
-             |    "bucket": "${ingest.sourceLocation.location.namespace}",
-             |    "path": "${ingest.sourceLocation.location.path}"
+             |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
+             |    "path": "${ingest.sourceLocation.prefix.path}"
              |  },
              |  "callback": {
              |    "type": "Callback",


### PR DESCRIPTION
Follows #607, part of wellcomecollection/platform#4596

When you start an ingest, you supply a SourceLocation. This could be S3 or Azure, and until now it's held a generic ObjectLocation. Changes:

* Ingests API: you can only upload a bag with the S3 provider. Anything else will be rejected immediately, because the unpacker doesn't support it.
* Strongly type the SourceLocation model with the appropriate provider/location model. We can’t try to unpack an S3 bag from an Azure location, or vice versa.
* Store a generic SourceLocation on the Ingest model. If we never add Azure support, it's just an extra `"type"` parameter in a few places; but we're set up to support it if we ever do.

This doesn't change the external interfaces – the ingests API or the indexed models. We will need to migrate the ingests table, so I’ll deploy this and look at that once this pull request is merged.