### PR TITLE
Use the new per-provider Location models inside the bag unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
@@ -5,18 +5,18 @@ import java.time.Instant
 import org.apache.commons.io.FileUtils
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
-case class UnpackSummary(
+case class UnpackSummary[SrcLocation <: Location, DstPrefix <: Prefix[_]](
   ingestId: IngestID,
-  srcLocation: ObjectLocation,
-  dstLocation: ObjectLocationPrefix,
+  srcLocation: SrcLocation,
+  dstPrefix: DstPrefix,
   fileCount: Long = 0L,
   bytesUnpacked: Long = 0L,
   startTime: Instant,
   maybeEndTime: Option[Instant] = None
 ) extends Summary {
-  def complete: UnpackSummary =
+  def complete: UnpackSummary[SrcLocation, DstPrefix] =
     this.copy(maybeEndTime = Some(Instant.now()))
 
   def size: String =
@@ -25,7 +25,7 @@ case class UnpackSummary(
   override val fieldsToLog: Seq[(String, Any)] =
     Seq(
       ("src", srcLocation),
-      ("dst", dstLocation),
+      ("dst", dstPrefix),
       ("files", fileCount),
       ("bytesUnpacked", bytesUnpacked),
       ("size", size)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -27,7 +27,11 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   bagUnpackerWorkerConfig: BagUnpackerWorkerConfig,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
-  unpacker: Unpacker[S3ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix],
+  unpacker: Unpacker[
+    S3ObjectLocation,
+    S3ObjectLocation,
+    S3ObjectLocationPrefix
+  ],
   val metricsNamespace: String
 )(
   implicit val mc: MetricsMonitoringClient,

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.platform.archive.common.{
   SourceLocationPayload,
   UnpackedBagLocationPayload
 }
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.util.Try
 
@@ -26,7 +27,7 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   bagUnpackerWorkerConfig: BagUnpackerWorkerConfig,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
-  unpacker: Unpacker,
+  unpacker: Unpacker[S3ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix],
   val metricsNamespace: String
 )(
   implicit val mc: MetricsMonitoringClient,
@@ -49,8 +50,8 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       stepResult <- unpacker.unpack(
         ingestId = payload.ingestId,
-        srcLocation = payload.sourceLocation,
-        dstLocation = unpackedBagLocation
+        srcLocation = S3ObjectLocation(payload.sourceLocation),
+        dstPrefix = S3ObjectLocationPrefix(unpackedBagLocation)
       )
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -34,11 +34,11 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[SourceLocationPayload]
-) extends IngestStepWorker[SourceLocationPayload, UnpackSummary] {
+) extends IngestStepWorker[SourceLocationPayload, UnpackSummary[_, _]] {
 
   def processMessage(
     payload: SourceLocationPayload
-  ): Try[IngestStepResult[UnpackSummary]] =
+  ): Try[IngestStepResult[UnpackSummary[_, _]]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -37,12 +37,12 @@ trait Unpacker[
     ingestId: IngestID,
     srcLocation: SrcLocation,
     dstPrefix: DstPrefix
-  ): Try[IngestStepResult[UnpackSummary]] = {
+  ): Try[IngestStepResult[UnpackSummary[SrcLocation, DstPrefix]]] = {
     val unpackSummary =
       UnpackSummary(
         ingestId = ingestId,
-        srcLocation = srcLocation.toObjectLocation,
-        dstLocation = dstPrefix.toObjectLocationPrefix,
+        srcLocation = srcLocation,
+        dstPrefix = dstPrefix,
         startTime = Instant.now
       )
 
@@ -94,10 +94,10 @@ trait Unpacker[
     }
 
   private def unpack(
-    unpackSummary: UnpackSummary,
+    unpackSummary: UnpackSummary[SrcLocation, DstPrefix],
     srcStream: InputStream,
     dstPrefix: DstPrefix
-  ): Either[UnpackerError, UnpackSummary] =
+  ): Either[UnpackerError, UnpackSummary[SrcLocation, DstPrefix]] =
     Unarchiver.open(srcStream) match {
       case Left(unarchiverError) =>
         Left(UnpackerUnarchiverError(unarchiverError))

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -19,9 +19,10 @@ import uk.ac.wellcome.storage._
 import scala.util.{Failure, Success, Try}
 
 trait Unpacker[
-    SrcLocation <: Location,
-    DstLocation <: Location,
-    DstPrefix <: Prefix[DstLocation]] extends Logging {
+  SrcLocation <: Location,
+  DstLocation <: Location,
+  DstPrefix <: Prefix[DstLocation]
+] extends Logging {
 
   // The unpacker asks for separate get/put methods rather than a Store
   // because it might be unpacking/uploading to different providers.

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -14,42 +14,44 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepSucceeded
 }
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{
-  DoesNotExistError,
-  ObjectLocation,
-  ObjectLocationPrefix,
-  StorageError
-}
+import uk.ac.wellcome.storage._
 
 import scala.util.{Failure, Success, Try}
 
-trait Unpacker extends Logging {
+trait Unpacker[
+    SrcLocation <: Location,
+    DstLocation <: Location,
+    DstPrefix <: Prefix[DstLocation]] extends Logging {
+
   // The unpacker asks for separate get/put methods rather than a Store
   // because it might be unpacking/uploading to different providers.
   //
   // e.g. we might unpack a package from an S3 bucket, then upload it to Azure.
   //
-  def get(location: ObjectLocation): Either[StorageError, InputStream]
-  def put(location: ObjectLocation)(
+  def get(location: SrcLocation): Either[StorageError, InputStream]
+  def put(location: DstLocation)(
     inputStream: InputStreamWithLength
   ): Either[StorageError, Unit]
 
-  def formatLocation(location: ObjectLocation): String
-
   def unpack(
     ingestId: IngestID,
-    srcLocation: ObjectLocation,
-    dstLocation: ObjectLocationPrefix
+    srcLocation: SrcLocation,
+    dstPrefix: DstPrefix
   ): Try[IngestStepResult[UnpackSummary]] = {
     val unpackSummary =
-      UnpackSummary(ingestId, srcLocation, dstLocation, startTime = Instant.now)
+      UnpackSummary(
+        ingestId = ingestId,
+        srcLocation = srcLocation.toObjectLocation,
+        dstLocation = dstPrefix.toObjectLocationPrefix,
+        startTime = Instant.now
+      )
 
     val result = for {
       srcStream <- get(srcLocation).left.map { storageError =>
         UnpackerStorageError(storageError)
       }
 
-      unpackSummary <- unpack(unpackSummary, srcStream, dstLocation)
+      unpackSummary <- unpack(unpackSummary, srcStream, dstPrefix)
     } yield unpackSummary
 
     result match {
@@ -76,16 +78,16 @@ trait Unpacker extends Logging {
   }
 
   protected def buildMessageFor(
-    srcLocation: ObjectLocation,
+    srcLocation: SrcLocation,
     error: UnpackerError
   ): Option[String] =
     error match {
       case UnpackerStorageError(_: DoesNotExistError) =>
-        Some(s"There is no archive at ${formatLocation(srcLocation)}")
+        Some(s"There is no archive at $srcLocation")
 
       case UnpackerUnarchiverError(_) =>
         Some(
-          s"Error trying to unpack the archive at ${formatLocation(srcLocation)} - is it the correct format?"
+          s"Error trying to unpack the archive at $srcLocation - is it the correct format?"
         )
 
       case _ => None
@@ -94,7 +96,7 @@ trait Unpacker extends Logging {
   private def unpack(
     unpackSummary: UnpackSummary,
     srcStream: InputStream,
-    dstLocation: ObjectLocationPrefix
+    dstPrefix: DstPrefix
   ): Either[UnpackerError, UnpackSummary] =
     Unarchiver.open(srcStream) match {
       case Left(unarchiverError) =>
@@ -116,7 +118,7 @@ trait Unpacker extends Logging {
                 val uploadedBytes = putObject(
                   inputStream = entryStream,
                   archiveEntry = archiveEntry,
-                  destination = dstLocation
+                  dstPrefix = dstPrefix
                 )
 
                 totalFiles += 1
@@ -139,9 +141,9 @@ trait Unpacker extends Logging {
   private def putObject(
     inputStream: InputStream,
     archiveEntry: ArchiveEntry,
-    destination: ObjectLocationPrefix
+    dstPrefix: DstPrefix
   ): Long = {
-    val uploadLocation = destination.asLocation(archiveEntry.getName)
+    val uploadLocation = dstPrefix.asLocation(archiveEntry.getName)
 
     val archiveEntrySize = archiveEntry.getSize
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessage.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessage.scala
@@ -10,7 +10,7 @@ object UnpackerMessage {
   //
   //    Unpacked 50MB from 30 files
   //
-  def create(summary: UnpackSummary): String = {
+  def create(summary: UnpackSummary[_, _]): String = {
     val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
     s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s"
     else ""}"

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
@@ -3,26 +3,23 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services.memory
 import java.io.InputStream
 
 import uk.ac.wellcome.platform.archive.bagunpacker.services.Unpacker
-import uk.ac.wellcome.storage.{ObjectLocation, StorageError}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
+import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix, StorageError}
 
-class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[ObjectLocation])
-    extends Unpacker {
+class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[MemoryLocation])
+    extends Unpacker[MemoryLocation, MemoryLocation, MemoryLocationPrefix] {
   override def get(
-    location: ObjectLocation
+    location: MemoryLocation
   ): Either[StorageError, InputStream] =
     streamStore.get(location).map { _.identifiedT }
 
   override def put(
-    location: ObjectLocation
+    location: MemoryLocation
   )(inputStream: InputStreamWithLength): Either[StorageError, Unit] =
     streamStore
       .put(location)(inputStream)
       .map { _ =>
         ()
       }
-
-  override def formatLocation(location: ObjectLocation): String =
-    s"mem://$location"
 }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
@@ -5,7 +5,11 @@ import java.io.InputStream
 import uk.ac.wellcome.platform.archive.bagunpacker.services.Unpacker
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix, StorageError}
+import uk.ac.wellcome.storage.{
+  MemoryLocation,
+  MemoryLocationPrefix,
+  StorageError
+}
 
 class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[MemoryLocation])
     extends Unpacker[MemoryLocation, MemoryLocation, MemoryLocationPrefix] {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -11,7 +11,10 @@ import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.s3.S3CompressFixture
 import uk.ac.wellcome.platform.archive.common.UnpackedBagLocationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 class UnpackerFeatureTest
@@ -32,7 +35,9 @@ class UnpackerFeatureTest
           withLocalS3Bucket { srcBucket =>
             withArchive(srcBucket, archiveFile) { archiveLocation =>
               val sourceLocationPayload =
-                createSourceLocationPayloadWith(archiveLocation.toObjectLocation)
+                createSourceLocationPayloadWith(
+                  archiveLocation.toObjectLocation
+                )
               sendNotificationToSQS(queue, sourceLocationPayload)
 
               eventually {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -6,19 +6,13 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
-  BagUnpackerFixtures,
-  CompressFixture
-}
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.BagUnpackerFixtures
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.s3.S3CompressFixture
 import uk.ac.wellcome.platform.archive.common.UnpackedBagLocationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
 import uk.ac.wellcome.storage.ObjectLocationPrefix
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 class UnpackerFeatureTest
     extends AnyFunSpec
@@ -26,7 +20,7 @@ class UnpackerFeatureTest
     with Eventually
     with BagUnpackerFixtures
     with IntegrationPatience
-    with CompressFixture[Bucket]
+    with S3CompressFixture
     with IngestUpdateAssertions
     with PayloadGenerators {
 
@@ -38,7 +32,7 @@ class UnpackerFeatureTest
           withLocalS3Bucket { srcBucket =>
             withArchive(srcBucket, archiveFile) { archiveLocation =>
               val sourceLocationPayload =
-                createSourceLocationPayloadWith(archiveLocation)
+                createSourceLocationPayloadWith(archiveLocation.toObjectLocation)
               sendNotificationToSQS(queue, sourceLocationPayload)
 
               eventually {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -11,11 +11,11 @@ import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWork
 import uk.ac.wellcome.platform.archive.bagunpacker.services.BagUnpackerWorker
 import uk.ac.wellcome.platform.archive.bagunpacker.services.s3.S3Unpacker
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
+import uk.ac.wellcome.storage.S3ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.store.s3.NewS3StreamStore
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -89,7 +89,7 @@ trait BagUnpackerFixtures
     }
 
   def withStreamStore[R](
-    testWith: TestWith[StreamStore[ObjectLocation], R]
+    testWith: TestWith[StreamStore[S3ObjectLocation], R]
   ): R =
-    testWith(new S3StreamStore())
+    testWith(new NewS3StreamStore())
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
@@ -15,30 +15,27 @@ import org.apache.commons.compress.compressors.{
 import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.Location
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
-trait CompressFixture[Namespace]
+trait CompressFixture[BagLocation <: Location, Namespace]
     extends StorageRandomThings
     with S3Fixtures
     with Logging {
 
   val defaultFileCount = 10
 
-  def createObjectLocationWith(
-    namespace: Namespace,
-    path: String
-  ): ObjectLocation
+  def createLocationWith(namespace: Namespace, path: String): BagLocation
 
   def withArchive[R](
     namespace: Namespace,
     archiveFile: File
-  )(testWith: TestWith[ObjectLocation, R])(
-    implicit streamStore: StreamStore[ObjectLocation]
+  )(testWith: TestWith[BagLocation, R])(
+    implicit streamStore: StreamStore[BagLocation]
   ): R = {
-    val location = createObjectLocationWith(
+    val location = createLocationWith(
       namespace = namespace,
       path = archiveFile.getName
     )

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/s3/S3CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/s3/S3CompressFixture.scala
@@ -5,7 +5,12 @@ import uk.ac.wellcome.storage.S3ObjectLocation
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
-trait S3CompressFixture extends CompressFixture[S3ObjectLocation, Bucket] with NewS3Fixtures {
-  override def createLocationWith(bucket: Bucket, key: String): S3ObjectLocation =
+trait S3CompressFixture
+    extends CompressFixture[S3ObjectLocation, Bucket]
+    with NewS3Fixtures {
+  override def createLocationWith(
+    bucket: Bucket,
+    key: String
+  ): S3ObjectLocation =
     createS3ObjectLocationWith(bucket, key = key)
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/s3/S3CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/s3/S3CompressFixture.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.fixtures.s3
+
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
+import uk.ac.wellcome.storage.S3ObjectLocation
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+
+trait S3CompressFixture extends CompressFixture[S3ObjectLocation, Bucket] with NewS3Fixtures {
+  override def createLocationWith(bucket: Bucket, key: String): S3ObjectLocation =
+    createS3ObjectLocationWith(bucket, key = key)
+}

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
@@ -9,10 +9,8 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
-  BagUnpackerFixtures,
-  CompressFixture
-}
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.BagUnpackerFixtures
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.s3.S3CompressFixture
 import uk.ac.wellcome.platform.archive.common.UnpackedBagLocationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -27,7 +25,7 @@ class BagUnpackerWorkerTest
     extends AnyFunSpec
     with Matchers
     with BagUnpackerFixtures
-    with CompressFixture[Bucket]
+    with S3CompressFixture
     with IngestUpdateAssertions
     with PayloadGenerators
     with TryValues {
@@ -43,7 +41,7 @@ class BagUnpackerWorkerTest
         withLocalS3Bucket { dstBucket =>
           withArchive(srcBucket, archiveFile) { archiveLocation =>
             val payload =
-              createSourceLocationPayloadWith(archiveLocation)
+              createSourceLocationPayloadWith(archiveLocation.toObjectLocation)
 
             val result =
               withWorker(ingests, outgoing, dstBucket) { worker =>

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
@@ -6,15 +6,14 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix}
 
 import scala.util.Random
 
 class UnpackerMessageTest
     extends AnyFunSpec
     with Matchers
-    with StorageRandomThings
-    with ObjectLocationGenerators {
+    with StorageRandomThings {
   it("handles a single file correctly") {
     val summary = createSummaryWith(fileCount = 1)
 
@@ -42,11 +41,17 @@ class UnpackerMessageTest
   def createSummaryWith(
     fileCount: Long = Random.nextLong(),
     bytesUnpacked: Long = Random.nextLong()
-  ): UnpackSummary =
+  ): UnpackSummary[_, _] =
     UnpackSummary(
       ingestId = createIngestID,
-      srcLocation = createObjectLocation,
-      dstLocation = createObjectLocationPrefix,
+      srcLocation = MemoryLocation(
+        namespace = randomAlphanumeric,
+        path = randomAlphanumeric
+      ),
+      dstPrefix = MemoryLocationPrefix(
+        namespace = randomAlphanumeric,
+        pathPrefix = randomAlphanumeric
+      ),
       fileCount = fileCount,
       bytesUnpacked = bytesUnpacked,
       startTime = Instant.now()

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -142,7 +142,7 @@ trait UnpackerTestCases[
       ingestResult.summary.fileCount shouldBe 0
       ingestResult.summary.bytesUnpacked shouldBe 0
 
-      val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+      val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary[_, _]]]
       ingestFailed.maybeUserFacingMessage.get should startWith(
         "There is no archive at"
       )
@@ -173,7 +173,7 @@ trait UnpackerTestCases[
         ingestResult.summary.bytesUnpacked shouldBe 0
 
         val ingestFailed =
-          ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+          ingestResult.asInstanceOf[IngestFailed[UnpackSummary[_, _]]]
         ingestFailed.maybeUserFacingMessage.get should startWith(
           s"Error trying to unpack the archive at"
         )

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -9,27 +9,32 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.StreamAssertions
 import uk.ac.wellcome.storage.{Location, Prefix}
 
-trait UnpackerTestCases[
-  BagLocation <: Location,
-  BagPrefix <: Prefix[BagLocation],
-  StoreImpl <: StreamStore[BagLocation],
-  Namespace]
+trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+], StoreImpl <: StreamStore[BagLocation], Namespace]
     extends AnyFunSpec
     with Matchers
     with TryValues
     with CompressFixture[BagLocation, Namespace]
     with StreamAssertions {
-  def withUnpacker[R](testWith: TestWith[Unpacker[BagLocation, BagLocation, BagPrefix], R])(
+  def withUnpacker[R](
+    testWith: TestWith[Unpacker[BagLocation, BagLocation, BagPrefix], R]
+  )(
     implicit streamStore: StoreImpl
   ): R
 
-  private def withUnpackerAndStore[R](testWith: TestWith[Unpacker[BagLocation, BagLocation, BagPrefix], R]): R =
+  private def withUnpackerAndStore[R](
+    testWith: TestWith[Unpacker[BagLocation, BagLocation, BagPrefix], R]
+  ): R =
     withStreamStore { implicit streamStore =>
       withUnpacker { unpacker =>
         testWith(unpacker)
@@ -40,10 +45,19 @@ trait UnpackerTestCases[
 
   def withStreamStore[R](testWith: TestWith[StoreImpl, R]): R
 
-  def createSrcLocationWith(namespace: Namespace, path: String = randomAlphanumeric): BagLocation
-  def createDstPrefixWith(namespace: Namespace, pathPrefix: String = randomAlphanumeric): BagPrefix
+  def createSrcLocationWith(
+    namespace: Namespace,
+    path: String = randomAlphanumeric
+  ): BagLocation
+  def createDstPrefixWith(
+    namespace: Namespace,
+    pathPrefix: String = randomAlphanumeric
+  ): BagPrefix
 
-  override def createLocationWith(namespace: Namespace, path: String): BagLocation =
+  override def createLocationWith(
+    namespace: Namespace,
+    path: String
+  ): BagLocation =
     createSrcLocationWith(namespace = namespace, path = path)
 
   def createDstPrefix: BagPrefix =
@@ -58,7 +72,8 @@ trait UnpackerTestCases[
       withNamespace { dstNamespace =>
         withStreamStore { implicit streamStore =>
           withArchive(srcNamespace, archiveFile) { archiveLocation =>
-            val dstPrefix = createDstPrefixWith(dstNamespace, pathPrefix = "unpacker")
+            val dstPrefix =
+              createDstPrefixWith(dstNamespace, pathPrefix = "unpacker")
 
             val summaryResult =
               withUnpacker {
@@ -98,7 +113,8 @@ trait UnpackerTestCases[
       withNamespace { dstNamespace =>
         withStreamStore { implicit streamStore =>
           withArchive(srcNamespace, archiveFile) { archiveLocation =>
-            val dstPrefix = createDstPrefixWith(dstNamespace, pathPrefix = "unpacker")
+            val dstPrefix =
+              createDstPrefixWith(dstNamespace, pathPrefix = "unpacker")
             val summaryResult =
               withUnpacker {
                 _.unpack(
@@ -142,7 +158,8 @@ trait UnpackerTestCases[
       ingestResult.summary.fileCount shouldBe 0
       ingestResult.summary.bytesUnpacked shouldBe 0
 
-      val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary[_, _]]]
+      val ingestFailed =
+        ingestResult.asInstanceOf[IngestFailed[UnpackSummary[_, _]]]
       ingestFailed.maybeUserFacingMessage.get should startWith(
         "There is no archive at"
       )

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
@@ -1,14 +1,27 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{Unpacker, UnpackerTestCases}
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{
+  Unpacker,
+  UnpackerTestCases
+}
 import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
 class MemoryUnpackerTest
-    extends UnpackerTestCases[MemoryLocation, MemoryLocationPrefix, MemoryStreamStore[MemoryLocation], String] {
+    extends UnpackerTestCases[
+      MemoryLocation,
+      MemoryLocationPrefix,
+      MemoryStreamStore[MemoryLocation],
+      String
+    ] {
 
-  override def withUnpacker[R](testWith: TestWith[Unpacker[MemoryLocation, MemoryLocation, MemoryLocationPrefix], R])(
+  override def withUnpacker[R](
+    testWith: TestWith[
+      Unpacker[MemoryLocation, MemoryLocation, MemoryLocationPrefix],
+      R
+    ]
+  )(
     implicit streamStore: MemoryStreamStore[MemoryLocation]
   ): R =
     testWith(
@@ -23,9 +36,15 @@ class MemoryUnpackerTest
   ): R =
     testWith(MemoryStreamStore[MemoryLocation]())
 
-  override def createSrcLocationWith(namespace: String, path: String): MemoryLocation =
+  override def createSrcLocationWith(
+    namespace: String,
+    path: String
+  ): MemoryLocation =
     MemoryLocation(namespace = namespace, path = path)
 
-  override def createDstPrefixWith(namespace: String, pathPrefix: String): MemoryLocationPrefix =
+  override def createDstPrefixWith(
+    namespace: String,
+    pathPrefix: String
+  ): MemoryLocationPrefix =
     MemoryLocationPrefix(namespace = namespace, pathPrefix = pathPrefix)
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpackerTest.scala
@@ -1,18 +1,15 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{
-  Unpacker,
-  UnpackerTestCases
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{Unpacker, UnpackerTestCases}
+import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
 class MemoryUnpackerTest
-    extends UnpackerTestCases[MemoryStreamStore[ObjectLocation], String] {
+    extends UnpackerTestCases[MemoryLocation, MemoryLocationPrefix, MemoryStreamStore[MemoryLocation], String] {
 
-  override def withUnpacker[R](testWith: TestWith[Unpacker, R])(
-    implicit streamStore: MemoryStreamStore[ObjectLocation]
+  override def withUnpacker[R](testWith: TestWith[Unpacker[MemoryLocation, MemoryLocation, MemoryLocationPrefix], R])(
+    implicit streamStore: MemoryStreamStore[MemoryLocation]
   ): R =
     testWith(
       new MemoryUnpacker()
@@ -22,7 +19,13 @@ class MemoryUnpackerTest
     testWith(randomAlphanumeric)
 
   override def withStreamStore[R](
-    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]
+    testWith: TestWith[MemoryStreamStore[MemoryLocation], R]
   ): R =
-    testWith(MemoryStreamStore[ObjectLocation]())
+    testWith(MemoryStreamStore[MemoryLocation]())
+
+  override def createSrcLocationWith(namespace: String, path: String): MemoryLocation =
+    MemoryLocation(namespace = namespace, path = path)
+
+  override def createDstPrefixWith(namespace: String, pathPrefix: String): MemoryLocationPrefix =
+    MemoryLocationPrefix(namespace = namespace, pathPrefix = pathPrefix)
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3StreamReaderTest.scala
@@ -1,26 +1,24 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services.s3
 
 import org.mockito.{Mockito, Matchers => MockitoMatchers}
-import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.streaming.Codec._
 
 class S3StreamReaderTest
     extends AnyFunSpec
     with Matchers
-    with S3Fixtures
-    with StorageRandomThings
-    with EitherValues {
+    with NewS3Fixtures
+    with StorageRandomThings {
   it("makes multiple GetObject requests") {
     withLocalS3Bucket { bucket =>
-      val location = createObjectLocationWith(bucket)
+      val location = createS3ObjectLocationWith(bucket)
 
       s3Client.putObject(
-        location.namespace,
-        location.path,
+        location.bucket,
+        location.key,
         randomAlphanumericWithLength(length = 1000)
       )
 
@@ -45,9 +43,9 @@ class S3StreamReaderTest
   it("joins multiple GetObject streams correctly") {
     withLocalS3Bucket { bucket =>
       val message = randomAlphanumericWithLength(length = 1000)
-      val location = createObjectLocationWith(bucket)
+      val location = createS3ObjectLocationWith(bucket)
 
-      s3Client.putObject(location.namespace, location.path, message)
+      s3Client.putObject(location.bucket, location.key, message)
 
       val reader = new S3StreamReader(bufferSize = 500)
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -59,7 +59,7 @@ class S3UnpackerTest
           ingestResult.summary.bytesUnpacked shouldBe 0
 
           val underlyingError =
-            ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+            ingestResult.asInstanceOf[IngestFailed[UnpackSummary[_, _]]]
           underlyingError.e shouldBe a[AmazonS3Exception]
           underlyingError.e.getMessage should startWith(
             "The specified bucket does not exist"
@@ -165,7 +165,7 @@ class S3UnpackerTest
     }
   }
 
-  private def assertIsError(result: Try[IngestStepResult[UnpackSummary]])(
+  private def assertIsError(result: Try[IngestStepResult[UnpackSummary[_, _]]])(
     checkMessage: Option[String] => Assertion
   ): Assertion = {
     val ingestResult = result.success.value

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -6,8 +6,14 @@ import org.scalatest.Assertion
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.s3.S3CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{Unpacker, UnpackerTestCases}
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult}
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{
+  Unpacker,
+  UnpackerTestCases
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult
+}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ClientFactory
 import uk.ac.wellcome.storage.store.s3.NewS3StreamStore
@@ -16,12 +22,20 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import scala.util.Try
 
 class S3UnpackerTest
-    extends UnpackerTestCases[S3ObjectLocation, S3ObjectLocationPrefix, NewS3StreamStore, Bucket]
+    extends UnpackerTestCases[
+      S3ObjectLocation,
+      S3ObjectLocationPrefix,
+      NewS3StreamStore,
+      Bucket
+    ]
     with S3CompressFixture {
   val unpacker: S3Unpacker = new S3Unpacker()
 
   override def withUnpacker[R](
-    testWith: TestWith[Unpacker[S3ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix], R]
+    testWith: TestWith[
+      Unpacker[S3ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix],
+      R
+    ]
   )(implicit store: NewS3StreamStore): R =
     testWith(unpacker)
 
@@ -33,10 +47,16 @@ class S3UnpackerTest
   override def withStreamStore[R](testWith: TestWith[NewS3StreamStore, R]): R =
     testWith(new NewS3StreamStore())
 
-  override def createSrcLocationWith(bucket: Bucket, key: String): S3ObjectLocation =
+  override def createSrcLocationWith(
+    bucket: Bucket,
+    key: String
+  ): S3ObjectLocation =
     createS3ObjectLocationWith(bucket, key = key)
 
-  override def createDstPrefixWith(bucket: Bucket, keyPrefix: String): S3ObjectLocationPrefix =
+  override def createDstPrefixWith(
+    bucket: Bucket,
+    keyPrefix: String
+  ): S3ObjectLocationPrefix =
     createS3ObjectLocationPrefixWith(bucket, keyPrefix = keyPrefix)
 
   it("fails if asked to write to a non-existent bucket") {
@@ -45,7 +65,8 @@ class S3UnpackerTest
     withLocalS3Bucket { srcBucket =>
       withStreamStore { implicit streamStore =>
         withArchive(srcBucket, archiveFile) { archiveLocation =>
-          val dstPrefix = createS3ObjectLocationPrefixWith(bucket = createBucket)
+          val dstPrefix =
+            createS3ObjectLocationPrefixWith(bucket = createBucket)
           val result =
             unpacker.unpack(
               ingestId = createIngestID,

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -18,6 +18,9 @@ case class S3ObjectLocation(
   bucket: String,
   key: String
 ) extends Location {
+  override def toString: String =
+    s"s3://$bucket/$key"
+
   def toObjectLocation: ObjectLocation =
     ObjectLocation(
       namespace = this.bucket,
@@ -46,6 +49,9 @@ case class S3ObjectLocationPrefix(
   val namespace: String = bucket
   val path: String = keyPrefix
 
+  override def toString: String =
+    s"s3://$bucket/$keyPrefix"
+
   override def asLocation(parts: String*): S3ObjectLocation =
     S3ObjectLocation(
       bucket = bucket,
@@ -71,6 +77,9 @@ case class MemoryLocation(
   namespace: String,
   path: String
 ) extends Location {
+  override def toString: String =
+    s"mem://$namespace/$path"
+
   override def toObjectLocation: ObjectLocation =
     ObjectLocation(
       namespace = namespace,
@@ -91,6 +100,9 @@ case class MemoryLocationPrefix(
   pathPrefix: String
 ) extends Prefix[MemoryLocation] {
   val path: String = pathPrefix
+
+  override def toString: String =
+    s"mem://$namespace/$pathPrefix"
 
   override def asLocation(parts: String*): MemoryLocation =
     MemoryLocation(


### PR DESCRIPTION
This doesn't affect the interface between services, just the internals of the bag unpacker.

Another step towards https://github.com/wellcomecollection/platform/issues/4596