### PR TITLE
SourceLocation is an actual location, not a prefix

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -37,8 +37,7 @@ case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
     SourceLocationPayload(
       context = PipelineContext(ingest),
-      sourceLocation =
-        ingest.sourceLocation.prefix.toObjectLocationPrefix.asLocation()
+      sourceLocation = ingest.sourceLocation.location.toObjectLocation
     )
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -4,17 +4,17 @@ import uk.ac.wellcome.storage._
 
 sealed trait SourceLocation {
   val provider: StorageProvider
-  val prefix: Prefix[_]
+  val location: Location
 }
 
 case class S3SourceLocation(
-  prefix: S3ObjectLocationPrefix
+  location: S3ObjectLocation
 ) extends SourceLocation {
   val provider: StorageProvider = AmazonS3StorageProvider
 }
 
 case class AzureBlobSourceLocation(
-  prefix: AzureBlobItemLocationPrefix
+  location: AzureBlobItemLocation
 ) extends SourceLocation {
   val provider: StorageProvider = AzureBlobStorageProvider
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -6,9 +6,6 @@ trait Location {
 }
 
 trait Prefix[OfLocation <: Location] {
-  val namespace: String
-  val path: String
-
   def asLocation(parts: String*): OfLocation
 
   def toObjectLocationPrefix: ObjectLocationPrefix
@@ -46,9 +43,6 @@ case class S3ObjectLocationPrefix(
   bucket: String,
   keyPrefix: String
 ) extends Prefix[S3ObjectLocation] {
-  val namespace: String = bucket
-  val path: String = keyPrefix
-
   override def toString: String =
     s"s3://$bucket/$keyPrefix"
 
@@ -132,9 +126,6 @@ case class AzureBlobItemLocationPrefix(
   container: String,
   namePrefix: String
 ) extends Prefix[AzureBlobItemLocation] {
-  val namespace: String = container
-  val path: String = namePrefix
-
   override def asLocation(parts: String*): AzureBlobItemLocation =
     AzureBlobItemLocation(
       container = container,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -21,7 +21,7 @@ class SourceLocationPayloadTest
   it("creates a payload from an ingest") {
     val ingestId = createIngestID
     val ingestType = CreateIngestType
-    val sourcePrefix = createS3ObjectLocationPrefix
+    val sourceLocation = createS3ObjectLocation
     val space = createStorageSpace
     val ingestDate = Instant.now()
     val externalIdentifier = createExternalIdentifier
@@ -30,7 +30,7 @@ class SourceLocationPayloadTest
       id = ingestId,
       ingestType = ingestType,
       sourceLocation = S3SourceLocation(
-        prefix = sourcePrefix
+        location = sourceLocation
       ),
       space = space,
       createdDate = ingestDate,
@@ -47,7 +47,7 @@ class SourceLocationPayloadTest
         ingestDate = ingestDate,
         externalIdentifier = externalIdentifier
       ),
-      sourceLocation = sourcePrefix.asLocation().toObjectLocation
+      sourceLocation = sourceLocation.toObjectLocation
     )
 
     SourceLocationPayload(ingest) shouldBe expectedPayload

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -17,9 +17,7 @@ import scala.util.Random
 trait IngestGenerators extends BagIdGenerators with NewS3Fixtures {
 
   def createSourceLocation: SourceLocation =
-    S3SourceLocation(
-      prefix = createS3ObjectLocationPrefix
-    )
+    S3SourceLocation(location = createS3ObjectLocation)
 
   def createIngest: Ingest = createIngestWith()
 

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
@@ -7,10 +7,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   AzureBlobSourceLocation,
   S3SourceLocation
 }
-import uk.ac.wellcome.storage.{
-  AzureBlobItemLocationPrefix,
-  S3ObjectLocationPrefix
-}
+import uk.ac.wellcome.storage.{AzureBlobItemLocation, S3ObjectLocation}
 
 class DisplayLocationTest
     extends AnyFunSpec
@@ -20,28 +17,28 @@ class DisplayLocationTest
     ("internalLocation", "displayLocation"),
     (
       S3SourceLocation(
-        prefix = S3ObjectLocationPrefix(
+        location = S3ObjectLocation(
           bucket = "my-bukkit",
-          keyPrefix = "path/to/my/bag"
+          key = "path/to/my/bag.tar.gz"
         )
       ),
       DisplayLocation(
         provider = DisplayProvider("amazon-s3"),
         bucket = "my-bukkit",
-        path = "path/to/my/bag"
+        path = "path/to/my/bag.tar.gz"
       )
     ),
     (
       AzureBlobSourceLocation(
-        prefix = AzureBlobItemLocationPrefix(
+        location = AzureBlobItemLocation(
           container = "my-container",
-          namePrefix = "path/to/my/bag"
+          name = "path/to/my/bag.tar.gz"
         )
       ),
       DisplayLocation(
         provider = DisplayProvider("azure-blob-storage"),
         bucket = "my-container",
-        path = "path/to/my/bag"
+        path = "path/to/my/bag.tar.gz"
       )
     )
   )

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 class DisplayIngestTest
     extends AnyFunSpec
@@ -39,7 +39,7 @@ class DisplayIngestTest
         id = id,
         ingestType = CreateIngestType,
         sourceLocation = S3SourceLocation(
-          prefix = S3ObjectLocationPrefix("bukkit", "mybag")
+          location = S3ObjectLocation("bukkit", "mybag.tar.gz")
         ),
         space = StorageSpace(spaceId),
         callback = Some(Callback(new URI(callbackUrl))),
@@ -55,7 +55,7 @@ class DisplayIngestTest
       displayIngest.sourceLocation shouldBe DisplayLocation(
         DisplayProvider(id = "amazon-s3"),
         bucket = "bukkit",
-        path = "mybag"
+        path = "mybag.tar.gz"
       )
       displayIngest.callback shouldBe Some(
         DisplayCallback(
@@ -115,7 +115,7 @@ class DisplayIngestTest
     it("transforms itself into a ingest") {
       val displayProvider = DisplayProvider(id = "amazon-s3")
       val bucket = "ingest-bucket"
-      val path = "bag.zip"
+      val path = "bag.tar.gz"
 
       val externalIdentifier = createExternalIdentifier
 
@@ -140,7 +140,7 @@ class DisplayIngestTest
 
       ingest.id shouldBe a[IngestID]
       ingest.sourceLocation shouldBe S3SourceLocation(
-        prefix = S3ObjectLocationPrefix(bucket, path)
+        location = S3ObjectLocation(bucket, path)
       )
       ingest.callback shouldBe Some(
         Callback(URI.create(ingestCreateRequest.callback.get.url))

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -23,7 +23,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.archive.display.ingests._
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsApiFixture
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 /** Tests for POST /ingests
   *
@@ -45,7 +45,7 @@ class CreateIngestApiTest
         val url = s"$baseUrl/ingests"
 
         val bucketName = "bucket"
-        val s3key = "key.txt"
+        val s3key = "bag.tar.gz"
         val spaceName = "somespace"
 
         val externalIdentifier = createExternalIdentifier
@@ -101,7 +101,7 @@ class CreateIngestApiTest
               id = IngestID(id),
               ingestType = CreateIngestType,
               sourceLocation = S3SourceLocation(
-                prefix = S3ObjectLocationPrefix(bucketName, s3key)
+                location = S3ObjectLocation(bucketName, s3key)
               ),
               space = StorageSpace(spaceName),
               callback = Some(Callback(testCallbackUri, Callback.Pending)),

--- a/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/LookupIngestApiTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
+import uk.ac.wellcome.platform.archive.common.ingests.models.S3SourceLocation
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsApiFixture
 
 /** Tests for GET /ingests/:id
@@ -39,6 +40,9 @@ class LookupIngestApiTest
       case (_, _, metrics, baseUrl) =>
         whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
           result.status shouldBe StatusCodes.OK
+
+          val sourceLocation =
+            ingest.sourceLocation.asInstanceOf[S3SourceLocation]
 
           withStringEntity(result.entity) { jsonString =>
             assertJsonStringsAreEqual(
@@ -73,8 +77,8 @@ class LookupIngestApiTest
                  |      "type": "Provider",
                  |      "id": "amazon-s3"
                  |    },
-                 |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
-                 |    "path": "${ingest.sourceLocation.prefix.path}"
+                 |    "bucket": "${sourceLocation.location.bucket}",
+                 |    "path": "${sourceLocation.location.key}"
                  |  },
                  |  "callback": {
                  |    "type": "Callback",

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -13,12 +13,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Callback,
-  CallbackNotification,
-  IngestCallbackStatusUpdate,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{
   LocalWireMockFixture,
   NotifierFixtures
@@ -59,6 +54,9 @@ class NotifierFeatureTest
               CallbackNotification(ingestId, callbackUri, ingest)
             )
 
+            val ingestLocation =
+              ingest.sourceLocation.asInstanceOf[S3SourceLocation]
+
             val expectedJson =
               s"""
                  |{
@@ -90,8 +88,8 @@ class NotifierFeatureTest
                  |      "type": "Provider",
                  |      "id": "amazon-s3"
                  |    },
-                 |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
-                 |    "path": "${ingest.sourceLocation.prefix.path}"
+                 |    "bucket": "${ingestLocation.location.bucket}",
+                 |    "path": "${ingestLocation.location.key}"
                  |  },
                  |  "callback": {
                  |    "type": "Callback",
@@ -169,6 +167,9 @@ class NotifierFeatureTest
                 CallbackNotification(ingestID, callbackUri, ingest)
               )
 
+              val ingestLocation =
+                ingest.sourceLocation.asInstanceOf[S3SourceLocation]
+
               val expectedJson =
                 s"""
                    |{
@@ -201,8 +202,8 @@ class NotifierFeatureTest
                    |      "type": "Provider",
                    |      "id": "amazon-s3"
                    |    },
-                   |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
-                   |    "path": "${ingest.sourceLocation.prefix.path}"
+                   |    "bucket": "${ingestLocation.location.bucket}",
+                   |    "path": "${ingestLocation.location.key}"
                    |  },
                    |  "callback": {
                    |    "type": "Callback",

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, S3SourceLocation}
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{
   LocalWireMockFixture,
   NotifierFixtures
@@ -89,6 +89,9 @@ class CallbackUrlServiceTest
 
       val request = buildRequest(ingest, callbackUri)
 
+      val ingestLocation =
+        ingest.sourceLocation.asInstanceOf[S3SourceLocation]
+
       assertIsJsonRequest(request, uri = callbackUri) { requestJsonString =>
         assertJsonStringsAreEqual(
           requestJsonString,
@@ -122,8 +125,8 @@ class CallbackUrlServiceTest
              |      "type": "Provider",
              |      "id": "amazon-s3"
              |    },
-             |    "bucket": "${ingest.sourceLocation.prefix.namespace}",
-             |    "path": "${ingest.sourceLocation.prefix.path}"
+             |    "bucket": "${ingestLocation.location.bucket}",
+             |    "path": "${ingestLocation.location.key}"
              |  },
              |  "callback": {
              |    "type": "Callback",

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -18,7 +18,10 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, S3SourceLocation}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  S3SourceLocation
+}
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{
   LocalWireMockFixture,
   NotifierFixtures


### PR DESCRIPTION
The SourceLocation refers to the location of the compressed tar.gz bag, not a prefix under which all the files are unpacked.  We should store it as a Location, not a Prefix.

I only noticed this when I deployed it and looked at a new row in DynamoDB.

Part of https://github.com/wellcomecollection/platform/issues/4596