### PR TITLE
Send a new-style location from the ingests API to the bag unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/builders/BagLocationBuilder.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/builders/BagLocationBuilder.scala
@@ -5,17 +5,17 @@ import java.nio.file.Paths
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWorkerConfig
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 object BagLocationBuilder {
   def build(
     ingestId: IngestID,
     storageSpace: StorageSpace,
     unpackerWorkerConfig: BagUnpackerWorkerConfig
-  ): ObjectLocationPrefix =
-    ObjectLocationPrefix(
-      namespace = unpackerWorkerConfig.dstNamespace,
-      path = Paths
+  ): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = unpackerWorkerConfig.dstNamespace,
+      keyPrefix = Paths
         .get(
           storageSpace.toString,
           ingestId.toString

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -54,7 +54,8 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       stepResult <- unpacker.unpack(
         ingestId = payload.ingestId,
-        srcLocation = payload.sourceLocation.location.asInstanceOf[S3ObjectLocation],
+        srcLocation =
+          payload.sourceLocation.location.asInstanceOf[S3ObjectLocation],
         dstPrefix = unpackedBagLocation
       )
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -54,15 +54,15 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       stepResult <- unpacker.unpack(
         ingestId = payload.ingestId,
-        srcLocation = S3ObjectLocation(payload.sourceLocation),
-        dstPrefix = S3ObjectLocationPrefix(unpackedBagLocation)
+        srcLocation = payload.sourceLocation.location.asInstanceOf[S3ObjectLocation],
+        dstPrefix = unpackedBagLocation
       )
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
       outgoingPayload = UnpackedBagLocationPayload(
         context = payload.context,
-        unpackedBagLocation = unpackedBagLocation
+        unpackedBagLocation = unpackedBagLocation.toObjectLocationPrefix
       )
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)
     } yield stepResult

--- a/bag_unpacker/src/test/resources/logback-test.xml
+++ b/bag_unpacker/src/test/resources/logback-test.xml
@@ -8,4 +8,10 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -35,9 +35,7 @@ class UnpackerFeatureTest
           withLocalS3Bucket { srcBucket =>
             withArchive(srcBucket, archiveFile) { archiveLocation =>
               val sourceLocationPayload =
-                createSourceLocationPayloadWith(
-                  archiveLocation.toObjectLocation
-                )
+                createSourceLocationPayloadWith(archiveLocation)
               sendNotificationToSQS(queue, sourceLocationPayload)
 
               eventually {
@@ -83,7 +81,7 @@ class UnpackerFeatureTest
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, _, queue, ingests, outgoing) =>
-        val sourceLocation = createObjectLocationWith(
+        val sourceLocation = createS3ObjectLocationWith(
           bucket = createBucket
         )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,9 +2,21 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaResult, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestType,
+  SourceLocation
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  ReplicaResult,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 sealed trait PipelinePayload {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,21 +2,10 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestType
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  ReplicaResult,
-  StorageSpace
-}
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaResult, StorageSpace}
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 sealed trait PipelinePayload {
   val context: PipelineContext
@@ -30,14 +19,14 @@ sealed trait PipelinePayload {
 
 case class SourceLocationPayload(
   context: PipelineContext,
-  sourceLocation: ObjectLocation
+  sourceLocation: SourceLocation
 ) extends PipelinePayload
 
 case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
     SourceLocationPayload(
       context = PipelineContext(ingest),
-      sourceLocation = ingest.sourceLocation.location.toObjectLocation
+      sourceLocation = ingest.sourceLocation
     )
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -12,9 +12,3 @@ case class S3SourceLocation(
 ) extends SourceLocation {
   val provider: StorageProvider = AmazonS3StorageProvider
 }
-
-case class AzureBlobSourceLocation(
-  location: AzureBlobItemLocation
-) extends SourceLocation {
-  val provider: StorageProvider = AzureBlobStorageProvider
-}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -47,7 +47,7 @@ class SourceLocationPayloadTest
         ingestDate = ingestDate,
         externalIdentifier = externalIdentifier
       ),
-      sourceLocation = sourceLocation.toObjectLocation
+      sourceLocation = S3SourceLocation(sourceLocation)
     )
 
     SourceLocationPayload(ingest) shouldBe expectedPayload

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -3,14 +3,11 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
-import uk.ac.wellcome.storage.{ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
@@ -42,14 +39,14 @@ trait PayloadGenerators
     createPipelineContextWith()
 
   def createSourceLocationPayloadWith(
-    sourceLocation: ObjectLocation = createObjectLocation,
+    sourceLocation: S3ObjectLocation = createS3ObjectLocation,
     storageSpace: StorageSpace = createStorageSpace
   ): SourceLocationPayload =
     SourceLocationPayload(
       context = createPipelineContextWith(
         storageSpace = storageSpace
       ),
-      sourceLocation = sourceLocation
+      sourceLocation = S3SourceLocation(sourceLocation)
     )
 
   def createSourceLocationPayload: SourceLocationPayload =

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.display
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
-import uk.ac.wellcome.storage.{AzureBlobItemLocation, S3ObjectLocation}
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 case class DisplayLocation(
   provider: DisplayProvider,
@@ -19,8 +19,8 @@ case class DisplayLocation(
         )
 
       case AzureBlobStorageProvider =>
-        AzureBlobSourceLocation(
-          location = AzureBlobItemLocation(container = bucket, name = path)
+        throw new IllegalArgumentException(
+          "Unpacking is not supported from an Azure location!"
         )
     }
 }
@@ -33,13 +33,6 @@ object DisplayLocation {
           provider = DisplayProvider(location.provider),
           bucket = s3Location.bucket,
           path = s3Location.key
-        )
-
-      case AzureBlobSourceLocation(azureLocation) =>
-        DisplayLocation(
-          provider = DisplayProvider(location.provider),
-          bucket = azureLocation.container,
-          path = azureLocation.name
         )
     }
 

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
@@ -3,11 +3,8 @@ package uk.ac.wellcome.platform.archive.display
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  AzureBlobSourceLocation,
-  S3SourceLocation
-}
-import uk.ac.wellcome.storage.{AzureBlobItemLocation, S3ObjectLocation}
+import uk.ac.wellcome.platform.archive.common.ingests.models.S3SourceLocation
+import uk.ac.wellcome.storage.S3ObjectLocation
 
 class DisplayLocationTest
     extends AnyFunSpec
@@ -28,19 +25,6 @@ class DisplayLocationTest
         path = "path/to/my/bag.tar.gz"
       )
     ),
-    (
-      AzureBlobSourceLocation(
-        location = AzureBlobItemLocation(
-          container = "my-container",
-          name = "path/to/my/bag.tar.gz"
-        )
-      ),
-      DisplayLocation(
-        provider = DisplayProvider("azure-blob-storage"),
-        bucket = "my-container",
-        path = "path/to/my/bag.tar.gz"
-      )
-    )
   )
 
   it("creates an internal SourceLocation") {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayLocationTest.scala
@@ -24,7 +24,7 @@ class DisplayLocationTest
         bucket = "my-bukkit",
         path = "path/to/my/bag.tar.gz"
       )
-    ),
+    )
   )
 
   it("creates an internal SourceLocation") {


### PR DESCRIPTION
Another step towards removing ObjectLocation from the codebase. Part of https://github.com/wellcomecollection/platform/issues/4596