### PR TITLE
Add dds dashboard principal to storage buckets

### DIFF
--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -94,8 +94,9 @@ data "aws_iam_policy_document" "replica_primary_read" {
         # See https://wellcome.slack.com/archives/CBT40CMKQ/p1573742247457800
         "AROAZQI22QHWTHLN4QHJU:*",
 
-        # Dashboard for iiif-builder staging
+        # Dashboard for iiif-builder staging + staging-prd
         "AROAZQI22QHW3RRRIYDN3:*"
+        "AROAZQI22QHWQI2FAIMQ5:*"
       ]
     }
 


### PR DESCRIPTION
There are now 2 'staging' dashboards - one using staging storage and one using production storage

https://github.com/wellcomecollection/iiif-builder-infrastructure/pull/7 is the 'other end' of this change, specifically [this](https://github.com/wellcomecollection/iiif-builder-infrastructure/blob/4591cecfa751dd3ed44b05be81baff274461f431/infrastructure/staging/dashboard.tf#L135-L144)