### PR TITLE
Don't check files are in the right namespace in the bag register

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -326,54 +326,6 @@ class StorageManifestServiceTest
         )
       }
     }
-
-    it("refers to a file in the wrong namespace") {
-      val fetchEntries = Map(
-        BagPath("data/file1.txt") -> createFetchMetadataWith(
-          uri = "s3://not-the-replica-bucket/file1.txt"
-        )
-      )
-
-      val bag = createBagWith(
-        manifestEntries = Map(
-          BagPath("data/file1.txt") -> randomChecksumValue
-        ),
-        fetchEntries = fetchEntries
-      )
-
-      assertIsError(bag = bag) { err =>
-        err shouldBe a[BadFetchLocationException]
-        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong namespace: not-the-replica-bucket"
-      }
-    }
-
-    it("refers to a file that isn't in a versioned directory") {
-      val version = createBagVersion
-      val bagRoot = createObjectLocation
-
-      val location = createPrimaryLocationWith(
-        bagRoot = bagRoot,
-        version = version
-      )
-
-      val fetchEntries = Map(
-        BagPath("data/file1.txt") -> createFetchMetadataWith(
-          uri = s"s3://${location.prefix.namespace}/file1.txt"
-        )
-      )
-
-      val bag = createBagWith(
-        manifestEntries = Map(
-          BagPath("data/file1.txt") -> randomChecksumValue
-        ),
-        fetchEntries = fetchEntries
-      )
-
-      assertIsError(bag = bag, location = location, version = version) { err =>
-        err shouldBe a[BadFetchLocationException]
-        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong path: /file1.txt"
-      }
-    }
   }
 
   describe("passes through metadata correctly") {


### PR DESCRIPTION
This is already checked by the bag verifier, and stricter as well -- it checks the scheme is s3://, rather than just lifting the host and path and treating it as definitely S3.

See https://github.com/wellcomecollection/storage-service/blob/167310dd85d78404ca7718017afcc572498f6277/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFetch.scala#L13-L54

If we detect an error here, it indicates a problem in the pipeline -- the bag should never have been allowed to get this far. The internal assertion gives us a quick check, but detailed error handling is unnecessary for what should be an impossible scenario.

This check was originally put in the bag register because it was the easiest place to add it, even though it's more appropriate in the bag verifier.  When it was added to the verifier, we didn't remove it from the register.

This also removes a dependency on ObjectLocation from the bag register.