### PR TITLE
Push BagLocation throughout the fixity checks in the verifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,6 +278,5 @@ Session.vim
 # temporary
 .netrwhist
 # auto-generated tag files
-tags
 
 # End of https://www.gitignore.io/api/osx,vim,java,linux,scala,python,textmate,intellij

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -4,7 +4,8 @@ sealed trait FileFixityResult[BagLocation] {
   val expectedFileFixity: ExpectedFileFixity
 }
 
-sealed trait FileFixityError[BagLocation] extends FileFixityResult[BagLocation] {
+sealed trait FileFixityError[BagLocation]
+    extends FileFixityResult[BagLocation] {
   val e: Throwable
 }
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -1,44 +1,40 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
-import uk.ac.wellcome.storage.ObjectLocation
-
-sealed trait FileFixityResult {
+sealed trait FileFixityResult[BagLocation] {
   val expectedFileFixity: ExpectedFileFixity
 }
 
-sealed trait FileFixityError extends FileFixityResult {
+sealed trait FileFixityError[BagLocation] extends FileFixityResult[BagLocation] {
   val e: Throwable
 }
 
-case class FileFixityCorrect(
+case class FileFixityCorrect[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: ObjectLocation,
+  objectLocation: BagLocation,
   // We record the size of the files as we verify them, so we can verify
   // the Payload-Oxum in the bag metadata.
   size: Long
-) extends FileFixityResult
+) extends FileFixityResult[BagLocation]
 
-case class FileFixityMismatch(
+case class FileFixityMismatch[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  objectLocation: Any,
+  objectLocation: BagLocation,
   e: Throwable
-) extends FileFixityError
+) extends FileFixityError[BagLocation]
 
-case class FileFixityCouldNotRead(
+case class FileFixityCouldNotRead[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
   e: Throwable
-) extends FileFixityError
+) extends FileFixityError[BagLocation]
 
-case class FileFixityCouldNotGetChecksum(
+case class FileFixityCouldNotGetChecksum[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: ObjectLocation,
+  objectLocation: BagLocation,
   e: Throwable
-) extends FileFixityError
+) extends FileFixityError[BagLocation]
 
-case class FileFixityCouldNotWriteTag(
+case class FileFixityCouldNotWriteTag[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: ObjectLocation,
+  objectLocation: BagLocation,
   e: Throwable
-) extends FileFixityError
+) extends FileFixityError[BagLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -28,7 +28,9 @@ trait FixityChecker[BagLocation <: Location] extends Logging {
 
   def locate(uri: URI): Either[LocateFailure[URI], BagLocation]
 
-  def check(expectedFileFixity: ExpectedFileFixity): FileFixityResult[BagLocation] = {
+  def check(
+    expectedFileFixity: ExpectedFileFixity
+  ): FileFixityResult[BagLocation] = {
     debug(s"Attempting to verify: $expectedFileFixity")
 
     val algorithm = expectedFileFixity.checksum.algorithm

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -12,14 +12,14 @@ class FixityListChecker[BagLocation <: Location, Container](
   verifiable: ExpectedFixity[Container],
   fixityChecker: FixityChecker[BagLocation]
 ) extends Logging {
-  def check(container: Container): FixityListResult = {
+  def check(container: Container): FixityListResult[BagLocation] = {
     debug(s"Checking the fixity info for $container")
     verifiable.create(container) match {
       case Left(err) => CouldNotCreateExpectedFixityList(err.msg)
       case Right(verifiableLocations) =>
         verifiableLocations
           .map(fixityChecker.check)
-          .foldLeft[FixityListCheckingResult](FixityListAllCorrect[BagLocation](Nil)) {
+          .foldLeft[FixityListCheckingResult[BagLocation]](FixityListAllCorrect(Nil)) {
 
             case (
                 existingCorrect: FixityListAllCorrect[BagLocation],

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -1,15 +1,16 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage.Location
 
 /** Given some Container of files, get the expected fixity information for every
   * file in the container, then verify the fixity on each of them.
   *
   */
-class FixityListChecker[Container](
+class FixityListChecker[BagLocation <: Location, Container](
   implicit
   verifiable: ExpectedFixity[Container],
-  fixityChecker: FixityChecker[_]
+  fixityChecker: FixityChecker[BagLocation]
 ) extends Logging {
   def check(container: Container): FixityListResult = {
     debug(s"Checking the fixity info for $container")
@@ -18,33 +19,33 @@ class FixityListChecker[Container](
       case Right(verifiableLocations) =>
         verifiableLocations
           .map(fixityChecker.check)
-          .foldLeft[FixityListCheckingResult](FixityListAllCorrect(Nil)) {
+          .foldLeft[FixityListCheckingResult](FixityListAllCorrect[BagLocation](Nil)) {
 
             case (
-                FixityListAllCorrect(locations),
-                correct: FileFixityCorrect
+                existingCorrect: FixityListAllCorrect[BagLocation],
+                newCorrect: FileFixityCorrect[BagLocation]
                 ) =>
-              FixityListAllCorrect(correct :: locations)
+              FixityListAllCorrect(newCorrect :: existingCorrect.locations)
 
-            case (FixityListAllCorrect(locations), err: FileFixityError) =>
+            case (correct: FixityListAllCorrect[BagLocation], err: FileFixityError[BagLocation]) =>
               FixityListWithErrors(
                 errors = List(err),
-                correct = locations
+                correct = correct.locations
               )
 
             case (
-                FixityListWithErrors(errors, correct),
-                c: FileFixityCorrect
+                existingErrors: FixityListWithErrors[BagLocation],
+                c: FileFixityCorrect[BagLocation]
                 ) =>
-              FixityListWithErrors(errors, c :: correct)
+              FixityListWithErrors(existingErrors.errors, c :: existingErrors.correct)
 
             case (
-                FixityListWithErrors(errors, correct),
-                err: FileFixityError
+                existingErrors: FixityListWithErrors[BagLocation],
+                err: FileFixityError[BagLocation]
                 ) =>
               FixityListWithErrors(
-                errors = err :: errors,
-                correct = correct
+                errors = err :: existingErrors.errors,
+                correct = existingErrors.correct
               )
           }
     }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -19,7 +19,9 @@ class FixityListChecker[BagLocation <: Location, Container](
       case Right(verifiableLocations) =>
         verifiableLocations
           .map(fixityChecker.check)
-          .foldLeft[FixityListCheckingResult[BagLocation]](FixityListAllCorrect(Nil)) {
+          .foldLeft[FixityListCheckingResult[BagLocation]](
+            FixityListAllCorrect(Nil)
+          ) {
 
             case (
                 existingCorrect: FixityListAllCorrect[BagLocation],
@@ -27,7 +29,10 @@ class FixityListChecker[BagLocation <: Location, Container](
                 ) =>
               FixityListAllCorrect(newCorrect :: existingCorrect.locations)
 
-            case (correct: FixityListAllCorrect[BagLocation], err: FileFixityError[BagLocation]) =>
+            case (
+                correct: FixityListAllCorrect[BagLocation],
+                err: FileFixityError[BagLocation]
+                ) =>
               FixityListWithErrors(
                 errors = List(err),
                 correct = correct.locations
@@ -37,7 +42,10 @@ class FixityListChecker[BagLocation <: Location, Container](
                 existingErrors: FixityListWithErrors[BagLocation],
                 c: FileFixityCorrect[BagLocation]
                 ) =>
-              FixityListWithErrors(existingErrors.errors, c :: existingErrors.correct)
+              FixityListWithErrors(
+                existingErrors.errors,
+                c :: existingErrors.correct
+              )
 
             case (
                 existingErrors: FixityListWithErrors[BagLocation],

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
@@ -4,12 +4,12 @@ sealed trait FixityListResult
 
 sealed trait FixityListCheckingResult extends FixityListResult
 
-case class FixityListAllCorrect(locations: List[FileFixityCorrect])
+case class FixityListAllCorrect[BagLocation](locations: List[FileFixityCorrect[BagLocation]])
     extends FixityListCheckingResult
 
-case class FixityListWithErrors(
-  errors: List[FileFixityError],
-  correct: List[FileFixityCorrect]
+case class FixityListWithErrors[BagLocation](
+  errors: List[FileFixityError[BagLocation]],
+  correct: List[FileFixityCorrect[BagLocation]]
 ) extends Throwable(
       "Some files don't have the expected fixity (size/checksum)!"
     )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
-sealed trait FixityListResult
+sealed trait FixityListResult[BagLocation]
 
-sealed trait FixityListCheckingResult extends FixityListResult
+sealed trait FixityListCheckingResult[BagLocation] extends FixityListResult[BagLocation]
 
 case class FixityListAllCorrect[BagLocation](locations: List[FileFixityCorrect[BagLocation]])
-    extends FixityListCheckingResult
+    extends FixityListCheckingResult[BagLocation]
 
 case class FixityListWithErrors[BagLocation](
   errors: List[FileFixityError[BagLocation]],
@@ -13,8 +13,8 @@ case class FixityListWithErrors[BagLocation](
 ) extends Throwable(
       "Some files don't have the expected fixity (size/checksum)!"
     )
-    with FixityListCheckingResult
+    with FixityListCheckingResult[BagLocation]
 
-case class CouldNotCreateExpectedFixityList(msg: String)
+case class CouldNotCreateExpectedFixityList[BagLocation](msg: String)
     extends Throwable(msg)
-    with FixityListResult
+    with FixityListResult[BagLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListResult.scala
@@ -2,10 +2,12 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity
 
 sealed trait FixityListResult[BagLocation]
 
-sealed trait FixityListCheckingResult[BagLocation] extends FixityListResult[BagLocation]
+sealed trait FixityListCheckingResult[BagLocation]
+    extends FixityListResult[BagLocation]
 
-case class FixityListAllCorrect[BagLocation](locations: List[FileFixityCorrect[BagLocation]])
-    extends FixityListCheckingResult[BagLocation]
+case class FixityListAllCorrect[BagLocation](
+  locations: List[FileFixityCorrect[BagLocation]]
+) extends FixityListCheckingResult[BagLocation]
 
 case class FixityListWithErrors[BagLocation](
   errors: List[FileFixityError[BagLocation]],

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   Locatable,
   Resolvable
 }
-import uk.ac.wellcome.platform.archive.bagverifier.storage.bag.BagLocatable._
+import uk.ac.wellcome.platform.archive.bagverifier.storage.bag.BagLocatable
 import uk.ac.wellcome.platform.archive.common.bagit.models._
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.verify._
@@ -21,6 +21,7 @@ class BagExpectedFixity(root: ObjectLocationPrefix)(
 ) extends ExpectedFixity[Bag]
     with Logging {
 
+  import BagLocatable._
   import Locatable._
 
   override def create(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -14,9 +14,9 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.bag.BagLocatable._
 import uk.ac.wellcome.platform.archive.common.bagit.models._
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.verify._
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
-class BagExpectedFixity(root: ObjectLocation)(
+class BagExpectedFixity(root: ObjectLocationPrefix)(
   implicit resolvable: Resolvable[ObjectLocation]
 ) extends ExpectedFixity[Bag]
     with Logging {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -6,28 +6,23 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocateFailure
 import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
 import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemorySizeFinder
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.MemoryLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityChecker(
-  val streamStore: MemoryStreamStore[ObjectLocation],
-  val tags: MemoryTags[ObjectLocation]
-) extends FixityChecker[ObjectLocation] {
+  val streamStore: MemoryStreamStore[MemoryLocation],
+  val tags: MemoryTags[MemoryLocation]
+) extends FixityChecker[MemoryLocation] {
 
-  override protected val sizeFinder: SizeFinder[ObjectLocation] =
+  override protected val sizeFinder: SizeFinder[MemoryLocation] =
     new MemorySizeFinder(streamStore.memoryStore)
 
-  override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
+  override def locate(uri: URI): Either[LocateFailure[URI], MemoryLocation] =
     Right(
-      ObjectLocation(
+      MemoryLocation(
         namespace = uri.getHost,
         path = uri.getPath.stripPrefix("/")
       )
     )
-
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  override def toLocation(location: ObjectLocation): ObjectLocation =
-    location
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -7,11 +7,11 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocateFailure
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3SizeFinder
+import uk.ac.wellcome.storage.S3ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.store.s3.S3StreamStore
+import uk.ac.wellcome.storage.store.s3.NewS3StreamStore
 import uk.ac.wellcome.storage.tags.Tags
-import uk.ac.wellcome.storage.tags.s3.S3Tags
-import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocation}
+import uk.ac.wellcome.storage.tags.s3.NewS3Tags
 
 class S3FixityChecker(implicit s3Client: AmazonS3)
     extends FixityChecker[S3ObjectLocation]
@@ -20,19 +20,14 @@ class S3FixityChecker(implicit s3Client: AmazonS3)
   import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable._
   import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Locatable._
 
-  override protected val streamStore: StreamStore[ObjectLocation] =
-    new S3StreamStore()
+  override protected val streamStore: StreamStore[S3ObjectLocation] =
+    new NewS3StreamStore()
 
   override protected val sizeFinder: S3SizeFinder =
     new S3SizeFinder()
 
-  override val tags: Tags[ObjectLocation] = new S3Tags()
+  override val tags: Tags[S3ObjectLocation] = new NewS3Tags()
 
   override def locate(uri: URI): Either[LocateFailure[URI], S3ObjectLocation] =
     uri.locate
-
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  override def toLocation(s3Location: S3ObjectLocation): ObjectLocation =
-    s3Location.toObjectLocation
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
@@ -105,7 +105,7 @@ case class VerificationIncompleteSummary(
 case class VerificationSuccessSummary(
   ingestId: IngestID,
   rootLocation: ObjectLocationPrefix,
-  fixityListResult: Some[FixityListAllCorrect],
+  fixityListResult: Some[FixityListAllCorrect[_]],
   startTime: Instant,
   endTime: Instant
 ) extends VerificationSummary
@@ -113,7 +113,7 @@ case class VerificationSuccessSummary(
 case class VerificationFailureSummary(
   ingestId: IngestID,
   rootLocation: ObjectLocationPrefix,
-  fixityListResult: Option[FixityListWithErrors],
+  fixityListResult: Option[FixityListWithErrors[_]],
   startTime: Instant,
   endTime: Instant
 ) extends VerificationSummary

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 sealed trait VerificationSummary extends Summary {
   val rootLocation: ObjectLocationPrefix
-  val fixityListResult: Option[FixityListResult]
+  val fixityListResult: Option[FixityListResult[_]]
 
   val endTime: Instant
   override val maybeEndTime: Option[Instant] = Some(endTime)
@@ -63,7 +63,7 @@ object VerificationSummary {
   def create(
     ingestId: IngestID,
     root: ObjectLocationPrefix,
-    v: FixityListResult,
+    v: FixityListResult[_],
     t: Instant
   ): VerificationSummary = v match {
     case i @ CouldNotCreateExpectedFixityList(_) =>
@@ -99,7 +99,7 @@ case class VerificationIncompleteSummary(
   e: Throwable,
   startTime: Instant,
   endTime: Instant,
-  fixityListResult: Option[FixityListResult] = None
+  fixityListResult: Option[FixityListResult[_]] = None
 ) extends VerificationSummary
 
 case class VerificationSuccessSummary(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -36,7 +36,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
-    with VerifyNoUnreferencedFiles {
+    with VerifyNoUnreferencedFiles[BagLocation] {
 
   def verify(
     ingestId: IngestID,
@@ -129,7 +129,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
 
   private def buildStepResult(
     ingestId: IngestID,
-    internalResult: Either[BagVerifierError, FixityListResult],
+    internalResult: Either[BagVerifierError, FixityListResult[BagLocation]],
     root: ObjectLocationPrefix,
     startTime: Instant
   ): IngestStepResult[VerificationSummary] =
@@ -146,7 +146,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           maybeUserFacingMessage = error.userMessage
         )
 
-      case Right(creationError: CouldNotCreateExpectedFixityList) =>
+      case Right(creationError: CouldNotCreateExpectedFixityList[BagLocation]) =>
         IngestFailed(
           summary = VerificationIncompleteSummary(
             ingestId = ingestId,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -29,10 +29,10 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
 )(
   implicit bagReader: BagReader[BagLocation, BagPrefix],
   val resolvable: Resolvable[ObjectLocation],
-  val fixityChecker: FixityChecker[_],
+  val fixityChecker: FixityChecker[BagLocation],
   listing: Listing[ObjectLocationPrefix, ObjectLocation]
 ) extends Logging
-    with VerifyChecksumAndSize
+    with VerifyChecksumAndSize[BagLocation]
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
@@ -159,7 +159,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           maybeUserFacingMessage = Some(creationError.getMessage)
         )
 
-      case Right(success: FixityListAllCorrect) =>
+      case Right(success: FixityListAllCorrect[BagLocation]) =>
         IngestStepSucceeded(
           VerificationSuccessSummary(
             ingestId = ingestId,
@@ -170,10 +170,10 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           )
         )
 
-      case Right(result: FixityListWithErrors) =>
+      case Right(result: FixityListWithErrors[BagLocation]) =>
         val verificationFailureMessage =
           result.errors
-            .map { fixityError: FileFixityError =>
+            .map { fixityError: FileFixityError[BagLocation] =>
               s"${fixityError.expectedFileFixity.uri}: ${fixityError.e.getMessage}"
             }
             .mkString("\n")

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -148,7 +148,9 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           maybeUserFacingMessage = error.userMessage
         )
 
-      case Right(creationError: CouldNotCreateExpectedFixityList[BagLocation]) =>
+      case Right(
+          creationError: CouldNotCreateExpectedFixityList[BagLocation]
+          ) =>
         IngestFailed(
           summary = VerificationIncompleteSummary(
             ingestId = ingestId,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -96,10 +96,12 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
             verificationResult = verificationResult
           )
 
-          _ <- verifyPayloadOxumFileSize(
-            bag = bag,
-            verificationResult = verificationResult
-          )
+          _ <- verificationResult match {
+            case FixityListAllCorrect(locations) =>
+              verifyPayloadOxumFileSize(bag = bag, locations = locations)
+
+            case _ => Right(())
+          }
 
         } yield verificationResult
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/Locatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/Locatable.scala
@@ -1,17 +1,17 @@
 package uk.ac.wellcome.platform.archive.bagverifier.storage
 
-trait Locatable[LocationResult, T] {
+trait Locatable[LocationResult, SearchRoot, T] {
   def locate(t: T)(
-    maybeRoot: Option[LocationResult]
+    maybeRoot: Option[SearchRoot]
   ): Either[LocateFailure[T], LocationResult]
 }
 
 object Locatable {
-  implicit class LocatableOps[LocationResult, T](t: T)(
-    implicit locator: Locatable[LocationResult, T]
+  implicit class LocatableOps[LocationResult, SearchRoot, T](t: T)(
+    implicit locator: Locatable[LocationResult, SearchRoot, T]
   ) {
     def locateWith(
-      root: LocationResult
+      root: SearchRoot
     ): Either[LocateFailure[T], LocationResult] =
       locator.locate(t)(Some(root))
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
@@ -6,17 +6,17 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   LocationNotFound
 }
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 object BagLocatable {
-  implicit val bagPathLocatable: Locatable[ObjectLocation, BagPath] =
-    new Locatable[ObjectLocation, BagPath] {
+  implicit val bagPathLocatable: Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] =
+    new Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] {
       override def locate(bagPath: BagPath)(
-        maybeRoot: Option[ObjectLocation]
+        maybeRoot: Option[ObjectLocationPrefix]
       ): Either[LocateFailure[BagPath], ObjectLocation] =
         maybeRoot match {
           case None       => Left(LocationNotFound(bagPath, s"No root specified!"))
-          case Some(root) => Right(root.join(bagPath.value))
+          case Some(root) => Right(root.asLocation(bagPath.value))
         }
     }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
@@ -9,7 +9,8 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 object BagLocatable {
-  implicit val bagPathLocatable: Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] =
+  implicit val bagPathLocatable
+    : Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] =
     new Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] {
       override def locate(bagPath: BagPath)(
         maybeRoot: Option[ObjectLocationPrefix]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Locatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Locatable.scala
@@ -13,7 +13,8 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import scala.util.{Failure, Success, Try}
 
 object S3Locatable {
-  implicit val s3UriLocatable: Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
+  implicit val s3UriLocatable
+    : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
     new Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] {
       override def locate(uri: URI)(
         maybeRoot: Option[S3ObjectLocationPrefix]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Locatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Locatable.scala
@@ -8,31 +8,31 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   LocateFailure,
   LocationParsingError
 }
-import uk.ac.wellcome.storage.S3ObjectLocation
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
 
 object S3Locatable {
-  implicit val s3UriLocatable: Locatable[S3ObjectLocation, URI] =
-    new Locatable[S3ObjectLocation, URI] {
-      override def locate(t: URI)(
-        maybeRoot: Option[S3ObjectLocation]
+  implicit val s3UriLocatable: Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
+    new Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] {
+      override def locate(uri: URI)(
+        maybeRoot: Option[S3ObjectLocationPrefix]
       ): Either[LocateFailure[URI], S3ObjectLocation] =
-        Try { new AmazonS3URI(t) } match {
+        Try { new AmazonS3URI(uri) } match {
           case Success(s3Uri) =>
             Right(
               S3ObjectLocation(bucket = s3Uri.getBucket, key = s3Uri.getKey)
             )
 
           // We are not running in AWS - manually parse URL
-          case Failure(_) if t.getHost == "localhost" =>
-            t.getPath.split("/").toList match {
+          case Failure(_) if uri.getHost == "localhost" =>
+            uri.getPath.split("/").toList match {
               case _ :: head :: tail =>
                 Right(S3ObjectLocation(bucket = head, key = tail.mkString("/")))
               case default =>
                 Left(
                   LocationParsingError(
-                    t,
+                    uri,
                     s"Failed to parse S3 URI: invalid path trying to parse local URL (${default
                       .mkString("/")})"
                   )
@@ -43,7 +43,7 @@ object S3Locatable {
           case Failure(e) =>
             Left(
               LocationParsingError(
-                t,
+                uri,
                 s"Failed to parse S3 URI: ${e.getMessage}"
               )
             )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -1,21 +1,17 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FixityChecker,
-  FixityListChecker,
-  FixityListResult
-}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FixityChecker, FixityListChecker, FixityListResult}
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.bag.BagExpectedFixity
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
 import uk.ac.wellcome.platform.archive.common.bagit.models.Bag
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
 
-trait VerifyChecksumAndSize {
+trait VerifyChecksumAndSize[BagLocation <: Location] {
   implicit val resolvable: Resolvable[ObjectLocation]
-  implicit val fixityChecker: FixityChecker[_]
+  implicit val fixityChecker: FixityChecker[BagLocation]
 
   def verifyChecksumAndSize(
     root: ObjectLocationPrefix,
@@ -24,7 +20,7 @@ trait VerifyChecksumAndSize {
     implicit val bagExpectedFixity: BagExpectedFixity =
       new BagExpectedFixity(root)
 
-    implicit val fixityListChecker: FixityListChecker[Bag] =
+    implicit val fixityListChecker: FixityListChecker[BagLocation, Bag] =
       new FixityListChecker()
 
     Try { fixityListChecker.check(bag) } match {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -16,7 +16,7 @@ trait VerifyChecksumAndSize[BagLocation <: Location] {
   def verifyChecksumAndSize(
     root: ObjectLocationPrefix,
     bag: Bag
-  ): Either[BagVerifierError, FixityListResult] = {
+  ): Either[BagVerifierError, FixityListResult[BagLocation]] = {
     implicit val bagExpectedFixity: BagExpectedFixity =
       new BagExpectedFixity(root)
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -22,7 +22,7 @@ trait VerifyChecksumAndSize {
     bag: Bag
   ): Either[BagVerifierError, FixityListResult] = {
     implicit val bagExpectedFixity: BagExpectedFixity =
-      new BagExpectedFixity(root.asLocation())
+      new BagExpectedFixity(root)
 
     implicit val fixityListChecker: FixityListChecker[Bag] =
       new FixityListChecker()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FixityChecker, FixityListChecker, FixityListResult}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FixityChecker,
+  FixityListChecker,
+  FixityListResult
+}
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.bag.BagExpectedFixity
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -7,9 +7,9 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
 }
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, ObjectLocation, ObjectLocationPrefix}
 
-trait VerifyNoUnreferencedFiles extends Logging {
+trait VerifyNoUnreferencedFiles[BagLocation <: Location] extends Logging {
 
   // Files that it's okay not to be referenced by any other manifests/files.
   //
@@ -29,11 +29,11 @@ trait VerifyNoUnreferencedFiles extends Logging {
   def verifyNoUnreferencedFiles(
     root: ObjectLocationPrefix,
     actualLocations: Seq[ObjectLocation],
-    verificationResult: FixityListResult
+    verificationResult: FixityListResult[BagLocation]
   ): Either[BagVerifierError, Unit] =
     verificationResult match {
       case FixityListAllCorrect(locations) =>
-        val expectedLocations = locations.map { _.objectLocation }
+        val expectedLocations = locations.map { _.objectLocation.toObjectLocation }
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -33,7 +33,9 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location] extends Logging {
   ): Either[BagVerifierError, Unit] =
     verificationResult match {
       case FixityListAllCorrect(locations) =>
-        val expectedLocations = locations.map { _.objectLocation.toObjectLocation }
+        val expectedLocations = locations.map {
+          _.objectLocation.toObjectLocation
+        }
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyPayloadOxum.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyPayloadOxum.scala
@@ -1,9 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FixityListAllCorrect,
-  FixityListResult
-}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.FileFixityCorrect
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.Bag
 
@@ -25,35 +22,31 @@ trait VerifyPayloadOxum {
 
   def verifyPayloadOxumFileSize(
     bag: Bag,
-    verificationResult: FixityListResult[_]
-  ): Either[BagVerifierError, Unit] =
-    verificationResult match {
-      case FixityListAllCorrect(locations) =>
-        // The Payload-Oxum octetstream sum only counts the size of files in the payload,
-        // not manifest files such as the bag-info.txt file.
-        // We need to filter those out.
-        val dataFilePaths = bag.manifest.paths
+    locations: Seq[FileFixityCorrect[_]]
+  ): Either[BagVerifierError, Unit] = {
+    // The Payload-Oxum octetstream sum only counts the size of files in the payload,
+    // not manifest files such as the bag-info.txt file.
+    // We need to filter those out.
+    val dataFilePaths = bag.manifest.paths
 
-        val actualSize =
-          locations
-            .filter { loc =>
-              dataFilePaths.contains(loc.expectedFileFixity.path)
-            }
-            .map { _.size }
-            .sum
-
-        val expectedSize = bag.info.payloadOxum.payloadBytes
-
-        if (actualSize == expectedSize) {
-          Right(())
-        } else {
-          Left(
-            BagVerifierError(
-              s"Payload-Oxum has the wrong octetstream sum: $expectedSize bytes, but bag actually contains $actualSize bytes"
-            )
-          )
+    val actualSize =
+      locations
+        .filter { loc =>
+          dataFilePaths.contains(loc.expectedFileFixity.path)
         }
+        .map { _.size }
+        .sum
 
-      case _ => Right(())
+    val expectedSize = bag.info.payloadOxum.payloadBytes
+
+    if (actualSize == expectedSize) {
+      Right(())
+    } else {
+      Left(
+        BagVerifierError(
+          s"Payload-Oxum has the wrong octetstream sum: $expectedSize bytes, but bag actually contains $actualSize bytes"
+        )
+      )
     }
+  }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyPayloadOxum.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyPayloadOxum.scala
@@ -25,7 +25,7 @@ trait VerifyPayloadOxum {
 
   def verifyPayloadOxumFileSize(
     bag: Bag,
-    verificationResult: FixityListResult
+    verificationResult: FixityListResult[_]
   ): Either[BagVerifierError, Unit] =
     verificationResult match {
       case FixityListAllCorrect(locations) =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -14,11 +14,11 @@ import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
 trait FixityCheckerTestCases[
-    BagLocation <: Location,
-    Namespace,
-    Context,
-    StreamStoreImpl <: StreamStore[BagLocation]]
-  extends AnyFunSpec
+  BagLocation <: Location,
+  Namespace,
+  Context,
+  StreamStoreImpl <: StreamStore[BagLocation]
+] extends AnyFunSpec
     with Matchers
     with EitherValues
     with NamespaceFixtures[BagLocation, Namespace]
@@ -109,7 +109,8 @@ trait FixityCheckerTestCases[
 
         result shouldBe a[FileFixityCouldNotRead[_]]
 
-        val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[BagLocation]]
+        val fixityCouldNotRead =
+          result.asInstanceOf[FileFixityCouldNotRead[BagLocation]]
 
         fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
         fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]
@@ -140,7 +141,8 @@ trait FixityCheckerTestCases[
 
         result shouldBe a[FileFixityMismatch[_]]
 
-        val fixityMismatch = result.asInstanceOf[FileFixityMismatch[BagLocation]]
+        val fixityMismatch =
+          result.asInstanceOf[FileFixityMismatch[BagLocation]]
 
         fixityMismatch.expectedFileFixity shouldBe expectedFileFixity
         fixityMismatch.e shouldBe a[FailedChecksumNoMatch]
@@ -179,7 +181,8 @@ trait FixityCheckerTestCases[
 
         result shouldBe a[FileFixityMismatch[_]]
 
-        val fixityMismatch = result.asInstanceOf[FileFixityMismatch[BagLocation]]
+        val fixityMismatch =
+          result.asInstanceOf[FileFixityMismatch[BagLocation]]
 
         fixityMismatch.expectedFileFixity shouldBe expectedFileFixity
         fixityMismatch.e shouldBe a[Throwable]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -81,9 +81,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityCorrect]
+        result shouldBe a[FileFixityCorrect[_]]
 
-        val fixityCorrect = result.asInstanceOf[FileFixityCorrect]
+        val fixityCorrect = result.asInstanceOf[FileFixityCorrect[BagLocation]]
         fixityCorrect.expectedFileFixity shouldBe expectedFileFixity
         fixityCorrect.size shouldBe contentString.getBytes.length
       }
@@ -107,9 +107,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityCouldNotRead]
+        result shouldBe a[FileFixityCouldNotRead[_]]
 
-        val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead]
+        val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[BagLocation]]
 
         fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
         fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]
@@ -138,9 +138,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityMismatch]
+        result shouldBe a[FileFixityMismatch[_]]
 
-        val fixityMismatch = result.asInstanceOf[FileFixityMismatch]
+        val fixityMismatch = result.asInstanceOf[FileFixityMismatch[BagLocation]]
 
         fixityMismatch.expectedFileFixity shouldBe expectedFileFixity
         fixityMismatch.e shouldBe a[FailedChecksumNoMatch]
@@ -177,9 +177,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityMismatch]
+        result shouldBe a[FileFixityMismatch[_]]
 
-        val fixityMismatch = result.asInstanceOf[FileFixityMismatch]
+        val fixityMismatch = result.asInstanceOf[FileFixityMismatch[BagLocation]]
 
         fixityMismatch.expectedFileFixity shouldBe expectedFileFixity
         fixityMismatch.e shouldBe a[Throwable]
@@ -216,9 +216,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityCorrect]
+        result shouldBe a[FileFixityCorrect[_]]
 
-        val fixityCorrect = result.asInstanceOf[FileFixityCorrect]
+        val fixityCorrect = result.asInstanceOf[FileFixityCorrect[BagLocation]]
         fixityCorrect.expectedFileFixity shouldBe expectedFileFixity
         fixityCorrect.size shouldBe contentString.getBytes.length
       }
@@ -250,9 +250,9 @@ trait FixityCheckerTestCases[
             _.check(expectedFileFixity)
           }
 
-        result shouldBe a[FileFixityCorrect]
+        result shouldBe a[FileFixityCorrect[_]]
 
-        val fixityCorrect = result.asInstanceOf[FileFixityCorrect]
+        val fixityCorrect = result.asInstanceOf[FileFixityCorrect[BagLocation]]
         fixityCorrect.expectedFileFixity shouldBe expectedFileFixity
         fixityCorrect.size shouldBe contentString.getBytes.length
       }
@@ -277,7 +277,7 @@ trait FixityCheckerTestCases[
 
           withFixityChecker { fixityChecker =>
             fixityChecker.check(expectedFileFixity) shouldBe a[
-              FileFixityCorrect
+              FileFixityCorrect[_]
             ]
 
             fixityChecker.tags.get(location).right.value shouldBe Identified(
@@ -307,7 +307,7 @@ trait FixityCheckerTestCases[
 
             withFixityChecker(spyStore) { fixityChecker =>
               fixityChecker.check(expectedFileFixity) shouldBe a[
-                FileFixityCorrect
+                FileFixityCorrect[_]
               ]
 
               // StreamStore.get() should have been called to read the object so
@@ -317,7 +317,7 @@ trait FixityCheckerTestCases[
               // It shouldn't be read a second time, because we see the tag written by
               // the previous verification.
               fixityChecker.check(expectedFileFixity) shouldBe a[
-                FileFixityCorrect
+                FileFixityCorrect[_]
               ]
               verify(spyStore, times(1)).get(location)
             }
@@ -348,7 +348,7 @@ trait FixityCheckerTestCases[
 
             withFixityChecker(spyStore) { fixityChecker =>
               fixityChecker.check(expectedFileFixity) shouldBe a[
-                FileFixityCorrect
+                FileFixityCorrect[_]
               ]
 
               // StreamStore.get() should have been called to read the object so
@@ -358,9 +358,9 @@ trait FixityCheckerTestCases[
               // It shouldn't be read a second time, because we see the tag written by
               // the previous verification.
               val result = fixityChecker.check(badExpectedFixity)
-              result shouldBe a[FileFixityMismatch]
+              result shouldBe a[FileFixityMismatch[_]]
               result
-                .asInstanceOf[FileFixityMismatch]
+                .asInstanceOf[FileFixityMismatch[BagLocation]]
                 .e
                 .getMessage should startWith(
                 "Cached verification tag doesn't match expected checksum"
@@ -392,7 +392,7 @@ trait FixityCheckerTestCases[
 
             withFixityChecker(spyStore) { fixityChecker =>
               fixityChecker.check(expectedFileFixity) shouldBe a[
-                FileFixityCorrect
+                FileFixityCorrect[_]
               ]
 
               // StreamStore.get() should have been called to read the object so
@@ -402,9 +402,9 @@ trait FixityCheckerTestCases[
               // It shouldn't be read a second time, because we see the tag written by
               // the previous verification.
               val result = fixityChecker.check(badExpectedFixity)
-              result shouldBe a[FileFixityMismatch]
+              result shouldBe a[FileFixityMismatch[_]]
               result
-                .asInstanceOf[FileFixityMismatch]
+                .asInstanceOf[FileFixityMismatch[BagLocation]]
                 .e
                 .getMessage should startWith("Lengths do not match")
               verify(spyStore, times(1)).get(location)
@@ -426,7 +426,7 @@ trait FixityCheckerTestCases[
 
           withFixityChecker { fixityChecker =>
             fixityChecker.check(expectedFileFixity) shouldBe a[
-              FileFixityMismatch
+              FileFixityMismatch[_]
             ]
 
             fixityChecker.tags.get(location).right.value shouldBe Identified(
@@ -468,7 +468,7 @@ trait FixityCheckerTestCases[
               )
 
               fixityChecker.check(expectedFileFixity) shouldBe a[
-                FileFixityCorrect
+                FileFixityCorrect[_]
               ]
             }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -51,7 +51,7 @@ class FixityCheckerTests
       }
 
       val expectedFileFixity = createExpectedFileFixity
-      brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead]
+      brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead[_]]
     }
 
     it("handles an error when trying to checksum the object") {
@@ -89,7 +89,7 @@ class FixityCheckerTests
       }
 
       checker.check(expectedFileFixity) shouldBe a[
-        FileFixityCouldNotGetChecksum
+        FileFixityCouldNotGetChecksum[_]
       ]
     }
 
@@ -142,7 +142,7 @@ class FixityCheckerTests
           }
       }
 
-      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotWriteTag]
+      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotWriteTag[_]]
     }
   }
 
@@ -188,7 +188,7 @@ class FixityCheckerTests
           }
       }
 
-      checker.check(expectedFileFixity) shouldBe a[FileFixityCorrect]
+      checker.check(expectedFileFixity) shouldBe a[FileFixityCorrect[_]]
 
       isClosed shouldBe true
     }
@@ -227,7 +227,7 @@ class FixityCheckerTests
           }
       }
 
-      checker.check(expectedFileFixity) shouldBe a[FileFixityMismatch]
+      checker.check(expectedFileFixity) shouldBe a[FileFixityMismatch[_]]
 
       isClosed shouldBe true
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -51,7 +51,9 @@ class FixityCheckerTests
       }
 
       val expectedFileFixity = createExpectedFileFixity
-      brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead[_]]
+      brokenChecker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotRead[
+        _
+      ]]
     }
 
     it("handles an error when trying to checksum the object") {
@@ -142,7 +144,9 @@ class FixityCheckerTests
           }
       }
 
-      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotWriteTag[_]]
+      checker.check(expectedFileFixity) shouldBe a[FileFixityCouldNotWriteTag[
+        _
+      ]]
     }
   }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.platform.archive.common.verify.{
   ChecksumValue,
   HashingAlgorithm
 }
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 class BagExpectedFixityTest
@@ -31,7 +31,7 @@ class BagExpectedFixityTest
   implicit val resolvable: Resolvable[ObjectLocation] =
     (t: ObjectLocation) => new URI(s"example://${t.namespace}/${t.path}")
 
-  val root: ObjectLocation = createObjectLocation
+  val root: ObjectLocationPrefix = createObjectLocationPrefix
   val bagExpectedFixity = new BagExpectedFixity(root)
 
   describe("creates the correct list of VerifiableLocation") {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -4,7 +4,10 @@ import java.net.URI
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FixityChecker, FixityCheckerTestCases}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FixityChecker,
+  FixityCheckerTestCases
+}
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -3,68 +3,66 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity.s3
 import java.net.URI
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FileFixityCouldNotRead,
-  FixityChecker,
-  FixityCheckerTestCases
-}
-import uk.ac.wellcome.platform.archive.bagverifier.storage.{
-  LocationError,
-  LocationNotFound
-}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FileFixityCouldNotRead, FixityChecker, FixityCheckerTestCases}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.bagverifier.storage.{LocationError, LocationNotFound}
+import uk.ac.wellcome.storage.S3ObjectLocation
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.store.fixtures.BucketNamespaceFixtures
-import uk.ac.wellcome.storage.store.s3.S3StreamStore
+import uk.ac.wellcome.storage.store.s3.NewS3StreamStore
 
 class S3FixityCheckerTest
-    extends FixityCheckerTestCases[Bucket, Unit, S3StreamStore]
-    with BucketNamespaceFixtures {
+    extends FixityCheckerTestCases[S3ObjectLocation, Bucket, Unit, NewS3StreamStore]
+    with NewS3Fixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
 
-  override def putString(location: ObjectLocation, contents: String)(
+  override def putString(location: S3ObjectLocation, contents: String)(
     implicit context: Unit
   ): Unit =
     s3Client.putObject(
-      location.namespace,
-      location.path,
+      location.bucket,
+      location.key,
       contents
     )
 
   override def withStreamStore[R](
-    testWith: TestWith[S3StreamStore, R]
+    testWith: TestWith[NewS3StreamStore, R]
   )(implicit context: Unit): R =
     testWith(
-      new S3StreamStore()
+      new NewS3StreamStore()
     )
 
   override def withFixityChecker[R](
-    s3Store: S3StreamStore
+    s3Store: NewS3StreamStore
   )(
-    testWith: TestWith[FixityChecker[_], R]
+    testWith: TestWith[FixityChecker[S3ObjectLocation], R]
   )(implicit context: Unit): R =
     testWith(new S3FixityChecker() {
-      override val streamStore: StreamStore[ObjectLocation] = s3Store
+      override val streamStore: StreamStore[S3ObjectLocation] = s3Store
     })
 
   implicit val context: Unit = ()
 
   implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
 
-  override def resolve(location: ObjectLocation): URI =
-    s3Resolvable.resolve(location)
+  override def resolve(location: S3ObjectLocation): URI =
+    s3Resolvable.resolve(location.toObjectLocation)
+
+  override def withNamespace[R](testWith: TestWith[Bucket, R]): R =
+    withLocalS3Bucket { bucket =>
+      testWith(bucket)
+    }
+
+  override def createId(implicit bucket: Bucket): S3ObjectLocation =
+    createS3ObjectLocationWith(bucket)
 
   it("fails if the bucket doesn't exist") {
-    val checksum = randomChecksum
-
-    val location = createObjectLocationWith(bucket = createBucket)
+    val location = createS3ObjectLocationWith(bucket = createBucket)
 
     val expectedFileFixity = createExpectedFileFixityWith(
-      location = location,
-      checksum = checksum
+      location = location
     )
 
     val result =
@@ -84,13 +82,10 @@ class S3FixityCheckerTest
   }
 
   it("fails if the bucket name is invalid") {
-    val checksum = randomChecksum
-
-    val location = createObjectLocationWith(namespace = "ABCD")
+    val location = createS3ObjectLocationWith(bucket = createInvalidBucket)
 
     val expectedFileFixity = createExpectedFileFixityWith(
-      location = location,
-      checksum = checksum
+      location = location
     )
 
     val result =
@@ -111,13 +106,10 @@ class S3FixityCheckerTest
 
   it("fails if the key doesn't exist in the bucket") {
     withLocalS3Bucket { bucket =>
-      val checksum = randomChecksum
-
-      val location = createObjectLocationWith(bucket)
+      val location = createS3ObjectLocationWith(bucket)
 
       val expectedFileFixity = createExpectedFileFixityWith(
-        location = location,
-        checksum = checksum
+        location = location
       )
 
       val result =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -70,9 +70,9 @@ class S3FixityCheckerTest
         _.check(expectedFileFixity)
       }
 
-    result shouldBe a[FileFixityCouldNotRead]
+    result shouldBe a[FileFixityCouldNotRead[_]]
 
-    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead]
+    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
     fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
     fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]
@@ -93,9 +93,9 @@ class S3FixityCheckerTest
         _.check(expectedFileFixity)
       }
 
-    result shouldBe a[FileFixityCouldNotRead]
+    result shouldBe a[FileFixityCouldNotRead[_]]
 
-    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead]
+    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
     fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
     fixityCouldNotRead.e shouldBe a[LocationError[_]]
@@ -117,9 +117,9 @@ class S3FixityCheckerTest
           _.check(expectedFileFixity)
         }
 
-      result shouldBe a[FileFixityCouldNotRead]
+      result shouldBe a[FileFixityCouldNotRead[_]]
 
-      val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead]
+      val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
       fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
       fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -3,9 +3,16 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity.s3
 import java.net.URI
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FileFixityCouldNotRead, FixityChecker, FixityCheckerTestCases}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FileFixityCouldNotRead,
+  FixityChecker,
+  FixityCheckerTestCases
+}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
-import uk.ac.wellcome.platform.archive.bagverifier.storage.{LocationError, LocationNotFound}
+import uk.ac.wellcome.platform.archive.bagverifier.storage.{
+  LocationError,
+  LocationNotFound
+}
 import uk.ac.wellcome.storage.S3ObjectLocation
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -13,7 +20,12 @@ import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.NewS3StreamStore
 
 class S3FixityCheckerTest
-    extends FixityCheckerTestCases[S3ObjectLocation, Bucket, Unit, NewS3StreamStore]
+    extends FixityCheckerTestCases[
+      S3ObjectLocation,
+      Bucket,
+      Unit,
+      NewS3StreamStore
+    ]
     with NewS3Fixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
@@ -72,7 +84,8 @@ class S3FixityCheckerTest
 
     result shouldBe a[FileFixityCouldNotRead[_]]
 
-    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
+    val fixityCouldNotRead =
+      result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
     fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
     fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]
@@ -95,7 +108,8 @@ class S3FixityCheckerTest
 
     result shouldBe a[FileFixityCouldNotRead[_]]
 
-    val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
+    val fixityCouldNotRead =
+      result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
     fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
     fixityCouldNotRead.e shouldBe a[LocationError[_]]
@@ -119,7 +133,8 @@ class S3FixityCheckerTest
 
       result shouldBe a[FileFixityCouldNotRead[_]]
 
-      val fixityCouldNotRead = result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
+      val fixityCouldNotRead =
+        result.asInstanceOf[FileFixityCouldNotRead[S3ObjectLocation]]
 
       fixityCouldNotRead.expectedFileFixity shouldBe expectedFileFixity
       fixityCouldNotRead.e shouldBe a[LocationNotFound[_]]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -6,22 +6,22 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.ExpectedFileFixity
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.Location
 
-trait FixityGenerators
-    extends ObjectLocationGenerators
-    with StorageRandomThings {
+trait FixityGenerators[BagLocation <: Location]
+    extends StorageRandomThings {
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
 
-  def resolve(location: ObjectLocation): URI
+  def resolve(location: BagLocation): URI
 
   def createExpectedFileFixity: ExpectedFileFixity =
     createExpectedFileFixityWith()
 
+  def createLocation: BagLocation
+
   def createExpectedFileFixityWith(
-    location: ObjectLocation = createObjectLocation,
+    location: BagLocation = createLocation,
     checksum: Checksum = randomChecksum,
     length: Option[Long] = None
   ): ExpectedFileFixity = {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -8,8 +8,7 @@ import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
 import uk.ac.wellcome.storage.Location
 
-trait FixityGenerators[BagLocation <: Location]
-    extends StorageRandomThings {
+trait FixityGenerators[BagLocation <: Location] extends StorageRandomThings {
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -4,35 +4,17 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, OptionValues, TryValues}
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  FailedChecksumNoMatch,
-  FileFixityCorrect
-}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FailedChecksumNoMatch, FileFixityCorrect}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{
-  VerificationFailureSummary,
-  VerificationIncompleteSummary,
-  VerificationSuccessSummary,
-  VerificationSummary
-}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary, VerificationSummary}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocationNotFound
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  BagPath,
-  ExternalIdentifier,
-  PayloadOxum
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagPath, ExternalIdentifier, PayloadOxum}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.StorageSpaceGenerators
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepResult,
-  IngestStepSucceeded,
-  StorageSpace
-}
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 class BagVerifierTest
@@ -602,10 +584,10 @@ class BagVerifierTest
   }
 
   private def verifySuccessCount(
-    successes: List[FileFixityCorrect],
+    successes: List[FileFixityCorrect[_]],
     expectedCount: Int
   ): Assertion =
-    if (successes.map { _.objectLocation.path }.exists {
+    if (successes.map { _.objectLocation.asInstanceOf[S3ObjectLocation].key }.exists {
           _.endsWith("/fetch.txt")
         }) {
       successes.size shouldBe expectedCount + 1

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -4,16 +4,34 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, OptionValues, TryValues}
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{FailedChecksumNoMatch, FileFixityCorrect}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FailedChecksumNoMatch,
+  FileFixityCorrect
+}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary, VerificationSummary}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  VerificationFailureSummary,
+  VerificationIncompleteSummary,
+  VerificationSuccessSummary,
+  VerificationSummary
+}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocationNotFound
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagPath, ExternalIdentifier, PayloadOxum}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagPath,
+  ExternalIdentifier,
+  PayloadOxum
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.StorageSpaceGenerators
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
@@ -587,9 +605,11 @@ class BagVerifierTest
     successes: List[FileFixityCorrect[_]],
     expectedCount: Int
   ): Assertion =
-    if (successes.map { _.objectLocation.asInstanceOf[S3ObjectLocation].key }.exists {
-          _.endsWith("/fetch.txt")
-        }) {
+    if (successes
+          .map { _.objectLocation.asInstanceOf[S3ObjectLocation].key }
+          .exists {
+            _.endsWith("/fetch.txt")
+          }) {
       successes.size shouldBe expectedCount + 1
     } else {
       successes.size shouldBe expectedCount

--- a/common/src/main/scala/uk/ac/wellcome/storage/tags/s3/NewS3Tags.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/tags/s3/NewS3Tags.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.storage.tags.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ObjectTagging, SetObjectTaggingRequest, Tag}
+import uk.ac.wellcome.storage._
+import uk.ac.wellcome.storage.tags.Tags
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+class NewS3Tags(implicit s3Client: AmazonS3) extends Tags[S3ObjectLocation] {
+  // The S3Tags doesn't expose writeTags() because it's a protected method, so
+  // inline a complete copy of it here.
+  // TODO: Upstream this into scala-storage.
+  override protected def writeTags(location: S3ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+    val tagSet = tags
+      .map { case (k, v) => new Tag(k, v) }
+      .toSeq
+      .asJava
+
+    Try {
+      s3Client.setObjectTagging(
+        new SetObjectTaggingRequest(
+          location.bucket,
+          location.key,
+          new ObjectTagging(tagSet)
+        )
+      )
+    } match {
+      case Success(_)   => Right(tags)
+      case Failure(err) => Left(StoreWriteError(err))
+    }
+  }
+
+  private val underlying: S3Tags = new S3Tags()
+
+  override def get(location: S3ObjectLocation): ReadEither =
+    underlying
+      .get(location.toObjectLocation)
+      .map { case Identified(_, tags) => Identified(location, tags) }
+}

--- a/common/src/main/scala/uk/ac/wellcome/storage/tags/s3/NewS3Tags.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/tags/s3/NewS3Tags.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.storage.tags.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectTagging, SetObjectTaggingRequest, Tag}
+import com.amazonaws.services.s3.model.{
+  ObjectTagging,
+  SetObjectTaggingRequest,
+  Tag
+}
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.tags.Tags
 
@@ -12,7 +16,10 @@ class NewS3Tags(implicit s3Client: AmazonS3) extends Tags[S3ObjectLocation] {
   // The S3Tags doesn't expose writeTags() because it's a protected method, so
   // inline a complete copy of it here.
   // TODO: Upstream this into scala-storage.
-  override protected def writeTags(location: S3ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+  override protected def writeTags(
+    location: S3ObjectLocation,
+    tags: Map[String, String]
+  ): Either[WriteError, Map[String, String]] = {
     val tagSet = tags
       .map { case (k, v) => new Tag(k, v) }
       .toSeq


### PR DESCRIPTION
Yet another step towards https://github.com/wellcomecollection/platform/issues/4596. I started at FixityChecker and worked my way outwards until the tests were passing and compiling again. This is probably the most fiddly part of the ObjectLocation disambiguation; I think it should be easier from here.