### PR TITLE
Ditch the ReplicaResult model; rename the payload to ReplicaComplete

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.platform.archive.bagreplicator.models
 
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.ReplicationRequest
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
-  ReplicaResult,
-  SecondaryStorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation, StorageLocation}
 
 // For bag replicas, we distinguish between primary and secondary replicas.
 //
@@ -29,27 +25,20 @@ sealed trait BagReplicationRequest {
         f"""replica=secondary src=${req.srcPrefix} dst=${req.dstPrefix}"""
     }
 
-  def toResult(provider: StorageProvider): ReplicaResult = {
-    val storageLocation =
-      this match {
-        case PrimaryBagReplicationRequest(req) =>
-          PrimaryStorageLocation(
-            provider = provider,
-            prefix = this.request.dstPrefix
-          )
+  def toLocation(provider: StorageProvider): StorageLocation =
+    this match {
+      case _: PrimaryBagReplicationRequest =>
+        PrimaryStorageLocation(
+          provider = provider,
+          prefix = this.request.dstPrefix
+        )
 
-        case SecondaryBagReplicationRequest(req) =>
-          SecondaryStorageLocation(
-            provider = provider,
-            prefix = this.request.dstPrefix
-          )
-      }
-
-    ReplicaResult(
-      originalLocation = request.srcPrefix,
-      storageLocation = storageLocation
-    )
-  }
+      case _: SecondaryBagReplicationRequest =>
+        SecondaryStorageLocation(
+          provider = provider,
+          prefix = this.request.dstPrefix
+        )
+    }
 }
 
 case class PrimaryBagReplicationRequest(request: ReplicationRequest)

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.models
 
-import java.time.Instant
-
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.ReplicationRequest
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -49,8 +47,7 @@ sealed trait BagReplicationRequest {
 
     ReplicaResult(
       originalLocation = request.srcPrefix,
-      storageLocation = storageLocation,
-      timestamp = Instant.now()
+      storageLocation = storageLocation
     )
   }
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/BagReplicationRequest.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.archive.bagreplicator.models
 
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.ReplicationRequest
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  SecondaryStorageLocation,
+  StorageLocation
+}
 
 // For bag replicas, we distinguish between primary and secondary replicas.
 //

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.platform.archive.common.{
-  ReplicaResultPayload,
+  ReplicaCompletePayload,
   VersionedBagRootPayload
 }
 import uk.ac.wellcome.storage.locking.{
@@ -85,7 +85,7 @@ class BagReplicatorWorker[
 
       _ <- outgoingPublisher.sendIfSuccessful(
         result,
-        ReplicaResultPayload(
+        ReplicaCompletePayload(
           context = payload.context,
           version = payload.version,
           replicaResult =

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -88,7 +88,8 @@ class BagReplicatorWorker[
         ReplicaCompletePayload(
           context = payload.context,
           srcPrefix = replicationRequest.request.srcPrefix,
-          dstLocation = replicationRequest.toLocation(destinationConfig.provider),
+          dstLocation =
+            replicationRequest.toLocation(destinationConfig.provider),
           version = payload.version
         )
       )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -87,9 +87,9 @@ class BagReplicatorWorker[
         result,
         ReplicaCompletePayload(
           context = payload.context,
-          version = payload.version,
-          replicaResult =
-            replicationRequest.toResult(destinationConfig.provider)
+          srcPrefix = replicationRequest.request.srcPrefix,
+          dstLocation = replicationRequest.toLocation(destinationConfig.provider),
+          version = payload.version
         )
       )
     } yield result

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.bagreplicator.models.PrimaryBagReplicationRequest
-import uk.ac.wellcome.platform.archive.common.ReplicaResultPayload
+import uk.ac.wellcome.platform.archive.common.ReplicaCompletePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -65,7 +65,7 @@ class BagReplicatorFeatureTest
 
               val receivedPayload =
                 outgoing
-                  .getMessages[ReplicaResultPayload]
+                  .getMessages[ReplicaCompletePayload]
                   .head
 
               receivedPayload.context shouldBe payload.context

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -71,7 +71,7 @@ class BagReplicatorFeatureTest
               receivedPayload.context shouldBe payload.context
               receivedPayload.version shouldBe payload.version
 
-              receivedPayload.replicaResult.storageLocation shouldBe PrimaryStorageLocation(
+              receivedPayload.dstLocation shouldBe PrimaryStorageLocation(
                 provider = provider,
                 prefix = expectedDst
               )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -72,7 +72,7 @@ class BagReplicatorWorkerTest
         receivedPayload.context shouldBe payload.context
         receivedPayload.version shouldBe payload.version
 
-        val dstBagRoot = receivedPayload.replicaResult.storageLocation.prefix
+        val dstBagRoot = receivedPayload.dstLocation.prefix
 
         verifyObjectsCopied(
           srcPrefix = srcBagRoot,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -332,8 +332,7 @@ class BagReplicatorWorkerTest
         outgoing
           .getMessages[ReplicaCompletePayload]
           .head
-          .replicaResult
-          .storageLocation
+          .dstLocation
           .provider shouldBe provider
       }
     }
@@ -364,8 +363,7 @@ class BagReplicatorWorkerTest
           outgoing
             .getMessages[ReplicaCompletePayload]
             .head
-            .replicaResult
-            .storageLocation shouldBe a[PrimaryStorageLocation]
+            .dstLocation shouldBe a[PrimaryStorageLocation]
         }
       }
     }
@@ -394,8 +392,7 @@ class BagReplicatorWorkerTest
           outgoing
             .getMessages[ReplicaCompletePayload]
             .head
-            .replicaResult
-            .storageLocation shouldBe a[SecondaryStorageLocation]
+            .dstLocation shouldBe a[SecondaryStorageLocation]
         }
       }
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.models.{
   PrimaryBagReplicationRequest,
   SecondaryBagReplicationRequest
 }
-import uk.ac.wellcome.platform.archive.common.ReplicaResultPayload
+import uk.ac.wellcome.platform.archive.common.ReplicaCompletePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -64,7 +64,7 @@ class BagReplicatorWorkerTest
         result shouldBe a[IngestStepSucceeded[_]]
 
         val receivedMessages =
-          outgoing.getMessages[ReplicaResultPayload]
+          outgoing.getMessages[ReplicaCompletePayload]
 
         receivedMessages.size shouldBe 1
 
@@ -330,7 +330,7 @@ class BagReplicatorWorkerTest
         }.success.value
 
         outgoing
-          .getMessages[ReplicaResultPayload]
+          .getMessages[ReplicaCompletePayload]
           .head
           .replicaResult
           .storageLocation
@@ -362,7 +362,7 @@ class BagReplicatorWorkerTest
           }.success.value
 
           outgoing
-            .getMessages[ReplicaResultPayload]
+            .getMessages[ReplicaCompletePayload]
             .head
             .replicaResult
             .storageLocation shouldBe a[PrimaryStorageLocation]
@@ -392,7 +392,7 @@ class BagReplicatorWorkerTest
           }.success.value
 
           outgoing
-            .getMessages[ReplicaResultPayload]
+            .getMessages[ReplicaCompletePayload]
             .head
             .replicaResult
             .storageLocation shouldBe a[SecondaryStorageLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -116,10 +116,8 @@ object BagVerifierWorkerBuilder {
       metricsNamespace = metricsNamespace,
       (payload: ReplicaResultPayload) =>
         ReplicatedBagVerifyContext(
-          root = S3ObjectLocationPrefix(
-            payload.replicaResult.storageLocation.prefix
-          ),
-          srcRoot = payload.replicaResult.originalLocation
+          root = S3ObjectLocationPrefix(payload.dstLocation.prefix),
+          srcRoot = payload.srcPrefix
         )
     )
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -22,7 +22,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
-  ReplicaResultPayload
+  ReplicaCompletePayload
 }
 import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -103,7 +103,7 @@ object BagVerifierWorkerBuilder {
     mc: MetricsMonitoringClient,
     as: ActorSystem,
     sc: SqsAsyncClient
-  ): BagVerifierWorker[ReplicaResultPayload, ReplicatedBagVerifyContext[
+  ): BagVerifierWorker[ReplicaCompletePayload, ReplicatedBagVerifyContext[
     S3ObjectLocation,
     S3ObjectLocationPrefix
   ], IngestDestination, OutgoingDestination] = {
@@ -114,7 +114,7 @@ object BagVerifierWorkerBuilder {
       outgoingPublisher = outgoingPublisher,
       verifier = verifier,
       metricsNamespace = metricsNamespace,
-      (payload: ReplicaResultPayload) =>
+      (payload: ReplicaCompletePayload) =>
         ReplicatedBagVerifyContext(
           root = S3ObjectLocationPrefix(payload.dstLocation.prefix),
           srcRoot = payload.srcPrefix

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.services.{
 }
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
-  ReplicaResultPayload
+  ReplicaCompletePayload
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
@@ -77,7 +77,7 @@ trait BagVerifierFixtures
     stepName: String = randomAlphanumericWithLength()
   )(
     testWith: TestWith[BagVerifierWorker[
-      ReplicaResultPayload,
+      ReplicaCompletePayload,
       ReplicatedBagVerifyContext[S3ObjectLocation, S3ObjectLocationPrefix],
       String,
       String

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -23,7 +23,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
-  ReplicaResultPayload
+  ReplicaCompletePayload
 }
 
 import scala.util.{Failure, Success, Try}
@@ -114,7 +114,7 @@ class BagVerifierWorkerTest
         val space = createStorageSpace
         val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
-        val payload = ReplicaResultPayload(
+        val payload = ReplicaCompletePayload(
           context = createPipelineContextWith(
             externalIdentifier = bagInfo.externalIdentifier,
             storageSpace = space
@@ -139,7 +139,7 @@ class BagVerifierWorkerTest
 
         result shouldBe a[Success[_]]
 
-        outgoing.getMessages[ReplicaResultPayload] shouldBe Seq(payload)
+        outgoing.getMessages[ReplicaCompletePayload] shouldBe Seq(payload)
       }
     }
   }
@@ -152,7 +152,7 @@ class BagVerifierWorkerTest
         val space = createStorageSpace
         val (bagRoot, bagInfo) = createS3BagWith(bucket, space = space)
 
-        val payload = ReplicaResultPayload(
+        val payload = ReplicaCompletePayload(
           context = createPipelineContextWith(
             externalIdentifier = bagInfo.externalIdentifier,
             storageSpace = space

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -18,8 +18,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
-  PrimaryStorageLocation,
-  ReplicaResult
+  PrimaryStorageLocation
 }
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
@@ -119,12 +118,10 @@ class BagVerifierWorkerTest
             externalIdentifier = bagInfo.externalIdentifier,
             storageSpace = space
           ),
-          replicaResult = ReplicaResult(
-            originalLocation = bagRoot,
-            storageLocation = PrimaryStorageLocation(
-              provider = AmazonS3StorageProvider,
-              prefix = bagRoot.toObjectLocationPrefix
-            )
+          srcPrefix = bagRoot,
+          dstLocation = PrimaryStorageLocation(
+            provider = AmazonS3StorageProvider,
+            prefix = bagRoot.toObjectLocationPrefix
           ),
           version = createBagVersion
         )
@@ -157,12 +154,10 @@ class BagVerifierWorkerTest
             externalIdentifier = bagInfo.externalIdentifier,
             storageSpace = space
           ),
-          replicaResult = ReplicaResult(
-            originalLocation = createS3ObjectLocationPrefix,
-            storageLocation = PrimaryStorageLocation(
-              provider = AmazonS3StorageProvider,
-              prefix = bagRoot.toObjectLocationPrefix
-            )
+          srcPrefix = createS3ObjectLocationPrefix,
+          dstLocation = PrimaryStorageLocation(
+            provider = AmazonS3StorageProvider,
+            prefix = bagRoot.toObjectLocationPrefix
           ),
           version = createBagVersion
         )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
-import java.time.Instant
-
 import io.circe.Encoder
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
@@ -126,8 +124,7 @@ class BagVerifierWorkerTest
             storageLocation = PrimaryStorageLocation(
               provider = AmazonS3StorageProvider,
               prefix = bagRoot.toObjectLocationPrefix
-            ),
-            timestamp = Instant.now
+            )
           ),
           version = createBagVersion
         )
@@ -165,8 +162,7 @@ class BagVerifierWorkerTest
             storageLocation = PrimaryStorageLocation(
               provider = AmazonS3StorageProvider,
               prefix = bagRoot.toObjectLocationPrefix
-            ),
-            timestamp = Instant.now
+            )
           ),
           version = createBagVersion
         )

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -54,7 +54,7 @@ case class VersionedBagRootPayload(
   version: BagVersion
 ) extends VerifiablePayload
 
-case class ReplicaResultPayload(
+case class ReplicaCompletePayload(
   context: PipelineContext,
   replicaResult: ReplicaResult,
   version: BagVersion

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,21 +2,9 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestType,
-  SourceLocation
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  ReplicaResult,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaResult, StorageLocation, StorageSpace}
 import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
 
 sealed trait PipelinePayload {
@@ -73,4 +61,10 @@ case class ReplicaResultPayload(
 ) extends VerifiablePayload {
   val bagRoot: ObjectLocationPrefix =
     replicaResult.storageLocation.prefix
+
+  def srcPrefix: S3ObjectLocationPrefix =
+    replicaResult.originalLocation
+
+  def dstLocation: StorageLocation =
+    replicaResult.storageLocation
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -4,8 +4,8 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaResult, StorageLocation, StorageSpace}
-import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, StorageLocation, StorageSpace}
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 sealed trait PipelinePayload {
   val context: PipelineContext
@@ -56,15 +56,7 @@ case class VersionedBagRootPayload(
 
 case class ReplicaCompletePayload(
   context: PipelineContext,
-  replicaResult: ReplicaResult,
+  srcPrefix: S3ObjectLocationPrefix,
+  dstLocation: StorageLocation,
   version: BagVersion
-) extends VerifiablePayload {
-  val bagRoot: ObjectLocationPrefix =
-    replicaResult.storageLocation.prefix
-
-  def srcPrefix: S3ObjectLocationPrefix =
-    replicaResult.originalLocation
-
-  def dstLocation: StorageLocation =
-    replicaResult.storageLocation
-}
+) extends VerifiablePayload

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,9 +2,21 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, StorageLocation, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestType,
+  SourceLocation
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  StorageLocation,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 sealed trait PipelinePayload {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.storage.models
 
-import java.time.Instant
-
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 case class ReplicaResult(
   originalLocation: S3ObjectLocationPrefix,
-  storageLocation: StorageLocation,
-  timestamp: Instant
+  storageLocation: StorageLocation
 )

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/ReplicaResult.scala
@@ -1,8 +1,0 @@
-package uk.ac.wellcome.platform.archive.common.storage.models
-
-import uk.ac.wellcome.storage.S3ObjectLocationPrefix
-
-case class ReplicaResult(
-  originalLocation: S3ObjectLocationPrefix,
-  storageLocation: StorageLocation
-)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -127,8 +127,7 @@ trait PayloadGenerators
         originalLocation = createS3ObjectLocationPrefix,
         storageLocation = createPrimaryLocationWith(
           provider = provider
-        ),
-        timestamp = Instant.now
+        )
       ),
       version = createBagVersion
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -118,10 +118,10 @@ trait PayloadGenerators
       bagRoot = bagRoot
     )
 
-  def createReplicaResultPayloadWith(
+  def createReplicaCompletePayloadWith(
     provider: StorageProvider = createProvider
-  ): ReplicaResultPayload =
-    ReplicaResultPayload(
+  ): ReplicaCompletePayload =
+    ReplicaCompletePayload(
       context = createPipelineContext,
       replicaResult = ReplicaResult(
         originalLocation = createS3ObjectLocationPrefix,
@@ -132,6 +132,6 @@ trait PayloadGenerators
       version = createBagVersion
     )
 
-  def createReplicaResultPayload: ReplicaResultPayload =
-    createReplicaResultPayloadWith()
+  def createReplicaCompletePayload: ReplicaCompletePayload =
+    createReplicaCompletePayloadWith()
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -119,16 +119,12 @@ trait PayloadGenerators
     )
 
   def createReplicaCompletePayloadWith(
-    provider: StorageProvider = createProvider
+    dstLocation: StorageLocation = createPrimaryLocation
   ): ReplicaCompletePayload =
     ReplicaCompletePayload(
       context = createPipelineContext,
-      replicaResult = ReplicaResult(
-        originalLocation = createS3ObjectLocationPrefix,
-        storageLocation = createPrimaryLocationWith(
-          provider = provider
-        )
-      ),
+      srcPrefix = createS3ObjectLocationPrefix,
+      dstLocation = dstLocation,
       version = createBagVersion
     )
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
-import uk.ac.wellcome.platform.archive.common.storage.models.ReplicaResult
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{UpdateError, UpdateNotApplied}
@@ -9,16 +9,15 @@ class ReplicaAggregator(
   versionedStore: VersionedStore[ReplicaPath, Int, AggregatorInternalRecord]
 ) {
   def aggregate(
-    result: ReplicaResult
+    storageLocation: StorageLocation
   ): Either[UpdateError, AggregatorInternalRecord] = {
     val replicaPath =
-      ReplicaPath(result.storageLocation.prefix.path)
+      ReplicaPath(storageLocation.prefix.path)
 
-    val initialRecord =
-      AggregatorInternalRecord(result.storageLocation)
+    val initialRecord = AggregatorInternalRecord(storageLocation)
 
     val upsert = versionedStore.upsert(replicaPath)(initialRecord) {
-      _.addLocation(result.storageLocation).toEither.left.map(UpdateNotApplied)
+      _.addLocation(storageLocation).toEither.left.map(UpdateNotApplied)
     }
 
     upsert.map(_.identifiedT)

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -52,7 +52,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
     for {
 
       aggregatorRecord <- replicaAggregator
-        .aggregate(replicaResult)
+        .aggregate(replicaResult.storageLocation)
         .left
         .map(AggregationFailure)
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -69,7 +69,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
     val replicaPath = ReplicaPath(payload.bagRoot.path)
     val startTime = Instant.now()
 
-    val ingestStep = getKnownReplicas(payload.replicaResult.storageLocation) match {
+    val ingestStep = getKnownReplicas(payload.dstLocation) match {
       // If we get a retryable error when trying to store the replica
       // (for example, a DynamoDB ConditionalUpdate error), we want to retry
       // it rather than failing the entire ingest.

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.{
   KnownReplicasPayload,
   PipelineContext,
-  ReplicaResultPayload
+  ReplicaCompletePayload
 }
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.{RetryableError, UpdateError, UpdateWriteError}
@@ -32,9 +32,9 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   implicit val mc: MetricsMonitoringClient,
   val as: ActorSystem,
   val sc: SqsAsyncClient,
-  val wd: Decoder[ReplicaResultPayload]
+  val wd: Decoder[ReplicaCompletePayload]
 ) extends IngestStepWorker[
-      ReplicaResultPayload,
+      ReplicaCompletePayload,
       ReplicationAggregationSummary
     ] {
 
@@ -64,7 +64,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
     } yield sufficientReplicas
 
   override def processMessage(
-    payload: ReplicaResultPayload
+    payload: ReplicaCompletePayload
   ): Try[IngestStepResult[ReplicationAggregationSummary]] = {
     val replicaPath = ReplicaPath(payload.bagRoot.path)
     val startTime = Instant.now()

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -66,7 +66,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   override def processMessage(
     payload: ReplicaCompletePayload
   ): Try[IngestStepResult[ReplicationAggregationSummary]] = {
-    val replicaPath = ReplicaPath(payload.bagRoot.path)
+    val replicaPath = ReplicaPath(payload.dstLocation.prefix.path)
     val startTime = Instant.now()
 
     val ingestStep = getKnownReplicas(payload.dstLocation) match {

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -47,12 +47,12 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   ) extends WorkerError
 
   private def getKnownReplicas(
-    replicaResult: ReplicaResult
+    storageLocation: StorageLocation
   ): Either[WorkerError, KnownReplicas] =
     for {
 
       aggregatorRecord <- replicaAggregator
-        .aggregate(replicaResult.storageLocation)
+        .aggregate(storageLocation)
         .left
         .map(AggregationFailure)
 
@@ -69,7 +69,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
     val replicaPath = ReplicaPath(payload.bagRoot.path)
     val startTime = Instant.now()
 
-    val ingestStep = getKnownReplicas(payload.replicaResult) match {
+    val ingestStep = getKnownReplicas(payload.replicaResult.storageLocation) match {
       // If we get a retryable error when trying to store the replica
       // (for example, a DynamoDB ConditionalUpdate error), we want to retry
       // it rather than failing the entire ingest.

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -68,7 +68,8 @@ class ReplicaAggregatorFeatureTest
           val stored =
             versionedStore.get(id = Version(expectedReplicaPath, 0)).right.value
 
-          val primaryLocation = payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
+          val primaryLocation =
+            payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
 
           val primaryReplicaLocation = PrimaryS3ReplicaLocation(
             prefix = S3ObjectLocationPrefix(payload.bagRoot)

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -38,7 +38,7 @@ class ReplicaAggregatorFeatureTest
       val ingests = new MemoryMessageSender()
       val outgoing = new MemoryMessageSender()
 
-      val payload = createReplicaResultPayloadWith(
+      val payload = createReplicaCompletePayloadWith(
         provider = AmazonS3StorageProvider
       )
       val versionedStore =

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -39,7 +39,9 @@ class ReplicaAggregatorFeatureTest
       val outgoing = new MemoryMessageSender()
 
       val payload = createReplicaCompletePayloadWith(
-        provider = AmazonS3StorageProvider
+        dstLocation = createPrimaryLocationWith(
+          provider = AmazonS3StorageProvider
+        )
       )
       val versionedStore =
         MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](Map.empty)
@@ -63,7 +65,7 @@ class ReplicaAggregatorFeatureTest
           )
 
           val expectedReplicaPath =
-            ReplicaPath(payload.bagRoot.path)
+            ReplicaPath(payload.dstLocation.prefix.path)
 
           val stored =
             versionedStore.get(id = Version(expectedReplicaPath, 0)).right.value
@@ -72,7 +74,7 @@ class ReplicaAggregatorFeatureTest
             payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
 
           val primaryReplicaLocation = PrimaryS3ReplicaLocation(
-            prefix = S3ObjectLocationPrefix(payload.bagRoot)
+            prefix = S3ObjectLocationPrefix(payload.dstLocation.prefix)
           )
 
           stored.identifiedT.location shouldBe Some(primaryReplicaLocation)

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -68,10 +68,7 @@ class ReplicaAggregatorFeatureTest
           val stored =
             versionedStore.get(id = Version(expectedReplicaPath, 0)).right.value
 
-          val primaryLocation = PrimaryStorageLocation(
-            provider = payload.replicaResult.storageLocation.provider,
-            prefix = payload.bagRoot
-          )
+          val primaryLocation = payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
 
           val primaryReplicaLocation = PrimaryS3ReplicaLocation(
             prefix = S3ObjectLocationPrefix(payload.bagRoot)

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -121,7 +121,9 @@ class ReplicaAggregatorTest
     val results =
       withAggregator(versionedStore) { aggregator =>
         locations
-          .map { loc => aggregator.aggregate(loc.toStorageLocation) }
+          .map { loc =>
+            aggregator.aggregate(loc.toStorageLocation)
+          }
           .map { _.right.value }
       }
 
@@ -170,7 +172,9 @@ class ReplicaAggregatorTest
 
     withAggregator(versionedStore) { aggregator =>
       Seq(primaryLocation1, primaryLocation2)
-        .foreach { loc => aggregator.aggregate(loc.toStorageLocation) }
+        .foreach { loc =>
+          aggregator.aggregate(loc.toStorageLocation)
+        }
     }
 
     versionedStore.store
@@ -197,7 +201,9 @@ class ReplicaAggregatorTest
       }
 
     val result =
-      withAggregator(brokenStore)(_.aggregate(createPrimaryLocation.toStorageLocation))
+      withAggregator(brokenStore)(
+        _.aggregate(createPrimaryLocation.toStorageLocation)
+      )
 
     result.left.value shouldBe UpdateWriteError(err)
   }
@@ -233,14 +239,16 @@ class ReplicaAggregatorTest
     )
 
     withAggregator() { aggregator =>
-      val result = aggregator.aggregate(primaryLocation1.toStorageLocation).right.value
+      val result =
+        aggregator.aggregate(primaryLocation1.toStorageLocation).right.value
 
       result shouldBe AggregatorInternalRecord(
         location = Some(primaryLocation1),
         replicas = List()
       )
 
-      val err = aggregator.aggregate(primaryLocation2.toStorageLocation).left.get
+      val err =
+        aggregator.aggregate(primaryLocation2.toStorageLocation).left.get
       err.e.getMessage should startWith(
         "Record already has a different PrimaryStorageLocation"
       )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -50,10 +50,7 @@ class ReplicaAggregatorWorkerTest
     )
 
     val expectedKnownReplicas = KnownReplicas(
-      location = PrimaryStorageLocation(
-        provider = payload.replicaResult.storageLocation.provider,
-        prefix = payload.bagRoot
-      ),
+      location = payload.dstLocation.asInstanceOf[PrimaryStorageLocation],
       replicas = List.empty
     )
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -45,7 +45,8 @@ class ReplicaAggregatorWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val dstLocation = createPrimaryLocationWith(provider = AmazonS3StorageProvider)
+    val dstLocation =
+      createPrimaryLocationWith(provider = AmazonS3StorageProvider)
 
     val payload = createReplicaCompletePayloadWith(dstLocation = dstLocation)
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
-import java.time.Instant
-
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.TryValues
@@ -323,8 +321,7 @@ class ReplicaAggregatorWorkerTest
         context = context,
         replicaResult = ReplicaResult(
           originalLocation = createS3ObjectLocationPrefix,
-          storageLocation = storageLocation,
-          timestamp = Instant.now
+          storageLocation = storageLocation
         ),
         version = version
       )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.{
   KnownReplicasPayload,
-  ReplicaResultPayload,
+  ReplicaCompletePayload,
   VersionedBagRootPayload
 }
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
@@ -45,7 +45,7 @@ class ReplicaAggregatorWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val payload = createReplicaResultPayloadWith(
+    val payload = createReplicaCompletePayloadWith(
       provider = AmazonS3StorageProvider
     )
 
@@ -105,7 +105,7 @@ class ReplicaAggregatorWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val payload = createReplicaResultPayload
+    val payload = createReplicaCompletePayload
 
     val result =
       withReplicaAggregatorWorker(
@@ -180,7 +180,7 @@ class ReplicaAggregatorWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val payload = createReplicaResultPayload
+    val payload = createReplicaCompletePayload
 
     val result =
       withReplicaAggregatorWorker(
@@ -236,7 +236,7 @@ class ReplicaAggregatorWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val payload = createReplicaResultPayload
+    val payload = createReplicaCompletePayload
 
     val result =
       withReplicaAggregatorWorker(
@@ -314,7 +314,7 @@ class ReplicaAggregatorWorkerTest
     val context = createPipelineContext
 
     val payloads = locations.map { storageLocation =>
-      ReplicaResultPayload(
+      ReplicaCompletePayload(
         context = context,
         replicaResult = ReplicaResult(
           originalLocation = createS3ObjectLocationPrefix,

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.{
   KnownReplicasPayload,
-  ReplicaCompletePayload,
   VersionedBagRootPayload
 }
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators


### PR DESCRIPTION
Some more refactoring in service of https://github.com/wellcomecollection/platform/issues/4596

We have a model "ReplicaResult" and another "ReplicationResult". This isn't at all confusing.

The former is only a wrapper around two locations passed around as an inter-app payload, so this PR ditches the wrapper and puts those locations directly on the payload. One less class to think about.