### PR TITLE
Store new-style locations in the replica aggregator

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
@@ -5,6 +5,10 @@ import uk.ac.wellcome.storage.{Location, Prefix, S3ObjectLocationPrefix}
 
 sealed trait ReplicaLocation {
   val prefix: Prefix[_ <: Location]
+
+  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
+  // See https://github.com/wellcomecollection/platform/issues/4596
+  def toStorageLocation: StorageLocation
 }
 
 object ReplicaLocation {
@@ -29,22 +33,16 @@ sealed trait S3ReplicaLocation extends ReplicaLocation {
 }
 
 sealed trait PrimaryReplicaLocation extends ReplicaLocation {
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  def toStorageLocation: PrimaryStorageLocation
+  override def toStorageLocation: PrimaryStorageLocation
 }
 
 sealed trait SecondaryReplicaLocation extends ReplicaLocation {
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  def toStorageLocation: SecondaryStorageLocation
+  override def toStorageLocation: SecondaryStorageLocation
 }
 
 case class PrimaryS3ReplicaLocation(
   prefix: S3ObjectLocationPrefix
 ) extends S3ReplicaLocation with PrimaryReplicaLocation {
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
   override def toStorageLocation: PrimaryStorageLocation =
     PrimaryStorageLocation(
       provider = AmazonS3StorageProvider,
@@ -55,8 +53,6 @@ case class PrimaryS3ReplicaLocation(
 case class SecondaryS3ReplicaLocation(
   prefix: S3ObjectLocationPrefix
 ) extends S3ReplicaLocation with SecondaryReplicaLocation {
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
   override def toStorageLocation: SecondaryStorageLocation =
     SecondaryStorageLocation(
       provider = AmazonS3StorageProvider,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.platform.archive.common.storage.models
+
+import uk.ac.wellcome.storage.{Location, Prefix}
+
+sealed trait ReplicaLocation {
+  val prefix: Prefix[_ <: Location]
+}
+
+case class PrimaryReplicaLocation(
+  prefix: Prefix[_ <: Location]
+) extends ReplicaLocation
+
+case class SecondaryReplicaLocation(
+  prefix: Prefix[_ <: Location]
+) extends ReplicaLocation

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaLocation.scala
@@ -42,7 +42,8 @@ sealed trait SecondaryReplicaLocation extends ReplicaLocation {
 
 case class PrimaryS3ReplicaLocation(
   prefix: S3ObjectLocationPrefix
-) extends S3ReplicaLocation with PrimaryReplicaLocation {
+) extends S3ReplicaLocation
+    with PrimaryReplicaLocation {
   override def toStorageLocation: PrimaryStorageLocation =
     PrimaryStorageLocation(
       provider = AmazonS3StorageProvider,
@@ -52,7 +53,8 @@ case class PrimaryS3ReplicaLocation(
 
 case class SecondaryS3ReplicaLocation(
   prefix: S3ObjectLocationPrefix
-) extends S3ReplicaLocation with SecondaryReplicaLocation {
+) extends S3ReplicaLocation
+    with SecondaryReplicaLocation {
   override def toStorageLocation: SecondaryStorageLocation =
     SecondaryStorageLocation(
       provider = AmazonS3StorageProvider,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.platform.archive.common.generators
+
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.platform.archive.common.storage.models._
+import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
+
+trait ReplicaLocationGenerators
+  extends StorageRandomThings
+    with NewS3Fixtures {
+
+  def createPrimaryLocation: PrimaryReplicaLocation =
+    chooseFrom(Seq(
+      PrimaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
+    ))
+
+  def createSecondaryLocation: SecondaryReplicaLocation =
+    chooseFrom(Seq(
+      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
+    ))
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -4,17 +4,19 @@ import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
-trait ReplicaLocationGenerators
-  extends StorageRandomThings
-    with NewS3Fixtures {
+trait ReplicaLocationGenerators extends StorageRandomThings with NewS3Fixtures {
 
   def createPrimaryLocation: PrimaryReplicaLocation =
-    chooseFrom(Seq(
-      PrimaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
-    ))
+    chooseFrom(
+      Seq(
+        PrimaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
+      )
+    )
 
   def createSecondaryLocation: SecondaryReplicaLocation =
-    chooseFrom(Seq(
-      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
-    ))
+    chooseFrom(
+      Seq(
+        SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
+      )
+    )
 }

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -35,7 +35,9 @@ object AggregatorInternalRecord {
   // TODO: Bridging code while we split ObjectLocation.  Remove this later.
   // See https://github.com/wellcomecollection/platform/issues/4596
   def apply(storageLocation: StorageLocation): AggregatorInternalRecord =
-    AggregatorInternalRecord(ReplicaLocation.fromStorageLocation(storageLocation))
+    AggregatorInternalRecord(
+      ReplicaLocation.fromStorageLocation(storageLocation)
+    )
 
   def apply(replicaLocation: ReplicaLocation): AggregatorInternalRecord =
     replicaLocation match {

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -1,10 +1,6 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
-  SecondaryStorageLocation,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.storage.models._
 
 import scala.util.Try
 
@@ -14,15 +10,21 @@ import scala.util.Try
   * a secondary replica first.
   */
 case class AggregatorInternalRecord(
-  location: Option[PrimaryStorageLocation],
-  replicas: List[SecondaryStorageLocation]
+  location: Option[PrimaryReplicaLocation],
+  replicas: List[SecondaryReplicaLocation]
 ) {
-  def addLocation(
-    storageLocation: StorageLocation
-  ): Try[AggregatorInternalRecord] =
+  def addLocation(location: ReplicaLocation): Try[AggregatorInternalRecord] =
     AggregatorInternalRecord.addLocation(
       record = this,
-      storageLocation = storageLocation
+      replicaLocation = location
+    )
+
+  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
+  // See https://github.com/wellcomecollection/platform/issues/4596
+  def addLocation(location: StorageLocation): Try[AggregatorInternalRecord] =
+    AggregatorInternalRecord.addLocation(
+      record = this,
+      replicaLocation = ReplicaLocation.fromStorageLocation(location)
     )
 
   def count: Int =
@@ -30,15 +32,19 @@ case class AggregatorInternalRecord(
 }
 
 object AggregatorInternalRecord {
-
+  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
+  // See https://github.com/wellcomecollection/platform/issues/4596
   def apply(storageLocation: StorageLocation): AggregatorInternalRecord =
-    storageLocation match {
-      case primary: PrimaryStorageLocation =>
+    AggregatorInternalRecord(ReplicaLocation.fromStorageLocation(storageLocation))
+
+  def apply(replicaLocation: ReplicaLocation): AggregatorInternalRecord =
+    replicaLocation match {
+      case primary: PrimaryReplicaLocation =>
         AggregatorInternalRecord(
           location = Some(primary),
           replicas = List.empty
         )
-      case secondary: SecondaryStorageLocation =>
+      case secondary: SecondaryReplicaLocation =>
         AggregatorInternalRecord(
           location = None,
           replicas = List(secondary)
@@ -47,15 +53,15 @@ object AggregatorInternalRecord {
 
   def addLocation(
     record: AggregatorInternalRecord,
-    storageLocation: StorageLocation
+    replicaLocation: ReplicaLocation
   ): Try[AggregatorInternalRecord] = {
-    storageLocation match {
-      case primaryLocation: PrimaryStorageLocation =>
+    replicaLocation match {
+      case primaryLocation: PrimaryReplicaLocation =>
         addPrimaryLocation(
           record = record,
           primaryLocation = primaryLocation
         )
-      case secondaryLocation: SecondaryStorageLocation =>
+      case secondaryLocation: SecondaryReplicaLocation =>
         addSecondaryLocation(
           record = record,
           secondaryLocation = secondaryLocation
@@ -65,7 +71,7 @@ object AggregatorInternalRecord {
 
   private def addSecondaryLocation(
     record: AggregatorInternalRecord,
-    secondaryLocation: SecondaryStorageLocation
+    secondaryLocation: SecondaryReplicaLocation
   ) = Try {
     record.copy(
       replicas = (record.replicas.toSet ++ Set(secondaryLocation)).toList
@@ -74,7 +80,7 @@ object AggregatorInternalRecord {
 
   private def addPrimaryLocation(
     record: AggregatorInternalRecord,
-    primaryLocation: PrimaryStorageLocation
+    primaryLocation: PrimaryReplicaLocation
   ): Try[AggregatorInternalRecord] = Try {
     record.location match {
       case None                                          => record.copy(location = Some(primaryLocation))

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
@@ -33,8 +33,8 @@ class ReplicaCounter(val expectedReplicaCount: Int) {
         if (actualReplicaCount >= expectedReplicaCount) {
           Right(
             KnownReplicas(
-              location = primaryLocation,
-              replicas = record.replicas
+              location = primaryLocation.toStorageLocation,
+              replicas = record.replicas.map { _.toStorageLocation }
             )
           )
         } else {

--- a/replica_aggregator/src/test/resources/logback-test.xml
+++ b/replica_aggregator/src/test/resources/logback-test.xml
@@ -8,4 +8,10 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -9,16 +9,10 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  PrimaryStorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
-  AggregatorInternalRecord,
-  ReplicaPath
-}
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
+import uk.ac.wellcome.storage.{S3ObjectLocationPrefix, Version}
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 class ReplicaAggregatorFeatureTest
@@ -69,7 +63,11 @@ class ReplicaAggregatorFeatureTest
             prefix = payload.bagRoot
           )
 
-          stored.identifiedT.location shouldBe Some(primaryLocation)
+          val primaryReplicaLocation = PrimaryS3ReplicaLocation(
+            prefix = S3ObjectLocationPrefix(payload.bagRoot)
+          )
+
+          stored.identifiedT.location shouldBe Some(primaryReplicaLocation)
 
           stored.identifiedT.replicas shouldBe empty
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -9,9 +9,16 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  PrimaryS3ReplicaLocation,
+  PrimaryStorageLocation
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  ReplicaPath
+}
 import uk.ac.wellcome.storage.{S3ObjectLocationPrefix, Version}
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
@@ -3,24 +3,21 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.models
 import org.scalatest.TryValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
-import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryStorageLocation
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.platform.archive.common.generators.ReplicaLocationGenerators
+import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryReplicaLocation
 
 class AggregatorInternalRecordTest
     extends AnyFunSpec
     with Matchers
     with TryValues
-    with StorageLocationGenerators
-    with RandomThings {
+    with ReplicaLocationGenerators {
 
-  def createReplicas(min: Int = 0): List[SecondaryStorageLocation] =
+  def createReplicas(min: Int = 0): List[SecondaryReplicaLocation] =
     (1 to randomInt(min, 10))
       .map(_ => createSecondaryLocation)
       .toList
 
   describe("creates a record from a single storage location") {
-
     it("primary location") {
       val location = createPrimaryLocation
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -128,7 +128,9 @@ class ReplicaAggregatorWorkerTest
       )
       incompleteAggregation.aggregatorRecord shouldBe AggregatorInternalRecord(
         location = Some(
-          PrimaryS3ReplicaLocation(prefix = S3ObjectLocationPrefix(payload.bagRoot))
+          PrimaryS3ReplicaLocation(
+            prefix = S3ObjectLocationPrefix(payload.bagRoot)
+          )
         ),
         replicas = List.empty
       )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -128,10 +128,7 @@ class ReplicaAggregatorWorkerTest
       )
       incompleteAggregation.aggregatorRecord shouldBe AggregatorInternalRecord(
         location = Some(
-          PrimaryStorageLocation(
-            provider = payload.replicaResult.storageLocation.provider,
-            prefix = payload.bagRoot
-          )
+          PrimaryS3ReplicaLocation(prefix = S3ObjectLocationPrefix(payload.bagRoot))
         ),
         replicas = List.empty
       )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
@@ -3,15 +3,15 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.services
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.common.generators.ReplicaLocationGenerators
 import uk.ac.wellcome.platform.archive.common.storage.models.KnownReplicas
-import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.AggregatorInternalRecord
 
 class ReplicaCounterTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with StorageLocationGenerators {
+    with ReplicaLocationGenerators {
   it("rejects a record without a primary location") {
     val counter = new ReplicaCounter(expectedReplicaCount = 1)
 
@@ -51,7 +51,7 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location,
+      location = location.toStorageLocation,
       replicas = List.empty
     )
   }
@@ -68,8 +68,8 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location,
-      replicas = replicas
+      location = location.toStorageLocation,
+      replicas = replicas.map { _.toStorageLocation }
     )
   }
 
@@ -104,8 +104,8 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location,
-      replicas = replicas
+      location = location.toStorageLocation,
+      replicas = replicas.map { _.toStorageLocation }
     )
   }
 }


### PR DESCRIPTION
Part of wellcomecollection/platform#4596

Previously the replica aggregator would store a `PrimaryStorageLocation` and a list of `SecondaryStorageLocation`.

This patch modifies its internal storage to hold a `PrimaryReplicaLocation` and a list of `SecondaryReplicaLocation`. These omit the provider value, because we can deduce it from the type of `Prefix`.

It doesn't change the inter-app messaging formats.

Once this is merged and deployed, I'll run a migration over the existing replica aggregator tables to use the new format, which we know is always S3.