### PR TITLE
Use images in services with static tags for use with new deploy tool

### DIFF
--- a/terraform/modules/stack/images.tf
+++ b/terraform/modules/stack/images.tf
@@ -25,6 +25,12 @@ data "aws_ssm_parameter" "image_ids" {
   name = "/storage/images/${var.release_label}/${local.services[count.index]}"
 }
 
+data "aws_ecr_repository" "service" {
+  count = length(local.services)
+  name  = "uk.ac.wellcome/${local.services[count.index]}"
+}
+
 locals {
-  image_ids = zipmap(local.services, data.aws_ssm_parameter.image_ids.*.value)
+  repo_urls = [for repo_url in data.aws_ecr_repository.service.*.repository_url : "${repo_url}:env.${var.release_label}"]
+  image_ids = zipmap(local.services, local.repo_urls)
 }

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -95,7 +95,6 @@ variable "secrets" {
   default = {}
 }
 
-
 variable "deployment_service_name_verifier" {}
 variable "deployment_service_name_replicator" {}
 variable "deployment_service_env" {}


### PR DESCRIPTION
Requires:
- https://github.com/wellcomecollection/storage-service/pull/640
- https://github.com/wellcomecollection/storage-service/pull/639
- A release to be prepared and deployed for the staging environment

*Note*: `weco-deploy` as of 4.1.0 does not recognise that multiple images can target the same service - this may result in multiple deployment of a service when ECS automated deployment runs (this will be resolved in an upcoming weco-deploy release. See (https://github.com/wellcomecollection/weco-deploy/pull/24)