### PR TITLE
Remove a now-unused ObjectLocationGenerators trait

### DIFF
--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
@@ -18,14 +18,12 @@ import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.VersionedBagRootPayload
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.BagVersionerFixtures
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 class BagVersionerFeatureTest
     extends AnyFunSpec
     with BagVersionerFixtures
     with IngestUpdateAssertions
     with PayloadGenerators
-    with ObjectLocationGenerators
     with ExternalIdentifierGenerators
     with StorageSpaceGenerators
     with Eventually

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
@@ -20,14 +20,12 @@ import uk.ac.wellcome.platform.storage.bag_versioner.models.{
   BagVersionerFailureSummary,
   BagVersionerSuccessSummary
 }
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 class BagVersionerTest
     extends AnyFunSpec
     with Matchers
     with TryValues
     with BagVersionerFixtures
-    with ObjectLocationGenerators
     with ExternalIdentifierGenerators
     with StorageSpaceGenerators {
 


### PR DESCRIPTION
Another step for https://github.com/wellcomecollection/platform/issues/4596