### PR TITLE
Use new-style locations throughout the verifier

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -6,11 +6,19 @@ import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.cloudwatch.CloudwatchMetricsMonitoringClient
 import uk.ac.wellcome.platform.archive.bagverifier.services.BagVerifierWorker
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3BagVerifier
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -39,7 +47,8 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSAsyncClient(config)
 
     val verifier = new S3BagVerifier(
-      primaryBucket = config.requireString("bag-verifier.primary-storage-bucket"),
+      primaryBucket =
+        config.requireString("bag-verifier.primary-storage-bucket")
     )
 
     val operationName =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -20,20 +20,10 @@ import uk.ac.wellcome.platform.archive.bagverifier.services.{
 import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
-import uk.ac.wellcome.storage.listing.Listing
-import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.storage.listing.s3.NewS3ObjectLocationListing
 import uk.ac.wellcome.storage.typesafe.S3Builder
-import uk.ac.wellcome.storage.{
-  ObjectLocation,
-  ObjectLocationPrefix,
-  S3ObjectLocation,
-  S3ObjectLocationPrefix
-}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -70,8 +60,8 @@ object Main extends WellcomeTypesafeApp {
     implicit val s3Resolvable: S3Resolvable =
       new S3Resolvable()
 
-    implicit val s3Listing: Listing[ObjectLocationPrefix, ObjectLocation] =
-      S3ObjectLocationListing()
+    implicit val s3Listing: NewS3ObjectLocationListing =
+      new NewS3ObjectLocationListing()
 
     val verifier = new BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix](
       namespace = config.requireString("bag-verifier.primary-storage-bucket"),

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -6,24 +6,12 @@ import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.cloudwatch.CloudwatchMetricsMonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.s3.S3FixityChecker
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
-import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
-import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
-import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
+import uk.ac.wellcome.platform.archive.bagverifier.services.BagVerifierWorker
+import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3BagVerifier
 import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
-import uk.ac.wellcome.storage.listing.s3.NewS3ObjectLocationListing
 import uk.ac.wellcome.storage.typesafe.S3Builder
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -50,24 +38,8 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: SqsAsyncClient =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    implicit val s3FixityChecker: S3FixityChecker =
-      new S3FixityChecker()
-
-    implicit val bagReader
-      : BagReader[S3ObjectLocation, S3ObjectLocationPrefix] =
-      new S3BagReader()
-
-    implicit val s3Resolvable: S3Resolvable =
-      new S3Resolvable()
-
-    implicit val s3Listing: NewS3ObjectLocationListing =
-      new NewS3ObjectLocationListing()
-
-    val verifier = new BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix](
-      namespace = config.requireString("bag-verifier.primary-storage-bucket"),
-      toLocation = (location: ObjectLocation) => S3ObjectLocation(location),
-      toPrefix =
-        (prefix: ObjectLocationPrefix) => S3ObjectLocationPrefix(prefix)
+    val verifier = new S3BagVerifier(
+      primaryBucket = config.requireString("bag-verifier.primary-storage-bucket"),
     )
 
     val operationName =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -14,15 +14,18 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.bag.BagLocatable
 import uk.ac.wellcome.platform.archive.common.bagit.models._
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.verify._
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
-class BagExpectedFixity(root: ObjectLocationPrefix)(
-  implicit resolvable: Resolvable[ObjectLocation]
+class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](root: BagPrefix)(
+  implicit resolvable: Resolvable[BagLocation]
 ) extends ExpectedFixity[Bag]
     with Logging {
 
   import BagLocatable._
   import Locatable._
+
+  implicit val locatable: Locatable[BagLocation, BagPrefix, BagPath] =
+    bagPathLocatable[BagLocation, BagPrefix]
 
   override def create(
     bag: Bag

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -16,7 +16,9 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.{Location, Prefix}
 
-class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](root: BagPrefix)(
+class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]](root: BagPrefix)(
   implicit resolvable: Resolvable[BagLocation]
 ) extends ExpectedFixity[Bag]
     with Logging {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -30,7 +30,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
   implicit bagReader: BagReader[BagLocation, BagPrefix],
   val resolvable: Resolvable[BagLocation],
   val fixityChecker: FixityChecker[BagLocation],
-  listing: Listing[ObjectLocationPrefix, ObjectLocation]
+  listing: Listing[BagPrefix, BagLocation]
 ) extends Logging
     with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
@@ -73,7 +73,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
             bag = bag
           )
 
-          actualLocations <- listing.list(root) match {
+          actualLocations <- listing.list(toPrefix(root)) match {
             case Right(iterable) => Right(iterable.toSeq)
             case Left(listingFailure) =>
               Left(BagVerifierError(listingFailure.e))
@@ -84,7 +84,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
               verifyNoConcreteFetchEntries(
                 fetch = bag.fetch,
                 root = toPrefix(root),
-                actualLocations = actualLocations.map { toLocation }
+                actualLocations = actualLocations
               )
 
             case _ => Right(())
@@ -92,7 +92,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
 
           _ <- verifyNoUnreferencedFiles(
             root = toPrefix(root),
-            actualLocations = actualLocations.map { toLocation },
+            actualLocations = actualLocations,
             verificationResult = verificationResult
           )
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -36,7 +36,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
-    with VerifyNoUnreferencedFiles[BagLocation] {
+    with VerifyNoUnreferencedFiles[BagLocation, BagPrefix] {
 
   def verify(
     ingestId: IngestID,
@@ -91,8 +91,8 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           }
 
           _ <- verifyNoUnreferencedFiles(
-            root = root,
-            actualLocations = actualLocations,
+            root = toPrefix(root),
+            actualLocations = actualLocations.map { toLocation },
             verificationResult = verificationResult
           )
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.storage.{Location, Prefix}
 import scala.util.Try
 
 trait BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
-  extends Logging
+    extends Logging
     with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -28,11 +28,11 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
   toPrefix: ObjectLocationPrefix => BagPrefix
 )(
   implicit bagReader: BagReader[BagLocation, BagPrefix],
-  val resolvable: Resolvable[ObjectLocation],
+  val resolvable: Resolvable[BagLocation],
   val fixityChecker: FixityChecker[BagLocation],
   listing: Listing[ObjectLocationPrefix, ObjectLocation]
 ) extends Logging
-    with VerifyChecksumAndSize[BagLocation]
+    with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
@@ -69,7 +69,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           )
 
           verificationResult <- verifyChecksumAndSize(
-            root = root,
+            root = toPrefix(root),
             bag = bag
           )
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -12,35 +12,30 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.listing.Listing
-import uk.ac.wellcome.storage.{
-  Location,
-  ObjectLocation,
-  ObjectLocationPrefix,
-  Prefix
-}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
 import scala.util.Try
 
-class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
-  namespace: String,
-  // TODO: Temporary while we disambiguate ObjectLocation.  Remove eventually.
-  toLocation: ObjectLocation => BagLocation,
-  toPrefix: ObjectLocationPrefix => BagPrefix
-)(
-  implicit bagReader: BagReader[BagLocation, BagPrefix],
-  val resolvable: Resolvable[BagLocation],
-  val fixityChecker: FixityChecker[BagLocation],
-  listing: Listing[BagPrefix, BagLocation]
-) extends Logging
+trait BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
+  extends Logging
     with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
     with VerifyNoUnreferencedFiles[BagLocation, BagPrefix] {
 
+  val namespace: String
+
+  def createPrefix(namespace: String, path: String): BagPrefix
+
+  implicit val bagReader: BagReader[BagLocation, BagPrefix]
+  implicit val resolvable: Resolvable[BagLocation]
+  implicit val fixityChecker: FixityChecker[BagLocation]
+  implicit val listing: Listing[BagPrefix, BagLocation]
+
   def verify(
     ingestId: IngestID,
-    root: ObjectLocationPrefix,
+    root: BagPrefix,
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier
   ): Try[IngestStepResult[VerificationSummary]] =
@@ -60,20 +55,18 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
 
           _ <- verifyFetchPrefixes(
             fetch = bag.fetch,
-            root = toPrefix(
-              ObjectLocationPrefix(
-                namespace = namespace,
-                path = s"$space/$externalIdentifier"
-              )
+            root = createPrefix(
+              namespace = namespace,
+              path = s"$space/$externalIdentifier"
             )
           )
 
           verificationResult <- verifyChecksumAndSize(
-            root = toPrefix(root),
+            root = root,
             bag = bag
           )
 
-          actualLocations <- listing.list(toPrefix(root)) match {
+          actualLocations <- listing.list(root) match {
             case Right(iterable) => Right(iterable.toSeq)
             case Left(listingFailure) =>
               Left(BagVerifierError(listingFailure.e))
@@ -83,7 +76,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
             case FixityListAllCorrect(_) =>
               verifyNoConcreteFetchEntries(
                 fetch = bag.fetch,
-                root = toPrefix(root),
+                root = root,
                 actualLocations = actualLocations
               )
 
@@ -91,7 +84,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
           }
 
           _ <- verifyNoUnreferencedFiles(
-            root = toPrefix(root),
+            root = root,
             actualLocations = actualLocations,
             verificationResult = verificationResult
           )
@@ -114,10 +107,10 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
     }
 
   private def getBag(
-    root: ObjectLocationPrefix,
+    root: BagPrefix,
     startTime: Instant
   ): Either[BagVerifierError, Bag] =
-    bagReader.get(toPrefix(root)) match {
+    bagReader.get(root) match {
       case Left(bagUnavailable) =>
         Left(
           BagVerifierError(
@@ -132,7 +125,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
   private def buildStepResult(
     ingestId: IngestID,
     internalResult: Either[BagVerifierError, FixityListResult[BagLocation]],
-    root: ObjectLocationPrefix,
+    root: BagPrefix,
     startTime: Instant
   ): IngestStepResult[VerificationSummary] =
     internalResult match {
@@ -154,7 +147,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
         IngestFailed(
           summary = VerificationIncompleteSummary(
             ingestId = ingestId,
-            rootLocation = root,
+            root = root,
             e = creationError,
             startTime = startTime,
             endTime = Instant.now()
@@ -167,7 +160,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
         IngestStepSucceeded(
           VerificationSuccessSummary(
             ingestId = ingestId,
-            rootLocation = root,
+            root = root,
             fixityListResult = Some(success),
             startTime = startTime,
             endTime = Instant.now()
@@ -197,7 +190,7 @@ class BagVerifier[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]](
         IngestFailed(
           summary = VerificationFailureSummary(
             ingestId = ingestId,
-            rootLocation = root,
+            root = root,
             fixityListResult = Some(result),
             startTime = startTime,
             endTime = Instant.now()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -9,10 +9,8 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
 import uk.ac.wellcome.platform.archive.common.BagRootPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestStepResult,
-  IngestStepWorker
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, IngestStepWorker}
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.util.Try
 
@@ -20,7 +18,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
   val config: AlpakkaSQSWorkerConfig,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
-  verifier: BagVerifier[_, _],
+  verifier: BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
   val metricsNamespace: String
 )(
   implicit val mc: MetricsMonitoringClient,
@@ -39,7 +37,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(
         ingestId = payload.ingestId,
-        root = payload.bagRoot,
+        root = S3ObjectLocationPrefix(payload.bagRoot),
         space = payload.storageSpace,
         externalIdentifier = payload.externalIdentifier
       )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
 import uk.ac.wellcome.platform.archive.common.BagRootPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, IngestStepWorker}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestStepResult,
+  IngestStepWorker
+}
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.util.Try

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -13,14 +13,18 @@ import uk.ac.wellcome.storage.listing.s3.NewS3ObjectLocationListing
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 class S3BagVerifier(primaryBucket: String)(implicit s3Client: AmazonS3)
-  extends BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix] {
+    extends BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix] {
 
-  override  val namespace: String = primaryBucket
+  override val namespace: String = primaryBucket
 
-  override def createPrefix(bucket: String, keyPrefix: String): S3ObjectLocationPrefix =
+  override def createPrefix(
+    bucket: String,
+    keyPrefix: String
+  ): S3ObjectLocationPrefix =
     S3ObjectLocationPrefix(bucket = namespace, keyPrefix = keyPrefix)
 
-  override implicit val bagReader: BagReader[S3ObjectLocation, S3ObjectLocationPrefix] =
+  override implicit val bagReader
+    : BagReader[S3ObjectLocation, S3ObjectLocationPrefix] =
     new S3BagReader()
 
   override implicit val resolvable: Resolvable[S3ObjectLocation] =
@@ -29,6 +33,7 @@ class S3BagVerifier(primaryBucket: String)(implicit s3Client: AmazonS3)
   override implicit val fixityChecker: FixityChecker[S3ObjectLocation] =
     new S3FixityChecker()
 
-  override implicit val listing: Listing[S3ObjectLocationPrefix, S3ObjectLocation] =
+  override implicit val listing
+    : Listing[S3ObjectLocationPrefix, S3ObjectLocation] =
     new NewS3ObjectLocationListing()
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.platform.archive.bagverifier.services.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.s3.S3FixityChecker
+import uk.ac.wellcome.platform.archive.bagverifier.services.BagVerifier
+import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
+import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
+import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
+import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
+import uk.ac.wellcome.storage.listing.Listing
+import uk.ac.wellcome.storage.listing.s3.NewS3ObjectLocationListing
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
+
+class S3BagVerifier(primaryBucket: String)(implicit s3Client: AmazonS3)
+  extends BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix] {
+
+  override  val namespace: String = primaryBucket
+
+  override def createPrefix(bucket: String, keyPrefix: String): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(bucket = namespace, keyPrefix = keyPrefix)
+
+  override implicit val bagReader: BagReader[S3ObjectLocation, S3ObjectLocationPrefix] =
+    new S3BagReader()
+
+  override implicit val resolvable: Resolvable[S3ObjectLocation] =
+    new S3Resolvable()
+
+  override implicit val fixityChecker: FixityChecker[S3ObjectLocation] =
+    new S3FixityChecker()
+
+  override implicit val listing: Listing[S3ObjectLocationPrefix, S3ObjectLocation] =
+    new NewS3ObjectLocationListing()
+}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
@@ -9,8 +9,9 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.storage.{Location, Prefix}
 
 object BagLocatable {
-  implicit def bagPathLocatable[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
-    : Locatable[BagLocation, BagPrefix, BagPath] =
+  implicit def bagPathLocatable[BagLocation <: Location, BagPrefix <: Prefix[
+    BagLocation
+  ]]: Locatable[BagLocation, BagPrefix, BagPath] =
     new Locatable[BagLocation, BagPrefix, BagPath] {
       override def locate(bagPath: BagPath)(
         maybeRoot: Option[BagPrefix]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/bag/BagLocatable.scala
@@ -6,15 +6,15 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   LocationNotFound
 }
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
 object BagLocatable {
-  implicit val bagPathLocatable
-    : Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] =
-    new Locatable[ObjectLocation, ObjectLocationPrefix, BagPath] {
+  implicit def bagPathLocatable[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
+    : Locatable[BagLocation, BagPrefix, BagPath] =
+    new Locatable[BagLocation, BagPrefix, BagPath] {
       override def locate(bagPath: BagPath)(
-        maybeRoot: Option[ObjectLocationPrefix]
-      ): Either[LocateFailure[BagPath], ObjectLocation] =
+        maybeRoot: Option[BagPrefix]
+      ): Either[LocateFailure[BagPath], BagLocation] =
         maybeRoot match {
           case None       => Left(LocationNotFound(bagPath, s"No root specified!"))
           case Some(root) => Right(root.asLocation(bagPath.value))

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/storage/s3/S3Resolvable.scala
@@ -4,10 +4,10 @@ import java.net.URI
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 class S3Resolvable(implicit s3Client: AmazonS3)
-    extends Resolvable[ObjectLocation] {
-  override def resolve(location: ObjectLocation): URI =
-    s3Client.getUrl(location.namespace, location.path).toURI
+    extends Resolvable[S3ObjectLocation] {
+  override def resolve(location: S3ObjectLocation): URI =
+    s3Client.getUrl(location.bucket, location.key).toURI
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -9,20 +9,20 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.bag.BagExpectedFixity
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
 import uk.ac.wellcome.platform.archive.common.bagit.models.Bag
-import uk.ac.wellcome.storage.{Location, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
 import scala.util.{Failure, Success, Try}
 
-trait VerifyChecksumAndSize[BagLocation <: Location] {
-  implicit val resolvable: Resolvable[ObjectLocation]
+trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
+  implicit val resolvable: Resolvable[BagLocation]
   implicit val fixityChecker: FixityChecker[BagLocation]
 
   def verifyChecksumAndSize(
-    root: ObjectLocationPrefix,
+    root: BagPrefix,
     bag: Bag
   ): Either[BagVerifierError, FixityListResult[BagLocation]] = {
-    implicit val bagExpectedFixity: BagExpectedFixity =
-      new BagExpectedFixity(root)
+    implicit val bagExpectedFixity: BagExpectedFixity[BagLocation, BagPrefix] =
+      new BagExpectedFixity[BagLocation, BagPrefix](root)
 
     implicit val fixityListChecker: FixityListChecker[BagLocation, Bag] =
       new FixityListChecker()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -13,7 +13,9 @@ import uk.ac.wellcome.storage.{Location, Prefix}
 
 import scala.util.{Failure, Success, Try}
 
-trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
+trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] {
   implicit val resolvable: Resolvable[BagLocation]
   implicit val fixityChecker: FixityChecker[BagLocation]
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -9,7 +9,9 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
 import uk.ac.wellcome.storage.{Location, Prefix}
 
-trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] extends Logging {
+trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] extends Logging {
 
   // Files that it's okay not to be referenced by any other manifests/files.
   //
@@ -34,9 +36,7 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[Bag
     verificationResult match {
       case FixityListAllCorrect(locations) =>
         val expectedLocations =
-          locations
-            .map { _.objectLocation }
-            .toSet
+          locations.map { _.objectLocation }.toSet
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 
@@ -70,7 +70,9 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[Bag
 
           val userMessage = messagePrefix +
             unreferencedFiles
-              .map { loc: BagLocation => root.getRelativePathFrom(loc) }
+              .map { loc: BagLocation =>
+                root.getRelativePathFrom(loc)
+              }
               .mkString(", ")
 
           Left(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -7,9 +7,9 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
 }
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
-import uk.ac.wellcome.storage.{Location, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{Location, Prefix}
 
-trait VerifyNoUnreferencedFiles[BagLocation <: Location] extends Logging {
+trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] extends Logging {
 
   // Files that it's okay not to be referenced by any other manifests/files.
   //
@@ -27,20 +27,21 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location] extends Logging {
   // Check that there aren't any files in the bag that aren't referenced in
   // either the file manifest or the tag manifest.
   def verifyNoUnreferencedFiles(
-    root: ObjectLocationPrefix,
-    actualLocations: Seq[ObjectLocation],
+    root: BagPrefix,
+    actualLocations: Seq[BagLocation],
     verificationResult: FixityListResult[BagLocation]
   ): Either[BagVerifierError, Unit] =
     verificationResult match {
       case FixityListAllCorrect(locations) =>
-        val expectedLocations = locations.map {
-          _.objectLocation.toObjectLocation
-        }
+        val expectedLocations =
+          locations
+            .map { _.objectLocation }
+            .toSet
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 
         val unreferencedFiles = actualLocations
-          .filterNot { expectedLocations.contains(_) }
+          .filterNot { expectedLocations.contains }
           .filterNot { location =>
             excludedFiles.exists { root.asLocation(_) == location }
           }
@@ -69,7 +70,7 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location] extends Logging {
 
           val userMessage = messagePrefix +
             unreferencedFiles
-              .map { _.path.stripPrefix(root.path) }
+              .map { loc: BagLocation => root.getRelativePathFrom(loc) }
               .mkString(", ")
 
           Left(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
@@ -6,9 +6,19 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.ExpectedFileFixity
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagFetchMetadata, BagPath}
-import uk.ac.wellcome.platform.archive.common.generators.{BagGenerators, FetchMetadataGenerators}
-import uk.ac.wellcome.platform.archive.common.verify.{Checksum, ChecksumValue, HashingAlgorithm}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagFetchMetadata,
+  BagPath
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagGenerators,
+  FetchMetadataGenerators
+}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  Checksum,
+  ChecksumValue,
+  HashingAlgorithm
+}
 import uk.ac.wellcome.storage.{MemoryLocation, MemoryLocationPrefix}
 
 class BagExpectedFixityTest
@@ -24,7 +34,8 @@ class BagExpectedFixityTest
     pathPrefix = randomAlphanumeric
   )
 
-  val bagExpectedFixity = new BagExpectedFixity[MemoryLocation, MemoryLocationPrefix](root)
+  val bagExpectedFixity =
+    new BagExpectedFixity[MemoryLocation, MemoryLocationPrefix](root)
 
   def createLocationWith(root: MemoryLocation): MemoryLocation =
     MemoryLocation(
@@ -36,7 +47,8 @@ class BagExpectedFixityTest
     it("for an empty bag") {
       val bag = createBag
 
-      val bagExpectedFixity = new BagExpectedFixity[MemoryLocation, MemoryLocationPrefix](root)
+      val bagExpectedFixity =
+        new BagExpectedFixity[MemoryLocation, MemoryLocationPrefix](root)
 
       bagExpectedFixity.create(bag) shouldBe Right(List.empty)
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -60,7 +60,7 @@ class S3FixityCheckerTest
   implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
 
   override def resolve(location: S3ObjectLocation): URI =
-    s3Resolvable.resolve(location.toObjectLocation)
+    s3Resolvable.resolve(location)
 
   override def withNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -8,7 +8,10 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3BagVerifier
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -16,15 +16,10 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.storage.{
-  ObjectLocation,
-  ObjectLocationPrefix,
-  S3ObjectLocation,
-  S3ObjectLocationPrefix
-}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
+import uk.ac.wellcome.storage.listing.s3.NewS3ObjectLocationListing
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -78,7 +73,7 @@ trait BagVerifierFixtures
       implicit val _s3Resolvable: S3Resolvable =
         new S3Resolvable()
 
-      implicit val listing: S3ObjectLocationListing = S3ObjectLocationListing()
+      implicit val listing: NewS3ObjectLocationListing = new NewS3ObjectLocationListing()
 
       val verifier = new BagVerifier[S3ObjectLocation, S3ObjectLocationPrefix](
         namespace = bucket.name,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -68,7 +68,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot.toObjectLocationPrefix,
+            root = bagRoot,
             space = space,
             externalIdentifier = bagInfo.externalIdentifier
           )
@@ -260,7 +260,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot.toObjectLocationPrefix,
+            root = bagRoot,
             space = space,
             externalIdentifier = payloadExternalIdentifier
           )
@@ -552,7 +552,7 @@ class BagVerifierTest
           withVerifier(bucket) {
             _.verify(
               ingestId = createIngestID,
-              root = bagRoot.toObjectLocationPrefix,
+              root = bagRoot,
               space = space,
               externalIdentifier = bagInfo.externalIdentifier
             )
@@ -632,7 +632,7 @@ class BagVerifierTest
         withVerifier(bucket) {
           _.verify(
             ingestId = createIngestID,
-            root = bagRoot.toObjectLocationPrefix,
+            root = bagRoot,
             space = space,
             externalIdentifier = bagInfo.externalIdentifier
           )

--- a/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -9,6 +9,8 @@ trait Prefix[OfLocation <: Location] {
   def asLocation(parts: String*): OfLocation
 
   def toObjectLocationPrefix: ObjectLocationPrefix
+
+  def getRelativePathFrom(location: OfLocation): String
 }
 
 case class S3ObjectLocation(
@@ -57,6 +59,11 @@ case class S3ObjectLocationPrefix(
       namespace = this.bucket,
       path = this.keyPrefix
     )
+
+  override def getRelativePathFrom(location: S3ObjectLocation): String = {
+    assert(location.bucket == this.bucket)
+    location.key.stripPrefix(this.keyPrefix)
+  }
 }
 
 case object S3ObjectLocationPrefix {
@@ -109,6 +116,11 @@ case class MemoryLocationPrefix(
       namespace = namespace,
       path = pathPrefix
     )
+
+  override def getRelativePathFrom(location: MemoryLocation): String = {
+    assert(location.namespace == this.namespace)
+    location.path.stripPrefix(this.pathPrefix)
+  }
 }
 
 case class AzureBlobItemLocation(
@@ -137,4 +149,9 @@ case class AzureBlobItemLocationPrefix(
       namespace = container,
       path = namePrefix
     )
+
+  override def getRelativePathFrom(location: AzureBlobItemLocation): String = {
+    assert(location.container == this.container)
+    location.name.stripPrefix(this.namePrefix)
+  }
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3Listing.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3Listing.scala
@@ -3,4 +3,5 @@ package uk.ac.wellcome.storage.listing.s3
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.listing.Listing
 
-trait NewS3Listing[ListingResult] extends Listing[S3ObjectLocationPrefix, ListingResult]
+trait NewS3Listing[ListingResult]
+    extends Listing[S3ObjectLocationPrefix, ListingResult]

--- a/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3Listing.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3Listing.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.storage.listing.s3
+
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.listing.Listing
+
+trait NewS3Listing[ListingResult] extends Listing[S3ObjectLocationPrefix, ListingResult]

--- a/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3ObjectLocationListing.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3ObjectLocationListing.scala
@@ -1,15 +1,23 @@
 package uk.ac.wellcome.storage.listing.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.storage.{ListingFailure, S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  ListingFailure,
+  S3ObjectLocation,
+  S3ObjectLocationPrefix
+}
 
-class NewS3ObjectLocationListing(implicit s3Client: AmazonS3) extends NewS3Listing[S3ObjectLocation] {
+class NewS3ObjectLocationListing(implicit s3Client: AmazonS3)
+    extends NewS3Listing[S3ObjectLocation] {
   private val underlying: S3ObjectLocationListing =
     S3ObjectLocationListing()
 
   override def list(prefix: S3ObjectLocationPrefix): ListingResult =
     underlying.list(prefix.toObjectLocationPrefix) match {
-      case Right(iterable)              => Right(iterable.map { loc => S3ObjectLocation(loc) })
+      case Right(iterable) =>
+        Right(iterable.map { loc =>
+          S3ObjectLocation(loc)
+        })
       case Left(ListingFailure(_, err)) => Left(ListingFailure(prefix, err))
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3ObjectLocationListing.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/listing/s3/NewS3ObjectLocationListing.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.storage.listing.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.storage.{ListingFailure, S3ObjectLocation, S3ObjectLocationPrefix}
+
+class NewS3ObjectLocationListing(implicit s3Client: AmazonS3) extends NewS3Listing[S3ObjectLocation] {
+  private val underlying: S3ObjectLocationListing =
+    S3ObjectLocationListing()
+
+  override def list(prefix: S3ObjectLocationPrefix): ListingResult =
+    underlying.list(prefix.toObjectLocationPrefix) match {
+      case Right(iterable)              => Right(iterable.map { loc => S3ObjectLocation(loc) })
+      case Left(ListingFailure(_, err)) => Left(ListingFailure(prefix, err))
+    }
+}


### PR DESCRIPTION
Another part of https://github.com/wellcomecollection/platform/issues/4596

This finishes the refactoring of the bag verifier internals. The inter-app payloads are still using old-style locations, but I'll fix that soon.