### PR TITLE
Create this instance of TagManifestFileFinder lazily

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestService.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestService.scala
@@ -22,7 +22,7 @@ trait StorageManifestService[BagLocation <: Location] extends Logging {
 
   implicit val streamReader: Readable[BagLocation, InputStreamWithLength]
 
-  private val tagManifestFileFinder = new TagManifestFileFinder()
+  private lazy val tagManifestFileFinder = new TagManifestFileFinder()
 
   def createLocation(uri: URI): BagLocation
 


### PR DESCRIPTION
If you don't make this value lazy, you get an error when you start the app via Main:

    Exception in thread "main" scala.UninitializedFieldError: Uninitialized field: bag_register/services/s3/S3StorageManifestService.scala: 28

I haven't fully debugged this error and I'm not sure why it occurs here but not in the tests; I do know that this change fixes it.  This is breaking the pipeline and doesn't add any tech debt, so I'm happy to leave it without digging further.

Fix for https://github.com/wellcomecollection/platform/issues/4617