### PR TITLE
Pass the unpacked bag location from the replicator

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -4,7 +4,11 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.ReplicationRequest
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, ReplicaResult, SecondaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  ReplicaResult,
+  SecondaryStorageLocation
+}
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 // For bag replicas, we distinguish between primary and secondary replicas.

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -4,11 +4,8 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.ReplicationRequest
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
-  ReplicaResult,
-  SecondaryStorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, ReplicaResult, SecondaryStorageLocation}
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 // For bag replicas, we distinguish between primary and secondary replicas.
 //
@@ -48,6 +45,7 @@ sealed trait BagReplicationRequest {
       }
 
     ReplicaResult(
+      originalLocation = S3ObjectLocationPrefix(request.srcPrefix),
       storageLocation = storageLocation,
       timestamp = Instant.now()
     )

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -54,7 +54,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
   )(step: IngestStepResult[RootFinderSummary]): Try[Unit] =
     step match {
       case IngestStepSucceeded(summary: RootFinderSuccessSummary, _) =>
-        val outgoingPayload: BagRootPayload = BagRootLocationPayload(
+        val outgoingPayload = BagRootLocationPayload(
           context = payload.context,
           bagRoot = summary.bagRoot.toObjectLocationPrefix
         )

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.storage.bag_root_finder
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.BagRootPayload
+import uk.ac.wellcome.platform.archive.common.BagRootLocationPayload
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
@@ -52,7 +52,7 @@ class BagRootFinderFeatureTest
           eventually {
             assertQueueEmpty(queue)
 
-            outgoing.getMessages[BagRootPayload] shouldBe Seq(expectedPayload)
+            outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(expectedPayload)
 
             assertTopicReceivesIngestEvents(
               payload.ingestId,
@@ -117,7 +117,7 @@ class BagRootFinderFeatureTest
             assertQueueEmpty(queue)
 
             outgoing
-              .getMessages[BagRootPayload] shouldBe Seq(expectedPayload)
+              .getMessages[BagRootLocationPayload] shouldBe Seq(expectedPayload)
 
             assertTopicReceivesIngestEvents(
               payload.ingestId,

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -52,7 +52,9 @@ class BagRootFinderFeatureTest
           eventually {
             assertQueueEmpty(queue)
 
-            outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(expectedPayload)
+            outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(
+              expectedPayload
+            )
 
             assertTopicReceivesIngestEvents(
               payload.ingestId,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -50,10 +50,10 @@ object Main extends WellcomeTypesafeApp {
 
     val outgoingPublisher =
       OutgoingPublisherBuilder.build(config, operationName)
-    BagVerifierWorkerBuilder.buildBagVerifierWorker(config)(
-      ingestUpdater,
-      outgoingPublisher
-    )
 
+    BagVerifierWorkerBuilder.buildBagVerifierWorker(config)(
+      ingestUpdater = ingestUpdater,
+      outgoingPublisher = outgoingPublisher
+    )
   }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -55,12 +55,12 @@ object BagVerifierWorkerBuilder {
     }
   }
 
-  private def buildStandaloneVerifierWorker(
+  def buildStandaloneVerifierWorker[IngestDestination, OutgoingDestination](
     primaryBucket: String,
     metricsNamespace: String,
     alpakkaSqsWorkerConfig: AlpakkaSQSWorkerConfig,
-    ingestUpdater: IngestUpdater[SNSConfig],
-    outgoingPublisher: OutgoingPublisher[SNSConfig]
+    ingestUpdater: IngestUpdater[IngestDestination],
+    outgoingPublisher: OutgoingPublisher[OutgoingDestination]
   )(
     implicit s3: AmazonS3,
     mc: MetricsMonitoringClient,
@@ -69,7 +69,7 @@ object BagVerifierWorkerBuilder {
   ): BagVerifierWorker[VersionedBagRootPayload, StandaloneBagVerifyContext[
     S3ObjectLocation,
     S3ObjectLocationPrefix
-  ], SNSConfig, SNSConfig] = {
+  ], IngestDestination, OutgoingDestination] = {
     val verifier = new S3StandaloneBagVerifier(primaryBucket)
 
     new BagVerifierWorker(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -107,8 +107,8 @@ object BagVerifierWorkerBuilder {
       metricsNamespace = metricsNamespace,
       (payload: ReplicaResultPayload) =>
         ReplicatedBagVerifyContext(
-          S3ObjectLocationPrefix(payload.bagRoot),
-          S3ObjectLocationPrefix(payload.replicaResult.storageLocation.prefix)
+          root = S3ObjectLocationPrefix(payload.replicaResult.storageLocation.prefix),
+          srcRoot = payload.replicaResult.originalLocation
         )
     )
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -9,12 +9,21 @@ import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.sqsworker.alpakka.AlpakkaSQSWorkerConfig
 import uk.ac.wellcome.messaging.typesafe.AlpakkaSqsWorkerConfigBuilder
 import uk.ac.wellcome.messaging.worker.monitoring.metrics.MetricsMonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.models.{ReplicatedBagVerifyContext, StandaloneBagVerifyContext}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  ReplicatedBagVerifyContext,
+  StandaloneBagVerifyContext
+}
 import uk.ac.wellcome.platform.archive.bagverifier.services.BagVerifierWorker
-import uk.ac.wellcome.platform.archive.bagverifier.services.s3.{S3ReplicatedBagVerifier, S3StandaloneBagVerifier}
+import uk.ac.wellcome.platform.archive.bagverifier.services.s3.{
+  S3ReplicatedBagVerifier,
+  S3StandaloneBagVerifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.{ReplicaResultPayload, VersionedBagRootPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  ReplicaResultPayload,
+  VersionedBagRootPayload
+}
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
@@ -107,7 +116,9 @@ object BagVerifierWorkerBuilder {
       metricsNamespace = metricsNamespace,
       (payload: ReplicaResultPayload) =>
         ReplicatedBagVerifyContext(
-          root = S3ObjectLocationPrefix(payload.replicaResult.storageLocation.prefix),
+          root = S3ObjectLocationPrefix(
+            payload.replicaResult.storageLocation.prefix
+          ),
           srcRoot = payload.replicaResult.originalLocation
         )
     )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.services.s3.{
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.{
-  BagRootPayload,
+  VerifiablePayload,
   ReplicaResultPayload
 }
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
@@ -65,7 +65,7 @@ object BagVerifierWorkerBuilder {
     mc: MetricsMonitoringClient,
     as: ActorSystem,
     sc: SqsAsyncClient
-  ): BagVerifierWorker[BagRootPayload, StandaloneBagVerifyContext[
+  ): BagVerifierWorker[VerifiablePayload, StandaloneBagVerifyContext[
     S3ObjectLocation,
     S3ObjectLocationPrefix
   ], SNSConfig, SNSConfig] = {
@@ -76,7 +76,7 @@ object BagVerifierWorkerBuilder {
       outgoingPublisher = outgoingPublisher,
       verifier = verifier,
       metricsNamespace = config.requireString("aws.metrics.namespace"),
-      (payload: BagRootPayload) =>
+      (payload: VerifiablePayload) =>
         StandaloneBagVerifyContext(S3ObjectLocationPrefix(payload.bagRoot))
     )
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
   BagVerifyContext,
   VerificationSummary
 }
-import uk.ac.wellcome.platform.archive.common.BagRootPayload
+import uk.ac.wellcome.platform.archive.common.VerifiablePayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -26,7 +26,7 @@ import uk.ac.wellcome.storage.{
 import scala.util.Try
 
 trait BagPayloadTranslator[
-  Payload <: BagRootPayload,
+  Payload <: VerifiablePayload,
   BagContext <: BagVerifyContext[BagLocation, BagPrefix],
   BagLocation <: Location,
   BagPrefix <: Prefix[BagLocation]
@@ -35,7 +35,7 @@ trait BagPayloadTranslator[
 }
 
 class BagVerifierWorker[
-  Payload <: BagRootPayload,
+  Payload <: VerifiablePayload,
   BagContext <: BagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
   IngestDestination,
   OutgoingDestination
@@ -56,10 +56,7 @@ class BagVerifierWorker[
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[Payload]
-) extends IngestStepWorker[
-      Payload,
-      VerificationSummary
-    ] {
+) extends IngestStepWorker[Payload, VerificationSummary] {
 
   override def processMessage(
     payload: Payload

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestStatusUpdate
 }
 import uk.ac.wellcome.platform.archive.common.{
-  BagRootPayload,
+  VerifiablePayload,
   VersionedBagRootPayload
 }
 
@@ -65,7 +65,7 @@ class BagVerifierFeatureTest
               bagRoot = bagRoot
             )
 
-            sendNotificationToSQS[BagRootPayload](queue, payload)
+            sendNotificationToSQS[VerifiablePayload](queue, payload)
 
             eventually {
               assertTopicReceivesIngestEvents(
@@ -121,7 +121,7 @@ class BagVerifierFeatureTest
               bagRoot = bagRootLocation
             )
 
-            sendNotificationToSQS[BagRootPayload](queue, payload)
+            sendNotificationToSQS[VerifiablePayload](queue, payload)
 
             eventually {
               assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -7,10 +7,19 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.builder.BagVerifierWorkerBuilder
-import uk.ac.wellcome.platform.archive.bagverifier.models.{ReplicatedBagVerifyContext, StandaloneBagVerifyContext}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  ReplicatedBagVerifyContext,
+  StandaloneBagVerifyContext
+}
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3StandaloneBagVerifier
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
-import uk.ac.wellcome.platform.archive.common.{ReplicaResultPayload, VersionedBagRootPayload}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker
+}
+import uk.ac.wellcome.platform.archive.common.{
+  ReplicaResultPayload,
+  VersionedBagRootPayload
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -40,7 +49,8 @@ trait BagVerifierFixtures
   ): R =
     withFakeMonitoringClient() { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
-        val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)
+        val ingestUpdater =
+          createIngestUpdaterWith(ingests, stepName = stepName)
 
         val outgoingPublisher = createOutgoingPublisherWith(outgoing)
 
@@ -71,11 +81,12 @@ trait BagVerifierFixtures
       ReplicatedBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
       String,
       String
-      ], R]
+    ], R]
   ): R =
     withFakeMonitoringClient() { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
-        val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)
+        val ingestUpdater =
+          createIngestUpdaterWith(ingests, stepName = stepName)
 
         val outgoingPublisher = createOutgoingPublisherWith(outgoing)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.services.{
   BagVerifier,
   BagVerifierWorker
 }
-import uk.ac.wellcome.platform.archive.common.BagRootPayload
+import uk.ac.wellcome.platform.archive.common.VerifiablePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -35,7 +35,7 @@ trait BagVerifierFixtures
     stepName: String = randomAlphanumericWithLength()
   )(
     testWith: TestWith[BagVerifierWorker[
-      BagRootPayload,
+      VerifiablePayload,
       StandaloneBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
       String,
       String
@@ -50,7 +50,7 @@ trait BagVerifierFixtures
           val outgoingPublisher = createOutgoingPublisherWith(outgoing)
 
           val service
-            : BagVerifierWorker[BagRootPayload, StandaloneBagVerifyContext[
+            : BagVerifierWorker[VerifiablePayload, StandaloneBagVerifyContext[
               S3ObjectLocation,
               S3ObjectLocationPrefix
             ], String, String] = new BagVerifierWorker(
@@ -59,7 +59,7 @@ trait BagVerifierFixtures
             outgoingPublisher = outgoingPublisher,
             verifier = verifier,
             metricsNamespace = "bag_verifier",
-            (payload: BagRootPayload) =>
+            (payload: VerifiablePayload) =>
               StandaloneBagVerifyContext(
                 S3ObjectLocationPrefix(payload.bagRoot)
               )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -7,12 +7,11 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.builder.BagVerifierWorkerBuilder
-import uk.ac.wellcome.platform.archive.bagverifier.models.StandaloneBagVerifyContext
+import uk.ac.wellcome.platform.archive.bagverifier.models.{ReplicatedBagVerifyContext, StandaloneBagVerifyContext}
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3StandaloneBagVerifier
 import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
 import uk.ac.wellcome.platform.archive.common.{ReplicaResultPayload, VersionedBagRootPayload}
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.storage.models.ReplicaResult
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
@@ -69,7 +68,7 @@ trait BagVerifierFixtures
   )(
     testWith: TestWith[BagVerifierWorker[
       ReplicaResultPayload,
-      StandaloneBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
+      ReplicatedBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
       String,
       String
       ], R]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -2,19 +2,17 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixtures
 
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.bagverifier.builder.BagVerifierWorkerBuilder
 import uk.ac.wellcome.platform.archive.bagverifier.models.StandaloneBagVerifyContext
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3StandaloneBagVerifier
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
-import uk.ac.wellcome.platform.archive.common.VerifiablePayload
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
+import uk.ac.wellcome.platform.archive.common.{ReplicaResultPayload, VersionedBagRootPayload}
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
+import uk.ac.wellcome.platform.archive.common.storage.models.ReplicaResult
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
@@ -28,14 +26,14 @@ trait BagVerifierFixtures
     with OperationFixtures
     with S3Fixtures {
   def withStandaloneBagVerifierWorker[R](
-    ingests: MemoryMessageSender,
+    ingests: MemoryMessageSender = new MemoryMessageSender(),
     outgoing: MemoryMessageSender,
     queue: Queue = dummyQueue,
     bucket: Bucket,
     stepName: String = randomAlphanumericWithLength()
   )(
     testWith: TestWith[BagVerifierWorker[
-      VerifiablePayload,
+      VersionedBagRootPayload,
       StandaloneBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
       String,
       String
@@ -43,32 +41,57 @@ trait BagVerifierFixtures
   ): R =
     withFakeMonitoringClient() { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
-        withVerifier(bucket) { verifier =>
-          val ingestUpdater =
-            createIngestUpdaterWith(ingests, stepName = stepName)
+        val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)
 
-          val outgoingPublisher = createOutgoingPublisherWith(outgoing)
+        val outgoingPublisher = createOutgoingPublisherWith(outgoing)
 
-          val service
-            : BagVerifierWorker[VerifiablePayload, StandaloneBagVerifyContext[
-              S3ObjectLocation,
-              S3ObjectLocationPrefix
-            ], String, String] = new BagVerifierWorker(
-            config = createAlpakkaSQSWorkerConfig(queue),
-            ingestUpdater = ingestUpdater,
-            outgoingPublisher = outgoingPublisher,
-            verifier = verifier,
+        val worker = BagVerifierWorkerBuilder
+          .buildStandaloneVerifierWorker(
+            primaryBucket = bucket.name,
             metricsNamespace = "bag_verifier",
-            (payload: VerifiablePayload) =>
-              StandaloneBagVerifyContext(
-                S3ObjectLocationPrefix(payload.bagRoot)
-              )
+            alpakkaSqsWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+            ingestUpdater = ingestUpdater,
+            outgoingPublisher = outgoingPublisher
           )
 
-          service.run()
+        worker.run()
 
-          testWith(service)
-        }
+        testWith(worker)
+      }
+    }
+
+  def withReplicaBagVerifierWorker[R](
+    ingests: MemoryMessageSender = new MemoryMessageSender(),
+    outgoing: MemoryMessageSender,
+    queue: Queue = dummyQueue,
+    bucket: Bucket,
+    stepName: String = randomAlphanumericWithLength()
+  )(
+    testWith: TestWith[BagVerifierWorker[
+      ReplicaResultPayload,
+      StandaloneBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
+      String,
+      String
+      ], R]
+  ): R =
+    withFakeMonitoringClient() { implicit monitoringClient =>
+      withActorSystem { implicit actorSystem =>
+        val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)
+
+        val outgoingPublisher = createOutgoingPublisherWith(outgoing)
+
+        val worker = BagVerifierWorkerBuilder
+          .buildReplicaBagVerifierWorker(
+            primaryBucket = bucket.name,
+            metricsNamespace = "bag_verifier",
+            alpakkaSqsWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+            ingestUpdater = ingestUpdater,
+            outgoingPublisher = outgoingPublisher
+          )
+
+        worker.run()
+
+        testWith(worker)
       }
     }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -14,9 +14,19 @@ import uk.ac.wellcome.platform.archive.common.fixtures.PayloadEntry
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{AmazonS3StorageProvider, Ingest}
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, PrimaryStorageLocation, ReplicaResult}
-import uk.ac.wellcome.platform.archive.common.{ReplicaResultPayload, VersionedBagRootPayload}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  AmazonS3StorageProvider,
+  Ingest
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  PrimaryStorageLocation,
+  ReplicaResult
+}
+import uk.ac.wellcome.platform.archive.common.{
+  ReplicaResultPayload,
+  VersionedBagRootPayload
+}
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -53,26 +53,26 @@ case class KnownReplicasPayload(
   knownReplicas: KnownReplicas
 ) extends PipelinePayload
 
-sealed trait BagRootPayload extends PipelinePayload {
-  val bagRoot: ObjectLocationPrefix
-}
-
 case class BagRootLocationPayload(
   context: PipelineContext,
   bagRoot: ObjectLocationPrefix
-) extends BagRootPayload
+) extends PipelinePayload
+
+sealed trait VerifiablePayload extends PipelinePayload {
+  val bagRoot: ObjectLocationPrefix
+}
 
 case class VersionedBagRootPayload(
   context: PipelineContext,
   bagRoot: ObjectLocationPrefix,
   version: BagVersion
-) extends BagRootPayload
+) extends VerifiablePayload
 
 case class ReplicaResultPayload(
   context: PipelineContext,
   replicaResult: ReplicaResult,
   version: BagVersion
-) extends BagRootPayload {
+) extends VerifiablePayload {
   val bagRoot: ObjectLocationPrefix =
     replicaResult.storageLocation.prefix
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 
 import java.time.Instant
 
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
+
 case class ReplicaResult(
+  originalLocation: S3ObjectLocationPrefix,
   storageLocation: StorageLocation,
   timestamp: Instant
 )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -124,6 +124,7 @@ trait PayloadGenerators
     ReplicaResultPayload(
       context = createPipelineContext,
       replicaResult = ReplicaResult(
+        originalLocation = createS3ObjectLocationPrefix,
         storageLocation = createPrimaryLocationWith(
           provider = provider
         ),

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -24,6 +24,7 @@ class ReplicaAggregatorTest
     replicaLocation: ReplicaLocation = createPrimaryLocation
   ): ReplicaResult =
     ReplicaResult(
+      originalLocation = createS3ObjectLocationPrefix,
       storageLocation = replicaLocation.toStorageLocation,
       timestamp = Instant.now
     )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -322,6 +322,7 @@ class ReplicaAggregatorWorkerTest
       ReplicaResultPayload(
         context = context,
         replicaResult = ReplicaResult(
+          originalLocation = createS3ObjectLocationPrefix,
           storageLocation = storageLocation,
           timestamp = Instant.now
         ),


### PR DESCRIPTION
A straggling bit from https://github.com/wellcomecollection/platform/issues/4594 that I missed in code review – as written, the verifier checks that the tag manifest in a replicated bag is the same as … itself. Which is less than helpful.

We also start to head in a direction of using new-style locations in the verifier, which unlocks doing it in the rest of the pipeline. https://github.com/wellcomecollection/platform/issues/4596