### PR TITLE
Continue to chip away at the bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -75,7 +75,7 @@ object Main extends WellcomeTypesafeApp {
 
     val verifier = new BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix](
       namespace = config.requireString("bag-verifier.primary-storage-bucket"),
-      toLocation =
+      toPrefix =
         (prefix: ObjectLocationPrefix) => S3ObjectLocationPrefix(prefix)
     )
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -24,7 +24,7 @@ import scala.util.Try
 class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
   namespace: String,
   // TODO: Temporary while we disambiguate ObjectLocation.  Remove eventually.
-  toLocation: ObjectLocationPrefix => BagPrefix
+  toPrefix: ObjectLocationPrefix => BagPrefix
 )(
   implicit bagReader: BagReader[BagLocation, BagPrefix],
   val resolvable: Resolvable[ObjectLocation],
@@ -108,7 +108,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
     root: ObjectLocationPrefix,
     startTime: Instant
   ): Either[BagVerifierError, Bag] =
-    bagReader.get(toLocation(root)) match {
+    bagReader.get(toPrefix(root)) match {
       case Left(bagUnavailable) =>
         Left(
           BagVerifierError(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -76,12 +76,16 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
               Left(BagVerifierError(listingFailure.e))
           }
 
-          _ <- verifyNoConcreteFetchEntries(
-            bag = bag,
-            root = root,
-            actualLocations = actualLocations,
-            verificationResult = verificationResult
-          )
+          _ <- verificationResult match {
+            case FixityListAllCorrect(_) =>
+              verifyNoConcreteFetchEntries(
+                fetch = bag.fetch,
+                root = root,
+                actualLocations = actualLocations
+              )
+
+            case _ => Right(())
+          }
 
           _ <- verifyNoUnreferencedFiles(
             root = root,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
@@ -59,7 +59,7 @@ trait VerifyFetch {
   def verifyNoConcreteFetchEntries(
     fetch: Option[BagFetch],
     root: ObjectLocationPrefix,
-    actualLocations: Seq[ObjectLocation],
+    actualLocations: Seq[ObjectLocation]
   ): Either[BagVerifierError, Unit] = {
     val bagFetchLocations: Seq[(BagPath, ObjectLocation)] = fetch match {
       case Some(bagFetch) =>
@@ -78,7 +78,9 @@ trait VerifyFetch {
     if (concreteFetchLocations.isEmpty) {
       Right(())
     } else {
-      val concretePaths = concreteFetchLocations.collect { case (bagPath, _) => bagPath }
+      val concretePaths = concreteFetchLocations.collect {
+        case (bagPath, _) => bagPath
+      }
 
       Left(
         BagVerifierError(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala
@@ -1,12 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FixityListAllCorrect,
-  FixityListResult
-}
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  Bag,
   BagFetch,
   BagFetchMetadata,
   BagPath
@@ -62,50 +57,43 @@ trait VerifyFetch {
   // Check that the user hasn't sent any files in the bag which
   // also have a fetch file entry.
   def verifyNoConcreteFetchEntries(
-    bag: Bag,
+    fetch: Option[BagFetch],
     root: ObjectLocationPrefix,
     actualLocations: Seq[ObjectLocation],
-    verificationResult: FixityListResult
-  ): Either[BagVerifierError, Unit] =
-    verificationResult match {
-      case FixityListAllCorrect(_) =>
-        val bagFetchLocations = bag.fetch match {
-          case Some(bagFetch) =>
-            bagFetch.paths
-              .map { path: BagPath =>
-                root.asLocation(path.value)
-              }
+  ): Either[BagVerifierError, Unit] = {
+    val bagFetchLocations = fetch match {
+      case Some(bagFetch) =>
+        bagFetch.paths
+          .map { path: BagPath =>
+            root.asLocation(path.value)
+          }
 
-          case None => Seq.empty
-        }
-
-        val concreteFetchLocations =
-          bagFetchLocations
-            .filter { actualLocations.contains(_) }
-
-        if (concreteFetchLocations.isEmpty) {
-          Right(())
-        } else {
-          val messagePrefix =
-            "Files referred to in the fetch.txt also appear in the bag: "
-
-          val internalMessage = messagePrefix + concreteFetchLocations.mkString(
-            ", "
-          )
-
-          val userMessage = messagePrefix +
-            concreteFetchLocations
-              .map { _.path.stripPrefix(root.path).stripPrefix("/") }
-              .mkString(", ")
-
-          Left(
-            BagVerifierError(
-              new Throwable(internalMessage),
-              userMessage = Some(userMessage)
-            )
-          )
-        }
-
-      case _ => Right(())
+      case None => Seq.empty
     }
+
+    val concreteFetchLocations =
+      bagFetchLocations
+        .filter { actualLocations.contains(_) }
+
+    if (concreteFetchLocations.isEmpty) {
+      Right(())
+    } else {
+      val messagePrefix =
+        "Files referred to in the fetch.txt also appear in the bag: "
+
+      val internalMessage = messagePrefix + concreteFetchLocations.mkString(", ")
+
+      val userMessage = messagePrefix +
+        concreteFetchLocations
+          .map { _.path.stripPrefix(root.path).stripPrefix("/") }
+          .mkString(", ")
+
+      Left(
+        BagVerifierError(
+          new Throwable(internalMessage),
+          userMessage = Some(userMessage)
+        )
+      )
+    }
+  }
 }

--- a/bag_verifier/src/test/resources/logback-test.xml
+++ b/bag_verifier/src/test/resources/logback-test.xml
@@ -8,4 +8,10 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -81,7 +81,7 @@ trait BagVerifierFixtures
 
       val verifier = new BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix](
         namespace = bucket.name,
-        toLocation =
+        toPrefix =
           (prefix: ObjectLocationPrefix) => S3ObjectLocationPrefix(prefix)
       )
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
@@ -54,7 +54,9 @@ class VerifyFetchTest
       verifier.verifyNoConcreteFetchEntries(
         fetch = None,
         root = createObjectLocationPrefix,
-        actualLocations = (1 to 5).map { _ => createObjectLocation }
+        actualLocations = (1 to 5).map { _ =>
+          createObjectLocation
+        }
       ) shouldBe Right(())
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetchTest.scala
@@ -48,4 +48,14 @@ class VerifyFetchTest
       )
     }
   }
+
+  describe("verifyNoConcreteFetchEntries") {
+    it("ignores a bag with no fetch entries") {
+      verifier.verifyNoConcreteFetchEntries(
+        fetch = None,
+        root = createObjectLocationPrefix,
+        actualLocations = (1 to 5).map { _ => createObjectLocation }
+      ) shouldBe Right(())
+    }
+  }
 }


### PR DESCRIPTION
Another step towards https://github.com/wellcomecollection/platform/issues/4596

The primary goal of this PR is to expunge `_.path.stripPrefix(root.path).stripPrefix("/")` where `_` is an old-style ObjectLocation, because getting a path from a new-style location is a bit trickier (and in this case, unnecessary). Plus some other general tidy-ups that don't change the functionality but make the code easier to work with.