### PR TITLE
Tidy up the bag unpacker tests

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services
 
 import java.io.InputStream
-import java.text.NumberFormat
 import java.time.Instant
 
 import grizzled.slf4j.Logging
@@ -37,12 +36,6 @@ trait Unpacker extends Logging {
 
   def formatLocation(location: ObjectLocation): String
 
-  def createMessage(summary: UnpackSummary): String = {
-    val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
-    s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s"
-    else ""}"
-  }
-
   def unpack(
     ingestId: IngestID,
     srcLocation: ObjectLocation,
@@ -64,7 +57,7 @@ trait Unpacker extends Logging {
         Success(
           IngestStepSucceeded(
             summary,
-            maybeUserFacingMessage = Some(createMessage(summary))
+            maybeUserFacingMessage = Some(UnpackerMessage.create(summary))
           )
         )
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessage.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessage.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.services
+
+import java.text.NumberFormat
+
+import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
+
+object UnpackerMessage {
+
+  // Creates the human-readable message for the ingest status, e.g.
+  //
+  //    Unpacked 50MB from 30 files
+  //
+  def create(summary: UnpackSummary): String = {
+    val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
+    s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s"
+    else ""}"
+  }
+}

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -15,8 +15,7 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
+import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -89,42 +88,6 @@ trait BagUnpackerFixtures
       }
     }
 
-  // TODO: Add covariance to StreamStore
-  def withStreamStore[R](
-    testWith: TestWith[StreamStore[ObjectLocation], R]
-  ): R = {
-    val s3StreamStore = new S3StreamStore()
-
-    val store = new StreamStore[ObjectLocation] {
-      override def get(location: ObjectLocation): ReadEither =
-        s3StreamStore
-          .get(location)
-          .map { is =>
-            Identified(
-              is.id,
-              new InputStreamWithLength(
-                is.identifiedT,
-                length = is.identifiedT.length
-              )
-            )
-          }
-
-      override def put(
-        location: ObjectLocation
-      )(inputStream: InputStreamWithLength): WriteEither =
-        s3StreamStore
-          .put(location)(inputStream)
-          .map {
-            identified: Identified[ObjectLocation, InputStreamWithLength] =>
-              identified.copy(
-                identifiedT = new InputStreamWithLength(
-                  identified.identifiedT,
-                  length = identified.identifiedT.length
-                )
-              )
-          }
-    }
-
-    testWith(store)
-  }
+  def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R =
+    testWith(new S3StreamStore())
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -88,6 +88,8 @@ trait BagUnpackerFixtures
       }
     }
 
-  def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R =
+  def withStreamStore[R](
+    testWith: TestWith[StreamStore[ObjectLocation], R]
+  ): R =
     testWith(new S3StreamStore())
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
@@ -147,7 +147,7 @@ trait CompressFixture[Namespace]
       compressorOutputStream
     )
 
-    def finish() = {
+    def finish(): Unit = {
       archiveOutputStream.flush()
       archiveOutputStream.finish()
       compressorOutputStream.flush()
@@ -157,7 +157,7 @@ trait CompressFixture[Namespace]
     def addFile(
       file: File,
       entryName: String
-    ) = {
+    ): ArchiveEntry = {
       synchronized {
 
         val entry = archiveOutputStream

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
@@ -222,10 +222,3 @@ trait CompressFixture[Namespace]
     }
   }
 }
-
-case class TestArchive(
-  archiveFile: File,
-  containedFiles: List[File],
-  archiveEntries: Set[ArchiveEntry],
-  location: ObjectLocation
-)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
@@ -1,0 +1,54 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.services
+
+import java.time.Instant
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+
+import scala.util.Random
+
+class UnpackerMessageTest
+  extends AnyFunSpec
+    with Matchers
+    with StorageRandomThings
+    with ObjectLocationGenerators {
+  it("handles a single file correctly") {
+    val summary = createSummaryWith(fileCount = 1)
+
+    UnpackerMessage.create(summary) should endWith("from 1 file")
+  }
+
+  it("handles multiple files correctly") {
+    val summary = createSummaryWith(fileCount = 5)
+
+    UnpackerMessage.create(summary) should endWith("from 5 files")
+  }
+
+  it("adds a comma to the file counts if appropriate") {
+    val summary = createSummaryWith(fileCount = 123456789)
+
+    UnpackerMessage.create(summary) should endWith("from 123,456,789 files")
+  }
+
+  it("pretty-prints the file size") {
+    val summary = createSummaryWith(bytesUnpacked = 123456789)
+
+    UnpackerMessage.create(summary) should startWith("Unpacked 117 MB")
+  }
+
+  def createSummaryWith(
+    fileCount: Long = Random.nextLong(),
+    bytesUnpacked: Long = Random.nextLong()
+  ): UnpackSummary =
+    UnpackSummary(
+      ingestId = createIngestID,
+      srcLocation = createObjectLocation,
+      dstLocation = createObjectLocationPrefix,
+      fileCount = fileCount,
+      bytesUnpacked = bytesUnpacked,
+      startTime = Instant.now()
+    )
+}

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 import scala.util.Random
 
 class UnpackerMessageTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with StorageRandomThings
     with ObjectLocationGenerators {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services
 
 import java.io.{File, FileInputStream}
 import java.nio.file.Paths
-import java.time.Instant
 
 import org.scalatest.{Assertion, TryValues}
 import org.scalatest.funspec.AnyFunSpec
@@ -18,8 +17,6 @@ import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.StreamAssertions
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-
-import scala.util.Random
 
 trait UnpackerTestCases[StoreImpl <: StreamStore[ObjectLocation], Namespace]
     extends AnyFunSpec
@@ -174,55 +171,6 @@ trait UnpackerTestCases[StoreImpl <: StreamStore[ObjectLocation], Namespace]
         )
       }
     }
-  }
-
-  describe("creates the correct message") {
-    it("handles a single file correctly") {
-      val summary = createUnpackSummaryWith(fileCount = 1)
-
-      withUnpackerAndStore {
-        _.createMessage(summary) should endWith("from 1 file")
-      }
-    }
-
-    it("handles multiple files correctly") {
-      val summary = createUnpackSummaryWith(fileCount = 5)
-
-      withUnpackerAndStore {
-        _.createMessage(summary) should endWith("from 5 files")
-      }
-    }
-
-    it("adds a comma to the file counts if appropriate") {
-      val summary = createUnpackSummaryWith(fileCount = 123456789)
-
-      withUnpackerAndStore {
-        _.createMessage(summary) should endWith("from 123,456,789 files")
-      }
-    }
-
-    it("pretty-prints the file size") {
-      val summary = createUnpackSummaryWith(bytesUnpacked = 123456789)
-
-      withStreamStore { implicit streamStore =>
-        withUnpacker {
-          _.createMessage(summary) should startWith("Unpacked 117 MB")
-        }
-      }
-    }
-
-    def createUnpackSummaryWith(
-      fileCount: Long = Random.nextLong(),
-      bytesUnpacked: Long = Random.nextLong()
-    ): UnpackSummary =
-      UnpackSummary(
-        ingestId = createIngestID,
-        srcLocation = createObjectLocation,
-        dstLocation = createObjectLocationPrefix,
-        fileCount = fileCount,
-        bytesUnpacked = bytesUnpacked,
-        startTime = Instant.now()
-      )
   }
 
   def assertEqual(prefix: ObjectLocationPrefix, expectedFiles: Seq[File])(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -24,7 +24,9 @@ trait UnpackerTestCases[StoreImpl <: StreamStore[ObjectLocation], Namespace]
     with TryValues
     with CompressFixture[Namespace]
     with StreamAssertions {
-  def withUnpacker[R](testWith: TestWith[Unpacker, R])(implicit streamStore: StoreImpl): R
+  def withUnpacker[R](testWith: TestWith[Unpacker, R])(
+    implicit streamStore: StoreImpl
+  ): R
 
   private def withUnpackerAndStore[R](testWith: TestWith[Unpacker, R]): R =
     withStreamStore { implicit streamStore =>

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -21,17 +21,24 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.Random
 
-trait UnpackerTestCases[Namespace]
+trait UnpackerTestCases[StoreImpl <: StreamStore[ObjectLocation], Namespace]
     extends AnyFunSpec
     with Matchers
     with TryValues
     with CompressFixture[Namespace]
     with StreamAssertions {
-  val unpacker: Unpacker
+  def withUnpacker[R](testWith: TestWith[Unpacker, R])(implicit streamStore: StoreImpl): R
+
+  private def withUnpackerAndStore[R](testWith: TestWith[Unpacker, R]): R =
+    withStreamStore { implicit streamStore =>
+      withUnpacker { unpacker =>
+        testWith(unpacker)
+      }
+    }
 
   def withNamespace[R](testWith: TestWith[Namespace, R]): R
 
-  def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R
+  def withStreamStore[R](testWith: TestWith[StoreImpl, R]): R
 
   it("unpacks a tgz archive") {
     val (archiveFile, filesInArchive, _) = createTgzArchiveWithRandomFiles()
@@ -43,12 +50,14 @@ trait UnpackerTestCases[Namespace]
             val dstLocation =
               createObjectLocationWith(dstNamespace, path = "unpacker").asPrefix
 
-            val summaryResult = unpacker
-              .unpack(
-                ingestId = createIngestID,
-                srcLocation = archiveLocation,
-                dstLocation = dstLocation
-              )
+            val summaryResult =
+              withUnpacker {
+                _.unpack(
+                  ingestId = createIngestID,
+                  srcLocation = archiveLocation,
+                  dstLocation = dstLocation
+                )
+              }
 
             val unpacked = summaryResult.success.value
             unpacked shouldBe a[IngestStepSucceeded[_]]
@@ -81,12 +90,14 @@ trait UnpackerTestCases[Namespace]
           withArchive(srcNamespace, archiveFile) { archiveLocation =>
             val dstLocation =
               createObjectLocationWith(dstNamespace, path = "unpacker").asPrefix
-            val summaryResult = unpacker
-              .unpack(
-                ingestId = createIngestID,
-                srcLocation = archiveLocation,
-                dstLocation = dstLocation
-              )
+            val summaryResult =
+              withUnpacker {
+                _.unpack(
+                  ingestId = createIngestID,
+                  srcLocation = archiveLocation,
+                  dstLocation = dstLocation
+                )
+              }
 
             val unpacked = summaryResult.success.value
             unpacked shouldBe a[IngestStepSucceeded[_]]
@@ -110,11 +121,13 @@ trait UnpackerTestCases[Namespace]
       val srcLocation =
         createObjectLocationWith(srcNamespace, path = randomAlphanumeric)
       val result =
-        unpacker.unpack(
-          ingestId = createIngestID,
-          srcLocation = srcLocation,
-          dstLocation = createObjectLocationPrefix
-        )
+        withUnpackerAndStore {
+          _.unpack(
+            ingestId = createIngestID,
+            srcLocation = srcLocation,
+            dstLocation = createObjectLocationPrefix
+          )
+        }
 
       val ingestResult = result.success.value
       ingestResult shouldBe a[IngestFailed[_]]
@@ -141,11 +154,13 @@ trait UnpackerTestCases[Namespace]
         ) shouldBe a[Right[_, _]]
 
         val result =
-          unpacker.unpack(
-            ingestId = createIngestID,
-            srcLocation = srcLocation,
-            dstLocation = createObjectLocationPrefix
-          )
+          withUnpacker {
+            _.unpack(
+              ingestId = createIngestID,
+              srcLocation = srcLocation,
+              dstLocation = createObjectLocationPrefix
+            )
+          }
 
         val ingestResult = result.success.value
         ingestResult shouldBe a[IngestFailed[_]]
@@ -165,25 +180,35 @@ trait UnpackerTestCases[Namespace]
     it("handles a single file correctly") {
       val summary = createUnpackSummaryWith(fileCount = 1)
 
-      unpacker.createMessage(summary) should endWith("from 1 file")
+      withUnpackerAndStore {
+        _.createMessage(summary) should endWith("from 1 file")
+      }
     }
 
     it("handles multiple files correctly") {
       val summary = createUnpackSummaryWith(fileCount = 5)
 
-      unpacker.createMessage(summary) should endWith("from 5 files")
+      withUnpackerAndStore {
+        _.createMessage(summary) should endWith("from 5 files")
+      }
     }
 
     it("adds a comma to the file counts if appropriate") {
       val summary = createUnpackSummaryWith(fileCount = 123456789)
 
-      unpacker.createMessage(summary) should endWith("from 123,456,789 files")
+      withUnpackerAndStore {
+        _.createMessage(summary) should endWith("from 123,456,789 files")
+      }
     }
 
     it("pretty-prints the file size") {
       val summary = createUnpackSummaryWith(bytesUnpacked = 123456789)
 
-      unpacker.createMessage(summary) should startWith("Unpacked 117 MB")
+      withStreamStore { implicit streamStore =>
+        withUnpacker {
+          _.createMessage(summary) should startWith("Unpacked 117 MB")
+        }
+      }
     }
 
     def createUnpackSummaryWith(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
@@ -6,18 +6,21 @@ import uk.ac.wellcome.platform.archive.bagunpacker.services.{
   UnpackerTestCases
 }
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
-class MemoryUnpackerTest extends UnpackerTestCases[String] {
-  implicit val streamStore: MemoryStreamStore[ObjectLocation] =
-    MemoryStreamStore[ObjectLocation]()
-  override val unpacker: Unpacker = new MemoryUnpacker()
+class MemoryUnpackerTest
+  extends UnpackerTestCases[MemoryStreamStore[ObjectLocation], String] {
+
+  override def withUnpacker[R](testWith: TestWith[Unpacker, R])(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]
+  ): R =
+    testWith(
+      new MemoryUnpacker()
+    )
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
     testWith(randomAlphanumeric)
 
-  // TODO: Should we be sharing an instance between tests?
-  override def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R =
-    testWith(streamStore)
+  override def withStreamStore[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+    testWith(MemoryStreamStore[ObjectLocation]())
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
 class MemoryUnpackerTest
-  extends UnpackerTestCases[MemoryStreamStore[ObjectLocation], String] {
+    extends UnpackerTestCases[MemoryStreamStore[ObjectLocation], String] {
 
   override def withUnpacker[R](testWith: TestWith[Unpacker, R])(
     implicit streamStore: MemoryStreamStore[ObjectLocation]
@@ -21,6 +21,8 @@ class MemoryUnpackerTest
   override def withNamespace[R](testWith: TestWith[String, R]): R =
     testWith(randomAlphanumeric)
 
-  override def withStreamStore[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+  override def withStreamStore[R](
+    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]
+  ): R =
     testWith(MemoryStreamStore[ObjectLocation]())
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -20,10 +20,14 @@ import uk.ac.wellcome.storage.store.s3.S3StreamStore
 
 import scala.util.Try
 
-class S3UnpackerTest extends UnpackerTestCases[S3StreamStore, Bucket] with S3Fixtures {
+class S3UnpackerTest
+    extends UnpackerTestCases[S3StreamStore, Bucket]
+    with S3Fixtures {
   val unpacker: Unpacker = new S3Unpacker()
 
-  override def withUnpacker[R](testWith: TestWith[Unpacker, R])(implicit store: S3StreamStore): R =
+  override def withUnpacker[R](
+    testWith: TestWith[Unpacker, R]
+  )(implicit store: S3StreamStore): R =
     testWith(unpacker)
 
   override def withNamespace[R](testWith: TestWith[Bucket, R]): R =

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -16,21 +16,22 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ClientFactory
-import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.Try
 
-class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
-  override val unpacker: Unpacker = new S3Unpacker()
+class S3UnpackerTest extends UnpackerTestCases[S3StreamStore, Bucket] with S3Fixtures {
+  val unpacker: Unpacker = new S3Unpacker()
+
+  override def withUnpacker[R](testWith: TestWith[Unpacker, R])(implicit store: S3StreamStore): R =
+    testWith(unpacker)
 
   override def withNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
       testWith(bucket)
     }
 
-  override def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R =
+  override def withStreamStore[R](testWith: TestWith[S3StreamStore, R]): R =
     testWith(new S3StreamStore())
 
   it("fails if asked to write to a non-existent bucket") {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -18,8 +18,7 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ClientFactory
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
+import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.Try
 
@@ -31,43 +30,8 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
       testWith(bucket)
     }
 
-  override def withStreamStore[R](
-    testWith: TestWith[StreamStore[ObjectLocation], R]
-  ): R = {
-    val s3StreamStore = new S3StreamStore()
-
-    val store = new StreamStore[ObjectLocation] {
-      override def get(location: ObjectLocation): ReadEither =
-        s3StreamStore
-          .get(location)
-          .map { is =>
-            Identified(
-              is.id,
-              new InputStreamWithLength(
-                is.identifiedT,
-                length = is.identifiedT.length
-              )
-            )
-          }
-
-      override def put(
-        location: ObjectLocation
-      )(inputStream: InputStreamWithLength): WriteEither =
-        s3StreamStore
-          .put(location)(inputStream)
-          .map {
-            identified: Identified[ObjectLocation, InputStreamWithLength] =>
-              identified.copy(
-                identifiedT = new InputStreamWithLength(
-                  identified.identifiedT,
-                  length = identified.identifiedT.length
-                )
-              )
-          }
-    }
-
-    testWith(store)
-  }
+  override def withStreamStore[R](testWith: TestWith[StreamStore[ObjectLocation], R]): R =
+    testWith(new S3StreamStore())
 
   it("fails if asked to write to a non-existent bucket") {
     val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()


### PR DESCRIPTION
Some improvements found while working on wellcomecollection/platform#4596, pulled out as a separate patch.

* Remove an unused class
* We used to have to wrap the StreamStore from the storage library, but now the metadata is gone, no more!
* Don't share state between different tests, eww
* Pull out the unpacker messages into a standalone object for simpler testing