### PR TITLE
Add iiif-builder dashboard principal to storage buckets

### DIFF
--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -93,6 +93,9 @@ data "aws_iam_policy_document" "replica_primary_read" {
         # Beta version of the DLCS orchestrator.
         # See https://wellcome.slack.com/archives/CBT40CMKQ/p1573742247457800
         "AROAZQI22QHWTHLN4QHJU:*",
+
+        # Dashboard for iiif-builder staging
+        "AROAZQI22QHW3RRRIYDN3:*"
       ]
     }
 


### PR DESCRIPTION
Add role uniqueId to s3_replica_primary, this is to allow the dashboard to read these buckets.

See [iiif-builder-infrastructure commit](https://github.com/wellcomecollection/iiif-builder-infrastructure/pull/2/commits/07e89fcab0e212f4999906bc29ea6d8ec8be1c2e) for where this is coming from.