### PR TITLE
Verify that the verifier checks the URI scheme in fetch.txt

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -58,7 +58,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           _ <- verifyPayloadOxumFileCount(bag)
 
           _ <- verifyFetchPrefixes(
-            bag,
+            fetch = bag.fetch,
             root = ObjectLocationPrefix(
               namespace = namespace,
               path = s"$space/$externalIdentifier"

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
@@ -52,7 +52,8 @@ trait VerifyFetch {
           case _ =>
             Left(
               BagVerifierError(
-                s"fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme: ${mismatchedPaths.mkString(", ")}"
+                s"fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme: ${mismatchedPaths
+                  .mkString(", ")}"
               )
             )
         }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
@@ -22,10 +22,10 @@ trait VerifyFetch {
   // ensures that a single bag (same space/external identifier) is completely self-contained,
   // and we don't have to worry about interconnected bag dependencies.
   def verifyFetchPrefixes(
-    bag: Bag,
+    fetch: Option[BagFetch],
     root: ObjectLocationPrefix
   ): Either[BagVerifierError, Unit] =
-    bag.fetch match {
+    fetch match {
       case None => Right(())
 
       case Some(BagFetch(entries)) =>

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
@@ -52,7 +52,7 @@ trait VerifyFetch {
           case _ =>
             Left(
               BagVerifierError(
-                s"fetch.txt refers to paths in a mismatched prefix: ${mismatchedPaths.mkString(", ")}"
+                s"fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme: ${mismatchedPaths.mkString(", ")}"
               )
             )
         }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -318,11 +318,11 @@ class BagVerifierTest
       assertBagIncomplete(wrongSchemeBuilder) {
         case (ingestFailed, _) =>
           ingestFailed.e.getMessage should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
 
           ingestFailed.maybeUserFacingMessage.get should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
       }
     }
@@ -341,11 +341,11 @@ class BagVerifierTest
       assertBagIncomplete(wrongBucketFetchBuilder) {
         case (ingestFailed, _) =>
           ingestFailed.e.getMessage should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
 
           ingestFailed.maybeUserFacingMessage.get should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
       }
     }
@@ -368,11 +368,11 @@ class BagVerifierTest
       assertBagIncomplete(bagSpaceFetchBuilder) {
         case (ingestFailed, _) =>
           ingestFailed.e.getMessage should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
 
           ingestFailed.maybeUserFacingMessage.get should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
       }
     }
@@ -397,11 +397,11 @@ class BagVerifierTest
       assertBagIncomplete(badExternalIdentifierFetchBuilder) {
         case (ingestFailed, _) =>
           ingestFailed.e.getMessage should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
 
           ingestFailed.maybeUserFacingMessage.get should startWith(
-            "fetch.txt refers to paths in a mismatched prefix:"
+            "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
           )
       }
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
@@ -41,7 +41,7 @@ class VerifyFetchTest
       // Then check that it's *not* a valid fetch.txt if the URI points elsewhere
       getVerifyResult(scheme = "https")
         .left.value
-        .userMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix")
+        .userMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:")
     }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
@@ -6,12 +6,16 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagFetch, BagFetchMetadata, BagPath}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagFetch,
+  BagFetchMetadata,
+  BagPath
+}
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 class VerifyFetchTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with EitherValues
     with ObjectLocationGenerators {
@@ -39,9 +43,9 @@ class VerifyFetchTest
       getVerifyResult(scheme = "s3") shouldBe Right(())
 
       // Then check that it's *not* a valid fetch.txt if the URI points elsewhere
-      getVerifyResult(scheme = "https")
-        .left.value
-        .userMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:")
+      getVerifyResult(scheme = "https").left.value.userMessage.get should startWith(
+        "fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme:"
+      )
     }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
@@ -1,0 +1,47 @@
+package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
+
+import java.net.URI
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagFetch, BagFetchMetadata, BagPath}
+import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+
+class VerifyFetchTest
+  extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with ObjectLocationGenerators {
+
+  val verifier: VerifyFetch = new VerifyFetch {}
+
+  describe("verifyFetchPrefixes") {
+    it("detects a non-S3 URI") {
+      def getVerifyResult(scheme: String): Either[BagVerifierError, Unit] =
+        verifier.verifyFetchPrefixes(
+          fetch = Some(
+            BagFetch(
+              entries = Map(
+                BagPath("data/cat.jpg") -> BagFetchMetadata(
+                  uri = new URI(s"$scheme://my-bukkit/b1234/data/cat.jpg"),
+                  length = None
+                )
+              )
+            )
+          ),
+          root = ObjectLocationPrefix(namespace = "my-bukkit", path = "b1234")
+        )
+
+      // First check this is a valid fetch.txt if the URI points to an S3 bucket
+      getVerifyResult(scheme = "s3") shouldBe Right(())
+
+      // Then check that it's *not* a valid fetch.txt if the URI points elsewhere
+      getVerifyResult(scheme = "https")
+        .left.value
+        .userMessage.get should startWith("fetch.txt refers to paths in a mismatched prefix")
+    }
+  }
+}


### PR DESCRIPTION
I wasn't sure if it did, and stumbled across it while doing ObjectLocation work. Added a test that, yes, it really does the right thing.