### PR TITLE
Use the new-style location in more verifier payloads

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   ReplicaResult,
   SecondaryStorageLocation
 }
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 // For bag replicas, we distinguish between primary and secondary replicas.
 //
@@ -49,7 +48,7 @@ sealed trait BagReplicationRequest {
       }
 
     ReplicaResult(
-      originalLocation = S3ObjectLocationPrefix(request.srcPrefix),
+      originalLocation = request.srcPrefix,
       storageLocation = storageLocation,
       timestamp = Instant.now()
     )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models._
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.storage.listing.Listing
 import uk.ac.wellcome.storage.transfer.{PrefixTransfer, TransferResult}
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix}
 
 // This is a generic replication from one location to another.
 //
@@ -24,8 +24,8 @@ trait Replicator extends Logging {
   ]
 
   implicit val prefixListing: Listing[
-    ObjectLocationPrefix,
-    ObjectLocation
+    S3ObjectLocationPrefix,
+    S3ObjectLocation
   ]
 
   def replicate(
@@ -67,7 +67,7 @@ trait Replicator extends Logging {
     debug(s"Consistency mode: checkForExisting = $checkForExisting")
 
     prefixTransfer.transferPrefix(
-      srcPrefix = request.srcPrefix,
+      srcPrefix = request.srcPrefix.toObjectLocationPrefix,
       dstPrefix = request.dstPrefix,
       checkForExisting = checkForExisting
     ) match {

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/Replicator.scala
@@ -7,7 +7,12 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models._
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.storage.listing.Listing
 import uk.ac.wellcome.storage.transfer.{PrefixTransfer, TransferResult}
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  ObjectLocation,
+  ObjectLocationPrefix,
+  S3ObjectLocation,
+  S3ObjectLocationPrefix
+}
 
 // This is a generic replication from one location to another.
 //

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.azure
 import com.amazonaws.services.s3.AmazonS3
 import com.azure.storage.blob.BlobServiceClient
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
-import uk.ac.wellcome.storage.listing.s3.{NewS3ObjectLocationListing, S3ObjectLocationListing}
+import uk.ac.wellcome.storage.listing.s3.{
+  NewS3ObjectLocationListing,
+  S3ObjectLocationListing
+}
 import uk.ac.wellcome.storage.store.s3.{S3StreamReadable, S3StreamStore}
 import uk.ac.wellcome.storage.transfer.PrefixTransfer
 import uk.ac.wellcome.storage.transfer.azure.{

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicator.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.azure
 import com.amazonaws.services.s3.AmazonS3
 import com.azure.storage.blob.BlobServiceClient
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
-import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
+import uk.ac.wellcome.storage.listing.s3.{NewS3ObjectLocationListing, S3ObjectLocationListing}
 import uk.ac.wellcome.storage.store.s3.{S3StreamReadable, S3StreamStore}
 import uk.ac.wellcome.storage.transfer.PrefixTransfer
 import uk.ac.wellcome.storage.transfer.azure.{
@@ -19,7 +19,10 @@ class AzureReplicator(
 
   implicit val readable: S3StreamReadable = new S3StreamStore()
 
-  override implicit val prefixListing: S3ObjectLocationListing =
+  override implicit val prefixListing: NewS3ObjectLocationListing =
+    new NewS3ObjectLocationListing()
+
+  implicit val listing: S3ObjectLocationListing =
     S3ObjectLocationListing()
 
   implicit val transfer: S3toAzureTransfer = new S3toAzureTransfer

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.models
 
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
 
 case class ReplicationRequest(
-  srcPrefix: ObjectLocationPrefix,
+  srcPrefix: S3ObjectLocationPrefix,
   dstPrefix: ObjectLocationPrefix
 )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationSummary.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationSummary.scala
@@ -4,7 +4,6 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
-import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 case class ReplicationSummary(
   ingestId: IngestID,
@@ -12,10 +11,6 @@ case class ReplicationSummary(
   maybeEndTime: Option[Instant] = None,
   request: ReplicationRequest
 ) extends Summary {
-
-  def srcPrefix: ObjectLocationPrefix = request.srcPrefix
-  def dstPrefix: ObjectLocationPrefix = request.dstPrefix
-
   def complete: ReplicationSummary = this.copy(
     maybeEndTime = Some(Instant.now)
   )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
-import uk.ac.wellcome.storage.listing.s3.{NewS3ObjectLocationListing, S3ObjectSummaryListing}
+import uk.ac.wellcome.storage.listing.s3.{
+  NewS3ObjectLocationListing,
+  S3ObjectSummaryListing
+}
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
-import uk.ac.wellcome.storage.listing.s3.{
-  S3ObjectLocationListing,
-  S3ObjectSummaryListing
-}
+import uk.ac.wellcome.storage.listing.s3.{NewS3ObjectLocationListing, S3ObjectSummaryListing}
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
@@ -25,6 +22,6 @@ class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
   implicit val s3ObjectSummaryListing: S3ObjectSummaryListing =
     new S3ObjectSummaryListing()
 
-  override implicit val prefixListing: S3ObjectLocationListing =
-    new S3ObjectLocationListing()
+  override implicit val prefixListing: NewS3ObjectLocationListing =
+    new NewS3ObjectLocationListing()
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/ReplicatorTestCases.scala
@@ -4,7 +4,11 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{ReplicationFailed, ReplicationRequest, ReplicationSucceeded}
+import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.{
+  ReplicationFailed,
+  ReplicationRequest,
+  ReplicationSucceeded
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/azure/AzureReplicatorTest.scala
@@ -5,26 +5,17 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.{
   Replicator,
   ReplicatorTestCases
 }
+import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
-import uk.ac.wellcome.storage.tags.s3.S3Tags
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 class AzureReplicatorTest
-    extends ReplicatorTestCases[Bucket, Container]
-    with AzureFixtures
-    with S3Fixtures {
-
-  override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
-    withLocalS3Bucket { bucket =>
-      testWith(bucket)
-    }
+    extends ReplicatorTestCases[Container]
+    with AzureFixtures {
 
   override def withDstNamespace[R](testWith: TestWith[Container, R]): R =
     withAzureContainer { container =>
@@ -34,29 +25,20 @@ class AzureReplicatorTest
   override def withReplicator[R](testWith: TestWith[Replicator, R]): R =
     testWith(new AzureReplicator())
 
-  override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
-    createObjectLocationWith(srcBucket)
-
   override def createDstLocationWith(
     dstContainer: Container,
     path: String
   ): ObjectLocation =
     createObjectLocationWith(dstContainer.name, path = path)
 
-  override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =
-    ObjectLocationPrefix(srcBucket.name, path = "")
-
   override def createDstPrefixWith(
     dstContainer: Container
   ): ObjectLocationPrefix =
     ObjectLocationPrefix(dstContainer.name, path = "")
 
-  override val srcStringStore: S3TypedStore[String] = S3TypedStore[String]
-
   implicit val streamStore: AzureStreamStore = new AzureStreamStore()
   override val dstStringStore: AzureTypedStore[String] =
     new AzureTypedStore[String]
 
-  override val srcTags: Tags[ObjectLocation] = new S3Tags()
   override val dstTags: Tags[ObjectLocation] = new AzureBlobMetadata()
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -13,13 +13,8 @@ import uk.ac.wellcome.storage.tags.s3.S3Tags
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 class S3ReplicatorTest
-    extends ReplicatorTestCases[Bucket, Bucket]
+    extends ReplicatorTestCases[Bucket]
     with S3Fixtures {
-
-  override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
-    withLocalS3Bucket { bucket =>
-      testWith(bucket)
-    }
 
   override def withDstNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
@@ -29,24 +24,16 @@ class S3ReplicatorTest
   override def withReplicator[R](testWith: TestWith[Replicator, R]): R =
     testWith(new S3Replicator())
 
-  override def createSrcLocationWith(srcBucket: Bucket): ObjectLocation =
-    createObjectLocationWith(srcBucket)
-
   override def createDstLocationWith(
     dstBucket: Bucket,
     key: String
   ): ObjectLocation =
     createObjectLocationWith(dstBucket, key)
 
-  override def createSrcPrefixWith(srcBucket: Bucket): ObjectLocationPrefix =
-    ObjectLocationPrefix(srcBucket.name, path = "")
-
   override def createDstPrefixWith(dstBucket: Bucket): ObjectLocationPrefix =
     ObjectLocationPrefix(dstBucket.name, path = "")
 
-  override val srcTags: Tags[ObjectLocation] = new S3Tags()
   override val dstTags: Tags[ObjectLocation] = new S3Tags()
 
-  override val srcStringStore: S3TypedStore[String] = S3TypedStore[String]
   override val dstStringStore: S3TypedStore[String] = S3TypedStore[String]
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -12,9 +12,7 @@ import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.s3.S3Tags
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
-class S3ReplicatorTest
-    extends ReplicatorTestCases[Bucket]
-    with S3Fixtures {
+class S3ReplicatorTest extends ReplicatorTestCases[Bucket] with S3Fixtures {
 
   override def withDstNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -110,7 +110,7 @@ class BagReplicatorWorkerTest
 
           result shouldBe a[IngestStepSucceeded[_]]
 
-          val destination = result.summary.dstPrefix
+          val destination = result.summary.request.dstPrefix
           destination.namespace shouldBe dstBucket.name
         }
       }
@@ -134,7 +134,7 @@ class BagReplicatorWorkerTest
 
           result shouldBe a[IngestStepSucceeded[_]]
 
-          val dstBagLocation = result.summary.dstPrefix
+          val dstBagLocation = result.summary.request.dstPrefix
           val expectedPath =
             Paths
               .get(

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -56,7 +56,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
       case IngestStepSucceeded(summary: RootFinderSuccessSummary, _) =>
         val outgoingPayload = BagRootLocationPayload(
           context = payload.context,
-          bagRoot = summary.bagRoot.toObjectLocationPrefix
+          bagRoot = summary.bagRoot
         )
         outgoingPublisher.sendIfSuccessful(step, outgoingPayload)
       case _ => Success(())

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -88,7 +88,7 @@ object BagVerifierWorkerBuilder {
       verifier = verifier,
       metricsNamespace = metricsNamespace,
       (payload: BagRootLocationPayload) =>
-        StandaloneBagVerifyContext(S3ObjectLocationPrefix(payload.bagRoot))
+        StandaloneBagVerifyContext(payload.bagRoot)
     )
   }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -65,10 +65,8 @@ class BagVerifierWorkerTest
         outgoing,
         bucket = bucket,
         stepName = "verification"
-      ) { worker =>
-        val r = worker.processMessage(payload)
-        println(s"@@AWLC $r")
-        r shouldBe a[Success[_]]
+      ) {
+        _.processMessage(payload) shouldBe a[Success[_]]
       }
 
       assertTopicReceivesIngestEvents(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -53,18 +53,16 @@ case class KnownReplicasPayload(
   knownReplicas: KnownReplicas
 ) extends PipelinePayload
 
-sealed trait VerifiablePayload extends PipelinePayload {
-  val bagRoot: ObjectLocationPrefix
-}
+sealed trait VerifiablePayload extends PipelinePayload
 
 case class BagRootLocationPayload(
   context: PipelineContext,
-  bagRoot: ObjectLocationPrefix
+  bagRoot: S3ObjectLocationPrefix
 ) extends VerifiablePayload
 
 case class VersionedBagRootPayload(
   context: PipelineContext,
-  bagRoot: ObjectLocationPrefix,
+  bagRoot: S3ObjectLocationPrefix,
   version: BagVersion
 ) extends VerifiablePayload
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -102,7 +102,7 @@ trait PayloadGenerators
   ): VersionedBagRootPayload =
     VersionedBagRootPayload(
       context = context,
-      bagRoot = bagRoot.toObjectLocationPrefix,
+      bagRoot = bagRoot,
       version = version
     )
 
@@ -115,7 +115,7 @@ trait PayloadGenerators
   ): BagRootLocationPayload =
     BagRootLocationPayload(
       context = context,
-      bagRoot = bagRoot.toObjectLocationPrefix
+      bagRoot = bagRoot
     )
 
   def createReplicaResultPayloadWith(


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4596

With this patch:

1. The bag root finder sends an S3ObjectLocationPrefix to the pre-replicator bag verifier
2. The pre-repl bag verifier sends an S3ObjectLocationPrefix to the bag replicator
3. The bag replicator expects to receive an S3ObjectLocationPrefix as a source

The last is mildly annoying, but follows what we've done elsewhere – the replicator/unpacker/root finder can only deal with bags stored in S3, and that's not changed, but now it's more explicit.