### PR TITLE
Add a internal AzureReplicator class

### DIFF
--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -9,3 +9,8 @@ s3:
     - "S3BACKEND=mem"
   ports:
     - "33333:8000"
+azurite:
+  image: "mcr.microsoft.com/azure-storage/azurite"
+  ports:
+    - "10000:10000"
+  command: ["azurite", "--blobHost", "0.0.0.0"]

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
@@ -6,11 +6,16 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
 import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
 import uk.ac.wellcome.storage.store.s3.{S3StreamReadable, S3StreamStore}
 import uk.ac.wellcome.storage.transfer.PrefixTransfer
-import uk.ac.wellcome.storage.transfer.azure.{S3toAzurePrefixTransfer, S3toAzureTransfer}
+import uk.ac.wellcome.storage.transfer.azure.{
+  S3toAzurePrefixTransfer,
+  S3toAzureTransfer
+}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
-class AzureReplicator(implicit s3Client: AmazonS3, blobClient: BlobServiceClient)
-  extends Replicator {
+class AzureReplicator(
+  implicit s3Client: AmazonS3,
+  blobClient: BlobServiceClient
+) extends Replicator {
 
   implicit val readable: S3StreamReadable = new S3StreamStore()
 
@@ -19,6 +24,7 @@ class AzureReplicator(implicit s3Client: AmazonS3, blobClient: BlobServiceClient
 
   implicit val transfer: S3toAzureTransfer = new S3toAzureTransfer
 
-  override implicit val prefixTransfer: PrefixTransfer[ObjectLocationPrefix, ObjectLocation] =
+  override implicit val prefixTransfer
+    : PrefixTransfer[ObjectLocationPrefix, ObjectLocation] =
     new S3toAzurePrefixTransfer()
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.replicator.azure
+
+import com.amazonaws.services.s3.AmazonS3
+import com.azure.storage.blob.BlobServiceClient
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
+import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
+import uk.ac.wellcome.storage.store.s3.{S3StreamReadable, S3StreamStore}
+import uk.ac.wellcome.storage.transfer.PrefixTransfer
+import uk.ac.wellcome.storage.transfer.azure.{S3toAzurePrefixTransfer, S3toAzureTransfer}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+
+class AzureReplicator(implicit s3Client: AmazonS3, blobClient: BlobServiceClient)
+  extends Replicator {
+
+  implicit val readable: S3StreamReadable = new S3StreamStore()
+
+  override implicit val prefixListing: S3ObjectLocationListing =
+    S3ObjectLocationListing()
+
+  implicit val transfer: S3toAzureTransfer = new S3toAzureTransfer
+
+  override implicit val prefixTransfer: PrefixTransfer[ObjectLocationPrefix, ObjectLocation] =
+    new S3toAzurePrefixTransfer()
+}

--- a/bag_replicator/src/test/resources/logback-test.xml
+++ b/bag_replicator/src/test/resources/logback-test.xml
@@ -8,4 +8,8 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
+  <logger name="io.netty" level="ERROR"/>
 </configuration>

--- a/bag_replicator/src/test/resources/logback-test.xml
+++ b/bag_replicator/src/test/resources/logback-test.xml
@@ -12,4 +12,5 @@
   <logger name="com.amazonaws" level="WARN"/>
   <logger name="software.amazon.awssdk" level="WARN"/>
   <logger name="io.netty" level="ERROR"/>
+  <logger name="reactor.netty" level="ERROR"/>
 </configuration>

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
@@ -4,14 +4,18 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{ReplicationFailed, ReplicationRequest, ReplicationSucceeded}
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{
+  ReplicationFailed,
+  ReplicationRequest,
+  ReplicationSucceeded
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
 
 trait ReplicatorTestCases[SrcNamespace, DstNamespace]
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with EitherValues
     with StorageRandomThings {
@@ -21,7 +25,10 @@ trait ReplicatorTestCases[SrcNamespace, DstNamespace]
   def withReplicator[R](testWith: TestWith[Replicator, R]): R
 
   def createSrcLocationWith(srcNamespace: SrcNamespace): ObjectLocation
-  def createDstLocationWith(dstNamespace: DstNamespace, path: String): ObjectLocation
+  def createDstLocationWith(
+    dstNamespace: DstNamespace,
+    path: String
+  ): ObjectLocation
 
   def createSrcPrefixWith(srcNamespace: SrcNamespace): ObjectLocationPrefix
   def createDstPrefixWith(dstNamespace: DstNamespace): ObjectLocationPrefix
@@ -165,7 +172,8 @@ trait ReplicatorTestCases[SrcNamespace, DstNamespace]
         result shouldBe a[ReplicationSucceeded]
 
         val dstLocation = createDstLocationWith(
-          dstNamespace, path = location.path
+          dstNamespace,
+          path = location.path
         )
 
         dstTags.get(dstLocation).right.value shouldBe Identified(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
@@ -1,0 +1,105 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.replicator
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{ReplicationFailed, ReplicationRequest, ReplicationSucceeded}
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+
+trait ReplicatorTestCases[SrcNamespace, DstNamespace]
+  extends AnyFunSpec
+    with Matchers
+    with StorageRandomThings {
+  def withSrcNamespace[R](testWith: TestWith[SrcNamespace, R]): R
+  def withDstNamespace[R](testWith: TestWith[DstNamespace, R]): R
+
+  def withReplicator[R](testWith: TestWith[Replicator, R]): R
+
+  def createSrcLocationWith(srcNamespace: SrcNamespace): ObjectLocation
+  def createDstLocationWith(dstNamespace: DstNamespace, path: String): ObjectLocation
+
+  def createSrcPrefixWith(srcNamespace: SrcNamespace): ObjectLocationPrefix
+  def createDstPrefixWith(dstNamespace: DstNamespace): ObjectLocationPrefix
+
+  def putSrcObject(location: ObjectLocation, contents: String): Unit
+  def putDstObject(location: ObjectLocation, contents: String): Unit
+
+  def getDstObject(location: ObjectLocation): String
+
+  it("replicates all the objects under a prefix") {
+    withSrcNamespace { srcNamespace =>
+      withDstNamespace { dstNamespace =>
+        val locations = (1 to 5).map { _ =>
+          createSrcLocationWith(srcNamespace)
+        }
+
+        val objects = locations.map { _ -> randomAlphanumeric }.toMap
+
+        objects.foreach {
+          case (loc, contents) => putSrcObject(loc, contents)
+        }
+
+        val srcPrefix = createSrcPrefixWith(srcNamespace)
+        val dstPrefix = createDstPrefixWith(dstNamespace)
+
+        val result = withReplicator {
+          _.replicate(
+            ingestId = createIngestID,
+            request = ReplicationRequest(
+              srcPrefix = srcPrefix,
+              dstPrefix = dstPrefix
+            )
+          )
+        }
+
+        result shouldBe a[ReplicationSucceeded]
+        result.summary.maybeEndTime.isDefined shouldBe true
+      }
+    }
+  }
+
+  it("fails if there are already different objects in the prefix") {
+    withSrcNamespace { srcNamespace =>
+      withDstNamespace { dstNamespace =>
+        val locations = (1 to 5).map { _ =>
+          createSrcLocationWith(srcNamespace)
+        }
+
+        val objects = locations.map { _ -> randomAlphanumeric }.toMap
+
+        objects.foreach {
+          case (loc, contents) => putSrcObject(loc, contents)
+        }
+
+        val srcPrefix = createSrcPrefixWith(srcNamespace)
+        val dstPrefix = createDstPrefixWith(dstNamespace)
+
+        // Write something to the first destination.  The replicator should realise
+        // this object already exists, and refuse to overwrite it.
+        val badContents = randomAlphanumeric
+
+        val dstLocation = createDstLocationWith(
+          dstNamespace = dstNamespace,
+          path = locations.head.path.replace("src/", "dst/")
+        )
+
+        putDstObject(dstLocation, contents = badContents)
+
+        val result = withReplicator {
+          _.replicate(
+            ingestId = createIngestID,
+            request = ReplicationRequest(
+              srcPrefix = srcPrefix,
+              dstPrefix = dstPrefix
+            )
+          )
+        }
+
+        result shouldBe a[ReplicationFailed]
+
+        getDstObject(dstLocation) shouldBe badContents
+      }
+    }
+  }
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{ReplicationFailed, ReplicationRequest, ReplicationSucceeded}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
 
@@ -25,13 +26,20 @@ trait ReplicatorTestCases[SrcNamespace, DstNamespace]
   def createSrcPrefixWith(srcNamespace: SrcNamespace): ObjectLocationPrefix
   def createDstPrefixWith(dstNamespace: DstNamespace): ObjectLocationPrefix
 
-  def putSrcObject(location: ObjectLocation, contents: String): Unit
-  def putDstObject(location: ObjectLocation, contents: String): Unit
-
-  def getDstObject(location: ObjectLocation): String
-
   val srcTags: Tags[ObjectLocation]
   val dstTags: Tags[ObjectLocation]
+
+  val srcStringStore: TypedStore[ObjectLocation, String]
+  val dstStringStore: TypedStore[ObjectLocation, String]
+
+  def putSrcObject(location: ObjectLocation, contents: String): Unit =
+    srcStringStore.put(location)(contents) shouldBe a[Right[_, _]]
+
+  def putDstObject(location: ObjectLocation, contents: String): Unit =
+    dstStringStore.put(location)(contents) shouldBe a[Right[_, _]]
+
+  def getDstObject(location: ObjectLocation): String =
+    dstStringStore.get(location).right.value.identifiedT
 
   it("replicates all the objects under a prefix") {
     withSrcNamespace { srcNamespace =>

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
@@ -1,15 +1,18 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{ReplicationFailed, ReplicationRequest, ReplicationSucceeded}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.tags.Tags
+import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
 
 trait ReplicatorTestCases[SrcNamespace, DstNamespace]
   extends AnyFunSpec
     with Matchers
+    with EitherValues
     with StorageRandomThings {
   def withSrcNamespace[R](testWith: TestWith[SrcNamespace, R]): R
   def withDstNamespace[R](testWith: TestWith[DstNamespace, R]): R
@@ -26,6 +29,9 @@ trait ReplicatorTestCases[SrcNamespace, DstNamespace]
   def putDstObject(location: ObjectLocation, contents: String): Unit
 
   def getDstObject(location: ObjectLocation): String
+
+  val srcTags: Tags[ObjectLocation]
+  val dstTags: Tags[ObjectLocation]
 
   it("replicates all the objects under a prefix") {
     withSrcNamespace { srcNamespace =>
@@ -99,6 +105,65 @@ trait ReplicatorTestCases[SrcNamespace, DstNamespace]
         result shouldBe a[ReplicationFailed]
 
         getDstObject(dstLocation) shouldBe badContents
+      }
+    }
+  }
+
+  it("fails if the underlying replication has an error") {
+    val srcPrefix = withSrcNamespace { createSrcPrefixWith }
+    val dstPrefix = withDstNamespace { createDstPrefixWith }
+
+    val result = withReplicator {
+      _.replicate(
+        ingestId = createIngestID,
+        request = ReplicationRequest(
+          srcPrefix = srcPrefix,
+          dstPrefix = dstPrefix
+        )
+      )
+    }
+
+    result shouldBe a[ReplicationFailed]
+    result.summary.maybeEndTime.isDefined shouldBe true
+
+    result.asInstanceOf[ReplicationFailed]
+  }
+
+  // The verifier will write a Content-SHA256 checksum tag to objects when it
+  // verifies them.  If an object is then replicated to a new location, any existing
+  // verification tags should be removed.
+  it("doesn't copy tags from the existing objects") {
+    withSrcNamespace { srcNamespace =>
+      withDstNamespace { dstNamespace =>
+        val location = createSrcLocationWith(srcNamespace)
+
+        putSrcObject(location, contents = randomAlphanumeric)
+        srcTags.update(location) { existingTags =>
+          Right(existingTags ++ Map("Content-SHA256" -> "abcdef"))
+        }
+
+        val request = ReplicationRequest(
+          srcPrefix = createSrcPrefixWith(srcNamespace),
+          dstPrefix = createDstPrefixWith(dstNamespace)
+        )
+
+        val result = withReplicator {
+          _.replicate(
+            ingestId = createIngestID,
+            request = request
+          )
+        }
+
+        result shouldBe a[ReplicationSucceeded]
+
+        val dstLocation = createDstLocationWith(
+          dstNamespace, path = location.path
+        )
+
+        dstTags.get(dstLocation).right.value shouldBe Identified(
+          dstLocation,
+          Map.empty
+        )
       }
     }
   }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
@@ -44,18 +45,11 @@ class AzureReplicatorTest
     dstContainer: Container): ObjectLocationPrefix =
     ObjectLocationPrefix(dstContainer.name, path = "")
 
-  override def putSrcObject(location: ObjectLocation, contents: String): Unit =
-    s3Client.putObject(location.namespace, location.path, contents)
+  override val srcStringStore: S3TypedStore[String] = S3TypedStore[String]
 
   implicit val streamStore: AzureStreamStore = new AzureStreamStore()
-  val typedStore = new AzureTypedStore[String]
+  override val dstStringStore: AzureTypedStore[String] = new AzureTypedStore[String]
 
-  override def putDstObject(location: ObjectLocation, contents: String): Unit =
-    typedStore.put(location)(contents)
-
-  override def getDstObject(location: ObjectLocation): String =
-    typedStore.get(location).right.value.identifiedT
-
-  override  val srcTags: Tags[ObjectLocation] = new S3Tags()
-  override  val dstTags: Tags[ObjectLocation] = new AzureBlobMetadata()
+  override val srcTags: Tags[ObjectLocation] = new S3Tags()
+  override val dstTags: Tags[ObjectLocation] = new AzureBlobMetadata()
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
@@ -7,6 +7,9 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
 import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.tags.Tags
+import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
+import uk.ac.wellcome.storage.tags.s3.S3Tags
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 class AzureReplicatorTest
@@ -52,4 +55,7 @@ class AzureReplicatorTest
 
   override def getDstObject(location: ObjectLocation): String =
     typedStore.get(location).right.value.identifiedT
+
+  override  val srcTags: Tags[ObjectLocation] = new S3Tags()
+  override  val dstTags: Tags[ObjectLocation] = new AzureBlobMetadata()
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.replicator.azure
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{Replicator, ReplicatorTestCases}
+import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
+import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
+import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+
+class AzureReplicatorTest
+  extends ReplicatorTestCases[Bucket, Container]
+    with AzureFixtures
+    with S3Fixtures {
+
+  override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
+    withLocalS3Bucket { bucket =>
+      testWith(bucket)
+    }
+
+  override def withDstNamespace[R](testWith: TestWith[Container, R]): R =
+    withAzureContainer { container =>
+      testWith(container)
+    }
+
+  override def withReplicator[R](testWith: TestWith[Replicator, R]): R =
+    testWith(new AzureReplicator())
+
+  override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
+    createObjectLocationWith(srcBucket)
+
+  override def createDstLocationWith(dstContainer: Container,
+                                     path: String): ObjectLocation =
+    createObjectLocationWith(dstContainer.name, path = path)
+
+  override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =
+    ObjectLocationPrefix(srcBucket.name, path = "")
+
+  override def createDstPrefixWith(
+    dstContainer: Container): ObjectLocationPrefix =
+    ObjectLocationPrefix(dstContainer.name, path = "")
+
+  override def putSrcObject(location: ObjectLocation, contents: String): Unit =
+    s3Client.putObject(location.namespace, location.path, contents)
+
+  implicit val streamStore: AzureStreamStore = new AzureStreamStore()
+  val typedStore = new AzureTypedStore[String]
+
+  override def putDstObject(location: ObjectLocation, contents: String): Unit =
+    typedStore.put(location)(contents)
+
+  override def getDstObject(location: ObjectLocation): String =
+    typedStore.get(location).right.value.identifiedT
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.azure
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{Replicator, ReplicatorTestCases}
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{
+  Replicator,
+  ReplicatorTestCases
+}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
@@ -14,7 +17,7 @@ import uk.ac.wellcome.storage.tags.s3.S3Tags
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 class AzureReplicatorTest
-  extends ReplicatorTestCases[Bucket, Container]
+    extends ReplicatorTestCases[Bucket, Container]
     with AzureFixtures
     with S3Fixtures {
 
@@ -34,21 +37,25 @@ class AzureReplicatorTest
   override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
     createObjectLocationWith(srcBucket)
 
-  override def createDstLocationWith(dstContainer: Container,
-                                     path: String): ObjectLocation =
+  override def createDstLocationWith(
+    dstContainer: Container,
+    path: String
+  ): ObjectLocation =
     createObjectLocationWith(dstContainer.name, path = path)
 
   override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =
     ObjectLocationPrefix(srcBucket.name, path = "")
 
   override def createDstPrefixWith(
-    dstContainer: Container): ObjectLocationPrefix =
+    dstContainer: Container
+  ): ObjectLocationPrefix =
     ObjectLocationPrefix(dstContainer.name, path = "")
 
   override val srcStringStore: S3TypedStore[String] = S3TypedStore[String]
 
   implicit val streamStore: AzureStreamStore = new AzureStreamStore()
-  override val dstStringStore: AzureTypedStore[String] = new AzureTypedStore[String]
+  override val dstStringStore: AzureTypedStore[String] =
+    new AzureTypedStore[String]
 
   override val srcTags: Tags[ObjectLocation] = new S3Tags()
   override val dstTags: Tags[ObjectLocation] = new AzureBlobMetadata()

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{Replicator, ReplicatorTestCases}
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{
+  Replicator,
+  ReplicatorTestCases
+}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
@@ -29,7 +32,10 @@ class S3ReplicatorTest
   override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
     createObjectLocationWith(srcBucket)
 
-  override def createDstLocationWith(dstBucket: Bucket, key: String): ObjectLocation =
+  override def createDstLocationWith(
+    dstBucket: Bucket,
+    key: String
+  ): ObjectLocation =
     createObjectLocationWith(dstBucket, key)
 
   override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -1,179 +1,46 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
-import com.amazonaws.services.s3.model.AmazonS3Exception
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{
-  ReplicationFailed,
-  ReplicationRequest,
-  ReplicationSucceeded
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{Replicator, ReplicatorTestCases}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.s3.S3Tags
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 class S3ReplicatorTest
-    extends AnyFunSpec
-    with Matchers
-    with S3Fixtures
-    with StorageRandomThings {
-  it("replicates all the objects under a prefix") {
+    extends ReplicatorTestCases[Bucket, Bucket]
+    with S3Fixtures {
+
+  override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
-      val locations = (1 to 5).map { _ =>
-        createObjectLocationWith(bucket, key = s"src/$randomAlphanumeric")
-      }
-
-      val objects = locations.map { _ -> randomAlphanumeric }.toMap
-
-      objects.foreach {
-        case (loc, contents) =>
-          s3Client.putObject(
-            loc.namespace,
-            loc.path,
-            contents
-          )
-      }
-
-      val srcPrefix = ObjectLocationPrefix(
-        namespace = bucket.name,
-        path = "src/"
-      )
-
-      val dstPrefix = ObjectLocationPrefix(
-        namespace = bucket.name,
-        path = "dst/"
-      )
-
-      val result = new S3Replicator().replicate(
-        ingestId = createIngestID,
-        request = ReplicationRequest(
-          srcPrefix = srcPrefix,
-          dstPrefix = dstPrefix
-        )
-      )
-
-      result shouldBe a[ReplicationSucceeded]
-      result.summary.maybeEndTime.isDefined shouldBe true
+      testWith(bucket)
     }
-  }
 
-  it("fails if there are already different objects in the prefix") {
+  override def withDstNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
-      val locations = (1 to 5).map { _ =>
-        createObjectLocationWith(bucket, key = s"src/$randomAlphanumeric")
-      }
-
-      val objects = locations.map { _ -> randomAlphanumeric }.toMap
-
-      objects.foreach {
-        case (loc, contents) =>
-          s3Client.putObject(
-            loc.namespace,
-            loc.path,
-            contents
-          )
-      }
-
-      val srcPrefix = ObjectLocationPrefix(
-        namespace = bucket.name,
-        path = "src/"
-      )
-
-      val dstPrefix = ObjectLocationPrefix(
-        namespace = bucket.name,
-        path = "dst/"
-      )
-
-      // Write something to the first destination.  The replicator should realise
-      // this object already exists, and refuse to overwrite it.
-      val badContents = randomAlphanumeric
-
-      val dstLocation = ObjectLocation(
-        namespace = bucket.name,
-        path = locations.head.path.replace("src/", "dst/")
-      )
-
-      s3Client.putObject(dstLocation.namespace, dstLocation.path, badContents)
-
-      val result = new S3Replicator().replicate(
-        ingestId = createIngestID,
-        request = ReplicationRequest(
-          srcPrefix = srcPrefix,
-          dstPrefix = dstPrefix
-        )
-      )
-
-      result shouldBe a[ReplicationFailed]
-
-      getContentFromS3(dstLocation) shouldBe badContents
+      testWith(bucket)
     }
-  }
 
-  it("fails if the underlying replication has an error") {
-    val result = new S3Replicator().replicate(
-      ingestId = createIngestID,
-      request = ReplicationRequest(
-        srcPrefix = ObjectLocationPrefix(
-          namespace = createBucketName,
-          path = randomAlphanumeric
-        ),
-        dstPrefix = ObjectLocationPrefix(
-          namespace = createBucketName,
-          path = randomAlphanumeric
-        )
-      )
-    )
+  override def withReplicator[R](testWith: TestWith[Replicator, R]): R =
+    testWith(new S3Replicator())
 
-    result shouldBe a[ReplicationFailed]
-    result.summary.maybeEndTime.isDefined shouldBe true
+  override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
+    createObjectLocationWith(srcBucket)
 
-    val failure = result.asInstanceOf[ReplicationFailed]
-    failure.e shouldBe a[AmazonS3Exception]
-    failure.e.getMessage should startWith(
-      "The specified bucket does not exist"
-    )
-  }
+  override def createDstLocationWith(dstBucket: Bucket, key: String): ObjectLocation =
+    createObjectLocationWith(dstBucket, key)
 
-  // The verifier will write a Content-SHA256 checksum tag to objects when it
-  // verifies them.  If an object is then replicated to a new location, any existing
-  // verification tags should be removed.
-  it("doesn't copy tags from the existing objects") {
-    val s3Tags = new S3Tags()
+  override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =
+    ObjectLocationPrefix(srcBucket.name, path = "")
 
-    withLocalS3Bucket { srcBucket =>
-      withLocalS3Bucket { dstBucket =>
-        val location = createObjectLocationWith(srcBucket)
+  override def createDstPrefixWith(dstBucket: Bucket): ObjectLocationPrefix =
+    ObjectLocationPrefix(dstBucket.name, path = "")
 
-        s3Client.putObject(
-          location.namespace,
-          location.path,
-          randomAlphanumeric
-        )
-        s3Tags.update(location) { existingTags =>
-          Right(existingTags ++ Map("Content-SHA256" -> "abcdef"))
-        }
+  override val srcTags: Tags[ObjectLocation] = new S3Tags()
+  override val dstTags: Tags[ObjectLocation] = new S3Tags()
 
-        val request = ReplicationRequest(
-          srcPrefix =
-            ObjectLocationPrefix(namespace = srcBucket.name, path = ""),
-          dstPrefix =
-            ObjectLocationPrefix(namespace = dstBucket.name, path = "")
-        )
-
-        val result = new S3Replicator().replicate(
-          ingestId = createIngestID,
-          request = request
-        )
-
-        result shouldBe a[ReplicationSucceeded]
-
-        val dstLocation = location.copy(namespace = dstBucket.name)
-        s3Tags.get(dstLocation).right.value shouldBe Identified(
-          dstLocation,
-          Map.empty
-        )
-      }
-    }
-  }
+  override val srcStringStore: S3TypedStore[String] = S3TypedStore[String]
+  override val dstStringStore: S3TypedStore[String] = S3TypedStore[String]
 }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4587

This adds a new AzureReplicator class which can be passed to BagReplicatorWorker once we sort out the config. I've not wired up the config yet because that requires more finesse, and I want to see how Alice does the verifier so we can stay in sync – this is a fairly vanilla patch that doesn't need as much thought.