### PR TITLE
Pass a new-style ReplicaLocation between the replicator and the aggregator

### DIFF
--- a/bag_register/docker-compose.yml
+++ b/bag_register/docker-compose.yml
@@ -1,5 +1,11 @@
 sqs:
-  image: s12v/elasticmq
+  image: "s12v/elasticmq"
   ports:
     - "9324:9324"
     - "4789:9324"
+s3:
+  image: "zenko/cloudserver:8.1.8"
+  environment:
+    - "S3BACKEND=mem"
+  ports:
+    - "33333:8000"

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -12,7 +12,12 @@ import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation, StorageManifest}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  PrimaryS3ReplicaLocation,
+  PrimaryStorageLocation,
+  StorageManifest
+}
 
 class BagRegisterFeatureTest
     extends AnyFunSpec

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -10,17 +10,9 @@ import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.generators.{
-  PayloadGenerators,
-  StorageLocationGenerators
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  PrimaryStorageLocation,
-  StorageManifest
-}
-import uk.ac.wellcome.storage.MemoryLocation
-import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
+import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation, StorageManifest}
 
 class BagRegisterFeatureTest
     extends AnyFunSpec
@@ -28,13 +20,9 @@ class BagRegisterFeatureTest
     with BagRegisterFixtures
     with PayloadGenerators
     with Eventually
-    with StorageLocationGenerators
     with IntegrationPatience {
 
   it("sends an update if it registers a bag") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val ingests = new MemoryMessageSender()
 
     val storageManifestDao = createStorageManifestDao()
@@ -44,78 +32,77 @@ class BagRegisterFeatureTest
     val version = createBagVersion
     val dataFileCount = randomInt(1, 15)
 
-    val (bagRoot, bagInfo) = createRegisterBagWith(
-      space = space,
-      version = version,
-      dataFileCount = dataFileCount
-    )
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, bagInfo) = createRegisterBagWith(
+        space = space,
+        version = version,
+        dataFileCount = dataFileCount
+      )
 
-    val bagId = BagId(
-      space = space,
-      externalIdentifier = bagInfo.externalIdentifier
-    )
+      val bagId = BagId(
+        space = space,
+        externalIdentifier = bagInfo.externalIdentifier
+      )
 
-    val primaryLocation = createPrimaryLocationWith(
-      prefix = bagRoot.toObjectLocationPrefix
-    )
+      val primaryLocation = PrimaryS3ReplicaLocation(
+        prefix = bagRoot
+      )
 
-    val knownReplicas = KnownReplicas(
-      location = primaryLocation,
-      replicas = List.empty
-    )
+      val knownReplicas = KnownReplicas(
+        location = primaryLocation.toStorageLocation,
+        replicas = List.empty
+      )
 
-    val payload = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space
-      ),
-      version = version,
-      knownReplicas = knownReplicas
-    )
+      val payload = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version,
+        knownReplicas = knownReplicas
+      )
 
-    withLocalSqsQueue(visibilityTimeout = 5) { queue =>
-      withBagRegisterWorker(
-        queue = queue,
-        ingests = ingests,
-        storageManifestDao = storageManifestDao
-      ) { _ =>
-        sendNotificationToSQS(queue, payload)
+      withLocalSqsQueue(visibilityTimeout = 5) { queue =>
+        withBagRegisterWorker(
+          queue = queue,
+          ingests = ingests,
+          storageManifestDao = storageManifestDao
+        ) { _ =>
+          sendNotificationToSQS(queue, payload)
 
-        eventually {
-          val storageManifest: StorageManifest =
-            storageManifestDao.getLatest(bagId).right.value
+          eventually {
+            val storageManifest: StorageManifest =
+              storageManifestDao.getLatest(bagId).right.value
 
-          storageManifest.space shouldBe bagId.space
-          storageManifest.info shouldBe bagInfo
-          storageManifest.manifest.files should have size dataFileCount
+            storageManifest.space shouldBe bagId.space
+            storageManifest.info shouldBe bagInfo
+            storageManifest.manifest.files should have size dataFileCount
 
-          storageManifest.location shouldBe PrimaryStorageLocation(
-            provider = primaryLocation.provider,
-            prefix = bagRoot
-              .copy(
-                pathPrefix = bagRoot.pathPrefix.stripSuffix(s"/$version")
-              )
-              .toObjectLocationPrefix
-          )
+            storageManifest.location shouldBe PrimaryStorageLocation(
+              provider = AmazonS3StorageProvider,
+              prefix = bagRoot
+                .copy(
+                  keyPrefix = bagRoot.keyPrefix.stripSuffix(s"/$version")
+                )
+                .toObjectLocationPrefix
+            )
 
-          storageManifest.replicaLocations shouldBe empty
+            storageManifest.replicaLocations shouldBe empty
 
-          storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
+            storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
 
-          assertBagRegisterSucceeded(
-            ingestId = payload.ingestId,
-            ingests = ingests
-          )
+            assertBagRegisterSucceeded(
+              ingestId = payload.ingestId,
+              ingests = ingests
+            )
 
-          assertQueueEmpty(queue)
+            assertQueueEmpty(queue)
+          }
         }
       }
     }
   }
 
   it("handles a failed registration") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val ingests = new MemoryMessageSender()
 
     // This registration will fail because when the register tries to read the

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -10,15 +10,29 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sqs.SQSClientFactory
 import uk.ac.wellcome.platform.archive.bag_register.services.s3.S3StorageManifestService
-import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
+import uk.ac.wellcome.platform.archive.bag_register.services.{
+  BagRegisterWorker,
+  Register
+}
 import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage._
@@ -137,7 +151,8 @@ trait BagRegisterFixtures
     implicit bucket: Bucket
   ): (S3ObjectLocationPrefix, BagInfo) = {
     implicit val streamStore: NewS3StreamStore = new NewS3StreamStore()
-    implicit val typedStore: NewS3TypedStore[String] = new NewS3TypedStore[String]()
+    implicit val typedStore: NewS3TypedStore[String] =
+      new NewS3TypedStore[String]()
 
     val (bagObjects, bagRoot, bagInfo) =
       createBagContentsWith(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, PayloadGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  PayloadGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
@@ -126,13 +129,14 @@ class BagRegisterWorkerTest
         knownReplicas = knownReplicas
       )
 
-      withBagRegisterWorker(registrationNotifications = registrationNotifications) {
-        worker =>
-          val future = worker.processPayload(payload)
+      withBagRegisterWorker(
+        registrationNotifications = registrationNotifications
+      ) { worker =>
+        val future = worker.processPayload(payload)
 
-          whenReady(future) {
-            _ shouldBe a[IngestCompleted[_]]
-          }
+        whenReady(future) {
+          _ shouldBe a[IngestCompleted[_]]
+        }
       }
 
       registrationNotifications
@@ -182,8 +186,7 @@ class BagRegisterWorkerTest
       )
 
       val knownReplicas2 = KnownReplicas(
-        location =
-          PrimaryS3ReplicaLocation(prefix = bagRoot2).toStorageLocation,
+        location = PrimaryS3ReplicaLocation(prefix = bagRoot2).toStorageLocation,
         replicas = List.empty
       )
 
@@ -278,12 +281,14 @@ class BagRegisterWorkerTest
       val storageManifest =
         storageManifestDao.getLatest(bagId).right.value
 
-      storageManifest.location shouldBe primaryLocation.copy(
-        prefix = bagRoot
-          .copy(
-            keyPrefix = bagRoot.keyPrefix.stripSuffix(s"/$version")
-          )
-      ).toStorageLocation
+      storageManifest.location shouldBe primaryLocation
+        .copy(
+          prefix = bagRoot
+            .copy(
+              keyPrefix = bagRoot.keyPrefix.stripSuffix(s"/$version")
+            )
+        )
+        .toStorageLocation
 
       storageManifest.replicaLocations shouldBe
         replicas.map { secondaryLocation =>

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -10,14 +10,9 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.generators.{
-  BagInfoGenerators,
-  PayloadGenerators,
-  StorageLocationGenerators
-}
+import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, PayloadGenerators}
+import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.storage.MemoryLocation
-import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
 class BagRegisterWorkerTest
     extends AnyFunSpec
@@ -26,13 +21,9 @@ class BagRegisterWorkerTest
     with IntegrationPatience
     with BagInfoGenerators
     with BagRegisterFixtures
-    with PayloadGenerators
-    with StorageLocationGenerators {
+    with PayloadGenerators {
 
   it("handles a successful registration") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val createdAfterDate = Instant.now()
     val space = createStorageSpace
     val version = createBagVersion
@@ -42,123 +33,120 @@ class BagRegisterWorkerTest
 
     val storageManifestDao = createStorageManifestDao()
 
-    val (bagRoot, bagInfo) = createRegisterBagWith(
-      space = space,
-      dataFileCount = dataFileCount,
-      version = version
-    )
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, bagInfo) = createRegisterBagWith(
+        space = space,
+        dataFileCount = dataFileCount,
+        version = version
+      )
 
-    val primaryLocation = createPrimaryLocationWith(
-      prefix = bagRoot.toObjectLocationPrefix
-    )
+      val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
 
-    val knownReplicas = KnownReplicas(
-      location = primaryLocation,
-      replicas = List.empty
-    )
+      val knownReplicas = KnownReplicas(
+        location = primaryLocation.toStorageLocation,
+        replicas = List.empty
+      )
 
-    val payload = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space
-      ),
-      version = version,
-      knownReplicas = knownReplicas
-    )
+      val payload = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version,
+        knownReplicas = knownReplicas
+      )
 
-    withBagRegisterWorker(
-      ingests = ingests,
-      storageManifestDao = storageManifestDao
-    ) { worker =>
-      val future = worker.processPayload(payload)
-
-      whenReady(future) {
-        _ shouldBe a[IngestCompleted[_]]
-      }
-    }
-
-    val bagId = BagId(
-      space = space,
-      externalIdentifier = bagInfo.externalIdentifier
-    )
-
-    val storageManifest =
-      storageManifestDao.getLatest(bagId).right.value
-
-    storageManifest.space shouldBe bagId.space
-    storageManifest.info shouldBe bagInfo
-    storageManifest.manifest.files should have size dataFileCount
-
-    storageManifest.location shouldBe PrimaryStorageLocation(
-      provider = primaryLocation.provider,
-      prefix = bagRoot
-        .copy(
-          pathPrefix = bagRoot.pathPrefix.stripSuffix(s"/$version")
-        )
-        .toObjectLocationPrefix
-    )
-
-    storageManifest.replicaLocations shouldBe empty
-
-    storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
-
-    assertBagRegisterSucceeded(
-      ingestId = payload.ingestId,
-      ingests = ingests
-    )
-  }
-
-  it("sends a notification of a registered bag") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
-    val space = createStorageSpace
-    val version = createBagVersion
-
-    val registrationNotifications = new MemoryMessageSender()
-
-    val (bagRoot, bagInfo) = createRegisterBagWith(
-      space = space,
-      version = version
-    )
-
-    val primaryLocation =
-      createPrimaryLocationWith(prefix = bagRoot.toObjectLocationPrefix)
-
-    val knownReplicas =
-      KnownReplicas(location = primaryLocation, replicas = List.empty)
-
-    val payload = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space,
-        externalIdentifier = bagInfo.externalIdentifier
-      ),
-      version = version,
-      knownReplicas = knownReplicas
-    )
-
-    withBagRegisterWorker(registrationNotifications = registrationNotifications) {
-      worker =>
+      withBagRegisterWorker(
+        ingests = ingests,
+        storageManifestDao = storageManifestDao
+      ) { worker =>
         val future = worker.processPayload(payload)
 
         whenReady(future) {
           _ shouldBe a[IngestCompleted[_]]
         }
-    }
+      }
 
-    registrationNotifications
-      .getMessages[BagRegistrationNotification]() shouldBe Seq(
-      BagRegistrationNotification(
+      val bagId = BagId(
         space = space,
-        externalIdentifier = bagInfo.externalIdentifier,
+        externalIdentifier = bagInfo.externalIdentifier
+      )
+
+      val storageManifest =
+        storageManifestDao.getLatest(bagId).right.value
+
+      storageManifest.space shouldBe bagId.space
+      storageManifest.info shouldBe bagInfo
+      storageManifest.manifest.files should have size dataFileCount
+
+      storageManifest.location shouldBe PrimaryStorageLocation(
+        provider = AmazonS3StorageProvider,
+        prefix = bagRoot
+          .copy(
+            keyPrefix = bagRoot.keyPrefix.stripSuffix(s"/$version")
+          )
+          .toObjectLocationPrefix
+      )
+
+      storageManifest.replicaLocations shouldBe empty
+
+      storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
+
+      assertBagRegisterSucceeded(
+        ingestId = payload.ingestId,
+        ingests = ingests
+      )
+    }
+  }
+
+  it("sends a notification of a registered bag") {
+    val space = createStorageSpace
+    val version = createBagVersion
+
+    val registrationNotifications = new MemoryMessageSender()
+
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, bagInfo) = createRegisterBagWith(
+        space = space,
         version = version
       )
-    )
+
+      val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
+
+      val knownReplicas = KnownReplicas(
+        location = primaryLocation.toStorageLocation,
+        replicas = List.empty
+      )
+
+      val payload = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space,
+          externalIdentifier = bagInfo.externalIdentifier
+        ),
+        version = version,
+        knownReplicas = knownReplicas
+      )
+
+      withBagRegisterWorker(registrationNotifications = registrationNotifications) {
+        worker =>
+          val future = worker.processPayload(payload)
+
+          whenReady(future) {
+            _ shouldBe a[IngestCompleted[_]]
+          }
+      }
+
+      registrationNotifications
+        .getMessages[BagRegistrationNotification]() shouldBe Seq(
+        BagRegistrationNotification(
+          space = space,
+          externalIdentifier = bagInfo.externalIdentifier,
+          version = version
+        )
+      )
+    }
   }
 
   it("stores multiple versions of a bag") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val version1 = createBagVersion
     val version2 = version1.increment
 
@@ -167,162 +155,157 @@ class BagRegisterWorkerTest
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    val (bagRoot1, bagInfo1) = createRegisterBagWith(
-      externalIdentifier = externalIdentifier,
-      space = space,
-      version = version1
-    )
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot1, bagInfo1) = createRegisterBagWith(
+        externalIdentifier = externalIdentifier,
+        space = space,
+        version = version1
+      )
 
-    val (bagRoot2, _) = createRegisterBagWith(
-      externalIdentifier = externalIdentifier,
-      space = space,
-      version = version2
-    )
+      val (bagRoot2, _) = createRegisterBagWith(
+        externalIdentifier = externalIdentifier,
+        space = space,
+        version = version2
+      )
 
-    val knownReplicas1 = KnownReplicas(
-      location =
-        createPrimaryLocationWith(prefix = bagRoot1.toObjectLocationPrefix),
-      replicas = List.empty
-    )
+      val knownReplicas1 = KnownReplicas(
+        location = PrimaryS3ReplicaLocation(prefix = bagRoot1).toStorageLocation,
+        replicas = List.empty
+      )
 
-    val payload1 = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space
-      ),
-      version = version1,
-      knownReplicas = knownReplicas1
-    )
+      val payload1 = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version1,
+        knownReplicas = knownReplicas1
+      )
 
-    val knownReplicas2 = KnownReplicas(
-      location =
-        createPrimaryLocationWith(prefix = bagRoot2.toObjectLocationPrefix),
-      replicas = List.empty
-    )
+      val knownReplicas2 = KnownReplicas(
+        location =
+          PrimaryS3ReplicaLocation(prefix = bagRoot2).toStorageLocation,
+        replicas = List.empty
+      )
 
-    val payload2 = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space
-      ),
-      version = version2,
-      knownReplicas = knownReplicas2
-    )
+      val payload2 = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version2,
+        knownReplicas = knownReplicas2
+      )
 
-    val bagId = BagId(
-      space = space,
-      externalIdentifier = bagInfo1.externalIdentifier
-    )
+      val bagId = BagId(
+        space = space,
+        externalIdentifier = bagInfo1.externalIdentifier
+      )
 
-    withBagRegisterWorker(storageManifestDao = storageManifestDao) { worker =>
-      whenReady(worker.processPayload(payload1)) {
-        _ shouldBe a[IngestCompleted[_]]
+      withBagRegisterWorker(storageManifestDao = storageManifestDao) { worker =>
+        whenReady(worker.processPayload(payload1)) {
+          _ shouldBe a[IngestCompleted[_]]
+        }
+
+        whenReady(worker.processPayload(payload2)) {
+          _ shouldBe a[IngestCompleted[_]]
+        }
       }
 
-      whenReady(worker.processPayload(payload2)) {
-        _ shouldBe a[IngestCompleted[_]]
-      }
+      storageManifestDao
+        .get(bagId, version = version1)
+        .right
+        .value
+        .version shouldBe version1
+      storageManifestDao
+        .get(bagId, version = version2)
+        .right
+        .value
+        .version shouldBe version2
+
+      storageManifestDao
+        .getLatest(bagId)
+        .right
+        .value
+        .version shouldBe version2
     }
-
-    storageManifestDao
-      .get(bagId, version = version1)
-      .right
-      .value
-      .version shouldBe version1
-    storageManifestDao
-      .get(bagId, version = version2)
-      .right
-      .value
-      .version shouldBe version2
-
-    storageManifestDao
-      .getLatest(bagId)
-      .right
-      .value
-      .version shouldBe version2
   }
 
   it("registers a bag with multiple locations") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val space = createStorageSpace
     val version = createBagVersion
 
     val storageManifestDao = createStorageManifestDao()
 
-    val (bagRoot, bagInfo) = createRegisterBagWith(
-      space = space,
-      version = version
-    )
-
-    val primaryLocation = createPrimaryLocationWith(
-      prefix = bagRoot.toObjectLocationPrefix
-    )
-
-    val replicas = collectionOf(min = 1) {
-      createSecondaryLocationWith(
-        prefix =
-          bagRoot.copy(namespace = randomAlphanumeric).toObjectLocationPrefix
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, bagInfo) = createRegisterBagWith(
+        space = space,
+        version = version
       )
-    }
 
-    val knownReplicas = KnownReplicas(
-      location = primaryLocation,
-      replicas = replicas
-    )
+      val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
 
-    val payload = createKnownReplicasPayloadWith(
-      context = createPipelineContextWith(
-        storageSpace = space
-      ),
-      version = version,
-      knownReplicas = knownReplicas
-    )
-
-    val bagId = BagId(
-      space = space,
-      externalIdentifier = bagInfo.externalIdentifier
-    )
-
-    withBagRegisterWorker(storageManifestDao = storageManifestDao) { worker =>
-      val future = worker.processPayload(payload)
-
-      whenReady(future) {
-        _ shouldBe a[IngestCompleted[_]]
-      }
-    }
-
-    val storageManifest =
-      storageManifestDao.getLatest(bagId).right.value
-
-    storageManifest.location shouldBe primaryLocation.copy(
-      prefix = bagRoot
-        .copy(
-          pathPrefix = bagRoot.pathPrefix.stripSuffix(s"/$version")
-        )
-        .toObjectLocationPrefix
-    )
-
-    storageManifest.replicaLocations shouldBe
-      replicas.map { secondaryLocation =>
-        val prefix = secondaryLocation.prefix
-
-        secondaryLocation.copy(
-          prefix = prefix
-            .copy(path = prefix.path.stripSuffix(s"/$version"))
+      val replicas = collectionOf(min = 1) {
+        SecondaryS3ReplicaLocation(
+          prefix = bagRoot.copy(bucket = createBucketName)
         )
       }
 
-    val tagManifestFiles =
-      storageManifest.tagManifest.files
-        .filter { _.name == "tagmanifest-sha256.txt" }
+      val knownReplicas = KnownReplicas(
+        location = primaryLocation.toStorageLocation,
+        replicas = replicas.map { _.toStorageLocation }
+      )
 
-    tagManifestFiles should have size 1
+      val payload = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version,
+        knownReplicas = knownReplicas
+      )
+
+      val bagId = BagId(
+        space = space,
+        externalIdentifier = bagInfo.externalIdentifier
+      )
+
+      withBagRegisterWorker(storageManifestDao = storageManifestDao) { worker =>
+        val future = worker.processPayload(payload)
+
+        whenReady(future) {
+          _ shouldBe a[IngestCompleted[_]]
+        }
+      }
+
+      val storageManifest =
+        storageManifestDao.getLatest(bagId).right.value
+
+      storageManifest.location shouldBe primaryLocation.copy(
+        prefix = bagRoot
+          .copy(
+            keyPrefix = bagRoot.keyPrefix.stripSuffix(s"/$version")
+          )
+      ).toStorageLocation
+
+      storageManifest.replicaLocations shouldBe
+        replicas.map { secondaryLocation =>
+          val prefix = secondaryLocation.prefix
+
+          secondaryLocation
+            .copy(
+              prefix = prefix
+                .copy(keyPrefix = prefix.keyPrefix.stripSuffix(s"/$version"))
+            )
+            .toStorageLocation
+        }
+
+      val tagManifestFiles =
+        storageManifest.tagManifest.files
+          .filter { _.name == "tagmanifest-sha256.txt" }
+
+      tagManifestFiles should have size 1
+    }
   }
 
   it("handles a failed registration") {
-    implicit val streamStore: MemoryStreamStore[MemoryLocation] =
-      MemoryStreamStore[MemoryLocation]()
-
     val ingests = new MemoryMessageSender()
     val registrationNotifications = new MemoryMessageSender()
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.platform.archive.bag_register.services.s3.S3StorageManifes
 import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.generators.{StorageLocationGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  StorageLocationGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestCompleted
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -89,8 +89,7 @@ class BagReplicatorWorker[
             .toReplicaLocation(
               provider = destinationConfig.provider,
               replicaType = destinationConfig.replicaType
-            )
-            .toStorageLocation,
+            ),
           version = payload.version
         )
       )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.platform.archive.common.ReplicaCompletePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
+import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.PrimaryS3ReplicaLocation
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
@@ -28,8 +29,6 @@ class BagReplicatorFeatureTest
   it("replicates a bag successfully and updates both topics") {
     withLocalS3Bucket { srcBucket =>
       withLocalS3Bucket { dstBucket =>
-        val provider = createProvider
-
         val ingests = new MemoryMessageSender()
         val outgoing = new MemoryMessageSender()
 
@@ -46,7 +45,7 @@ class BagReplicatorFeatureTest
             ingests = ingests,
             outgoing = outgoing,
             stepName = "replicating",
-            provider = provider,
+            provider = AmazonS3StorageProvider,
             replicaType = PrimaryReplica
           ) { _ =>
             sendNotificationToSQS(queue, payload)

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -13,8 +13,8 @@ import uk.ac.wellcome.platform.archive.common.ReplicaCompletePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.storage.models.PrimaryStorageLocation
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.platform.archive.common.storage.models.PrimaryS3ReplicaLocation
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 class BagReplicatorFeatureTest
     extends AnyFunSpec
@@ -52,9 +52,9 @@ class BagReplicatorFeatureTest
             sendNotificationToSQS(queue, payload)
 
             eventually {
-              val expectedDst = ObjectLocationPrefix(
-                namespace = dstBucket.name,
-                path = Paths
+              val expectedDst = S3ObjectLocationPrefix(
+                bucket = dstBucket.name,
+                keyPrefix = Paths
                   .get(
                     payload.storageSpace.toString,
                     payload.externalIdentifier.toString,
@@ -71,14 +71,13 @@ class BagReplicatorFeatureTest
               receivedPayload.context shouldBe payload.context
               receivedPayload.version shouldBe payload.version
 
-              receivedPayload.dstLocation shouldBe PrimaryStorageLocation(
-                provider = provider,
+              receivedPayload.dstLocation shouldBe PrimaryS3ReplicaLocation(
                 prefix = expectedDst
               )
 
               verifyObjectsCopied(
                 srcPrefix = srcBagRoot,
-                dstPrefix = expectedDst
+                dstPrefix = expectedDst.asInstanceOf[S3ObjectLocationPrefix]
               )
 
               assertTopicReceivesIngestEvents(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -24,7 +24,10 @@ import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
-import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
+import uk.ac.wellcome.storage.locking.memory.{
+  MemoryLockDao,
+  MemoryLockDaoFixtures
+}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -128,7 +131,8 @@ trait BagReplicatorFixtures
       _.getETag
     }
 
-    val destinationItems = listing.list(dstPrefix.toObjectLocationPrefix).right.value
+    val destinationItems =
+      listing.list(dstPrefix.toObjectLocationPrefix).right.value
     val destinationKeyEtags = destinationItems.map {
       _.getETag
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -15,20 +15,16 @@ import uk.ac.wellcome.platform.archive.bagreplicator.replicator.models.Replicati
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3.S3Replicator
 import uk.ac.wellcome.platform.archive.bagreplicator.services.BagReplicatorWorker
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   AmazonS3StorageProvider,
   StorageProvider
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
-import uk.ac.wellcome.storage.{ObjectLocationPrefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
-import uk.ac.wellcome.storage.locking.memory.{
-  MemoryLockDao,
-  MemoryLockDaoFixtures
-}
+import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -39,7 +35,6 @@ trait BagReplicatorFixtures
     with OperationFixtures
     with AlpakkaSQSWorkerFixtures
     with MemoryLockDaoFixtures
-    with StorageLocationGenerators
     with S3Fixtures {
 
   type ReplicatorLockingService =
@@ -126,14 +121,14 @@ trait BagReplicatorFixtures
 
   def verifyObjectsCopied(
     srcPrefix: S3ObjectLocationPrefix,
-    dstPrefix: ObjectLocationPrefix
+    dstPrefix: S3ObjectLocationPrefix
   ): Assertion = {
     val sourceItems = listing.list(srcPrefix.toObjectLocationPrefix).right.value
     val sourceKeyEtags = sourceItems.map {
       _.getETag
     }
 
-    val destinationItems = listing.list(dstPrefix).right.value
+    val destinationItems = listing.list(dstPrefix.toObjectLocationPrefix).right.value
     val destinationKeyEtags = destinationItems.map {
       _.getETag
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -11,7 +11,10 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
-import uk.ac.wellcome.platform.archive.bagreplicator.models.{PrimaryReplica, SecondaryReplica}
+import uk.ac.wellcome.platform.archive.bagreplicator.models.{
+  PrimaryReplica,
+  SecondaryReplica
+}
 import uk.ac.wellcome.platform.archive.common.ReplicaCompletePayload
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
@@ -71,7 +74,8 @@ class BagReplicatorWorkerTest
         receivedPayload.context shouldBe payload.context
         receivedPayload.version shouldBe payload.version
 
-        val dstBagRoot = receivedPayload.dstLocation.prefix.asInstanceOf[S3ObjectLocationPrefix]
+        val dstBagRoot = receivedPayload.dstLocation.prefix
+          .asInstanceOf[S3ObjectLocationPrefix]
 
         verifyObjectsCopied(
           srcPrefix = srcBagRoot,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -116,7 +116,7 @@ object BagVerifierWorkerBuilder {
       metricsNamespace = metricsNamespace,
       (payload: ReplicaCompletePayload) =>
         ReplicatedBagVerifyContext(
-          root = S3ObjectLocationPrefix(payload.dstLocation.prefix),
+          root = payload.dstLocation.prefix.asInstanceOf[S3ObjectLocationPrefix],
           srcRoot = payload.srcPrefix
         )
     )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -13,8 +13,14 @@ import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, PrimaryS3ReplicaLocation}
-import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, ReplicaCompletePayload}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  PrimaryS3ReplicaLocation
+}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootLocationPayload,
+  ReplicaCompletePayload
+}
 
 import scala.util.{Failure, Success, Try}
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -12,18 +12,9 @@ import uk.ac.wellcome.platform.archive.common.fixtures.PayloadEntry
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  AmazonS3StorageProvider,
-  Ingest
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  PrimaryStorageLocation
-}
-import uk.ac.wellcome.platform.archive.common.{
-  BagRootLocationPayload,
-  ReplicaCompletePayload
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, PrimaryS3ReplicaLocation}
+import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, ReplicaCompletePayload}
 
 import scala.util.{Failure, Success, Try}
 
@@ -119,10 +110,7 @@ class BagVerifierWorkerTest
             storageSpace = space
           ),
           srcPrefix = bagRoot,
-          dstLocation = PrimaryStorageLocation(
-            provider = AmazonS3StorageProvider,
-            prefix = bagRoot.toObjectLocationPrefix
-          ),
+          dstLocation = PrimaryS3ReplicaLocation(prefix = bagRoot),
           version = createBagVersion
         )
 
@@ -155,10 +143,7 @@ class BagVerifierWorkerTest
             storageSpace = space
           ),
           srcPrefix = createS3ObjectLocationPrefix,
-          dstLocation = PrimaryStorageLocation(
-            provider = AmazonS3StorageProvider,
-            prefix = bagRoot.toObjectLocationPrefix
-          ),
+          dstLocation = PrimaryS3ReplicaLocation(prefix = bagRoot),
           version = createBagVersion
         )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,21 +2,9 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestType,
-  SourceLocation
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  StorageLocation,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaLocation, StorageSpace}
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 sealed trait PipelinePayload {
@@ -69,6 +57,6 @@ case class VersionedBagRootPayload(
 case class ReplicaCompletePayload(
   context: PipelineContext,
   srcPrefix: S3ObjectLocationPrefix,
-  dstLocation: StorageLocation,
+  dstLocation: ReplicaLocation,
   version: BagVersion
 ) extends VerifiablePayload

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -2,9 +2,21 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType, SourceLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, ReplicaLocation, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestType,
+  SourceLocation
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  ReplicaLocation,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.S3ObjectLocationPrefix
 
 sealed trait PipelinePayload {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -7,7 +7,10 @@ import java.util.UUID
 
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.platform.archive.common.bagit.models._
-import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, StorageProvider}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestID,
+  StorageProvider
+}
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.generators.RandomThings
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.platform.archive.common.bagit.models._
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, StorageProvider}
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.generators.RandomThings
 
@@ -193,4 +193,9 @@ trait StorageRandomThings extends RandomThings {
 
   def createChecksum: Checksum =
     createChecksumWith()
+
+  def createProvider: StorageProvider =
+    StorageProvider(
+      id = chooseFrom(StorageProvider.allowedValues)
+    )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.storage.{S3ObjectLocation, S3ObjectLocationPrefix}
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
-    with StorageLocationGenerators
+    with ReplicaLocationGenerators
     with NewS3Fixtures {
 
   def randomIngestType: IngestType =
@@ -119,7 +119,7 @@ trait PayloadGenerators
     )
 
   def createReplicaCompletePayloadWith(
-    dstLocation: StorageLocation = createPrimaryLocation
+    dstLocation: ReplicaLocation = createPrimaryLocation
   ): ReplicaCompletePayload =
     ReplicaCompletePayload(
       context = createPipelineContext,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -5,7 +5,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.fixtures.NewS3Fixtures
 
 trait ReplicaLocationGenerators extends StorageRandomThings with NewS3Fixtures {
-
   def createPrimaryLocation: PrimaryReplicaLocation =
     chooseFrom(
       Seq(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
@@ -12,10 +12,6 @@ import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 trait StorageLocationGenerators
     extends ObjectLocationGenerators
     with StorageRandomThings {
-  def createProvider: StorageProvider =
-    StorageProvider(
-      id = chooseFrom(StorageProvider.allowedValues)
-    )
 
   def createPrimaryLocation: PrimaryStorageLocation =
     createPrimaryLocationWith()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -13,7 +13,7 @@ import scala.util.Random
 trait StorageManifestGenerators
     extends BagInfoGenerators
     with StorageSpaceGenerators
-    with StorageLocationGenerators {
+    with ReplicaLocationGenerators {
 
   val checksumAlgorithm: HashingAlgorithm = SHA256
 
@@ -50,10 +50,10 @@ trait StorageManifestGenerators
     bagInfo: BagInfo = createBagInfo,
     version: BagVersion = createBagVersion,
     fileCount: Int = 3,
-    location: PrimaryStorageLocation = createPrimaryLocation,
+    location: PrimaryStorageLocation = createPrimaryLocation.toStorageLocation,
     replicaLocations: Seq[SecondaryStorageLocation] = (1 to randomInt(0, 5))
       .map { _ =>
-        createSecondaryLocation
+        createSecondaryLocation.toStorageLocation
       },
     createdDate: Instant = Instant.now,
     files: Seq[StorageManifestFile] = Nil

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -19,26 +19,11 @@ case class AggregatorInternalRecord(
       replicaLocation = location
     )
 
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  def addLocation(location: StorageLocation): Try[AggregatorInternalRecord] =
-    AggregatorInternalRecord.addLocation(
-      record = this,
-      replicaLocation = ReplicaLocation.fromStorageLocation(location)
-    )
-
   def count: Int =
     (Seq(location).flatten ++ replicas).size
 }
 
 object AggregatorInternalRecord {
-  // TODO: Bridging code while we split ObjectLocation.  Remove this later.
-  // See https://github.com/wellcomecollection/platform/issues/4596
-  def apply(storageLocation: StorageLocation): AggregatorInternalRecord =
-    AggregatorInternalRecord(
-      ReplicaLocation.fromStorageLocation(storageLocation)
-    )
-
   def apply(replicaLocation: ReplicaLocation): AggregatorInternalRecord =
     replicaLocation match {
       case primary: PrimaryReplicaLocation =>

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaPath.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaPath.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.scanamo.DynamoFormat
-import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, Location, Prefix, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  AzureBlobItemLocationPrefix,
+  Location,
+  Prefix,
+  S3ObjectLocationPrefix
+}
 
 case class ReplicaPath(underlying: String) extends AnyVal {
   override def toString: String = underlying

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaPath.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaPath.scala
@@ -2,12 +2,19 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.scanamo.DynamoFormat
+import uk.ac.wellcome.storage.{AzureBlobItemLocationPrefix, Location, Prefix, S3ObjectLocationPrefix}
 
 case class ReplicaPath(underlying: String) extends AnyVal {
   override def toString: String = underlying
 }
 
-object ReplicaPath {
+case object ReplicaPath {
+  def apply(prefix: Prefix[_ <: Location]): ReplicaPath =
+    prefix match {
+      case S3ObjectLocationPrefix(_, keyPrefix)       => ReplicaPath(keyPrefix)
+      case AzureBlobItemLocationPrefix(_, namePrefix) => ReplicaPath(namePrefix)
+    }
+
   implicit val encoder: Encoder[ReplicaPath] =
     (value: ReplicaPath) => Json.fromString(value.toString)
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
+import uk.ac.wellcome.platform.archive.common.storage.models.ReplicaLocation
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{UpdateError, UpdateNotApplied}
@@ -9,15 +9,14 @@ class ReplicaAggregator(
   versionedStore: VersionedStore[ReplicaPath, Int, AggregatorInternalRecord]
 ) {
   def aggregate(
-    storageLocation: StorageLocation
+    replicaLocation: ReplicaLocation
   ): Either[UpdateError, AggregatorInternalRecord] = {
-    val replicaPath =
-      ReplicaPath(storageLocation.prefix.path)
+    val replicaPath = ReplicaPath(replicaLocation.prefix)
 
-    val initialRecord = AggregatorInternalRecord(storageLocation)
+    val initialRecord = AggregatorInternalRecord(replicaLocation)
 
     val upsert = versionedStore.upsert(replicaPath)(initialRecord) {
-      _.addLocation(storageLocation).toEither.left.map(UpdateNotApplied)
+      _.addLocation(replicaLocation).toEither.left.map(UpdateNotApplied)
     }
 
     upsert.map(_.identifiedT)

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -47,12 +47,12 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   ) extends WorkerError
 
   private def getKnownReplicas(
-    storageLocation: StorageLocation
+    replicaLocation: ReplicaLocation
   ): Either[WorkerError, KnownReplicas] =
     for {
 
       aggregatorRecord <- replicaAggregator
-        .aggregate(storageLocation)
+        .aggregate(replicaLocation)
         .left
         .map(AggregationFailure)
 
@@ -66,7 +66,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   override def processMessage(
     payload: ReplicaCompletePayload
   ): Try[IngestStepResult[ReplicationAggregationSummary]] = {
-    val replicaPath = ReplicaPath(payload.dstLocation.prefix.path)
+    val replicaPath = ReplicaPath(payload.dstLocation.prefix)
     val startTime = Instant.now()
 
     val ingestStep = getKnownReplicas(payload.dstLocation) match {

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -1,26 +1,18 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator
 
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.EitherValues
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
-import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
+import uk.ac.wellcome.platform.archive.common.generators.{PayloadGenerators, ReplicaLocationGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.AmazonS3StorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  KnownReplicas,
-  PrimaryS3ReplicaLocation,
-  PrimaryStorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
-  AggregatorInternalRecord,
-  ReplicaPath
-}
-import uk.ac.wellcome.storage.{S3ObjectLocationPrefix, Version}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 class ReplicaAggregatorFeatureTest
@@ -31,17 +23,20 @@ class ReplicaAggregatorFeatureTest
     with PayloadGenerators
     with Eventually
     with EitherValues
-    with IntegrationPatience {
+    with IntegrationPatience
+    with ReplicaLocationGenerators {
 
   it("completes after a single primary replica") {
     withLocalSqsQueue() { queue =>
       val ingests = new MemoryMessageSender()
       val outgoing = new MemoryMessageSender()
 
+      val primaryReplicaLocation = PrimaryS3ReplicaLocation(
+        prefix = createS3ObjectLocationPrefix
+      )
+
       val payload = createReplicaCompletePayloadWith(
-        dstLocation = createPrimaryLocationWith(
-          provider = AmazonS3StorageProvider
-        )
+        dstLocation = primaryReplicaLocation
       )
       val versionedStore =
         MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](Map.empty)
@@ -64,18 +59,13 @@ class ReplicaAggregatorFeatureTest
             )
           )
 
-          val expectedReplicaPath =
-            ReplicaPath(payload.dstLocation.prefix.path)
+          val expectedReplicaPath = ReplicaPath(payload.dstLocation.prefix)
 
           val stored =
             versionedStore.get(id = Version(expectedReplicaPath, 0)).right.value
 
           val primaryLocation =
             payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
-
-          val primaryReplicaLocation = PrimaryS3ReplicaLocation(
-            prefix = S3ObjectLocationPrefix(payload.dstLocation.prefix)
-          )
 
           stored.identifiedT.location shouldBe Some(primaryReplicaLocation)
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -7,11 +7,20 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
-import uk.ac.wellcome.platform.archive.common.generators.{PayloadGenerators, ReplicaLocationGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  PayloadGenerators,
+  ReplicaLocationGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  KnownReplicas,
+  PrimaryS3ReplicaLocation
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  ReplicaPath
+}
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.KnownReplicasPayload
 import uk.ac.wellcome.platform.archive.common.generators.{PayloadGenerators, ReplicaLocationGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation, PrimaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{KnownReplicas, PrimaryS3ReplicaLocation}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
 import uk.ac.wellcome.storage.Version
@@ -65,7 +65,7 @@ class ReplicaAggregatorFeatureTest
             versionedStore.get(id = Version(expectedReplicaPath, 0)).right.value
 
           val primaryLocation =
-            payload.dstLocation.asInstanceOf[PrimaryStorageLocation]
+            payload.dstLocation.asInstanceOf[PrimaryS3ReplicaLocation]
 
           stored.identifiedT.location shouldBe Some(primaryReplicaLocation)
 
@@ -75,7 +75,7 @@ class ReplicaAggregatorFeatureTest
             context = payload.context,
             version = payload.version,
             knownReplicas = KnownReplicas(
-              location = primaryLocation,
+              location = primaryLocation.toStorageLocation,
               replicas = List.empty
             )
           )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
@@ -32,8 +32,8 @@ trait ReplicaAggregatorFixtures
       MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
         initialEntries = Map.empty
       ),
-    ingests: MemoryMessageSender,
-    outgoing: MemoryMessageSender,
+    ingests: MemoryMessageSender = new MemoryMessageSender(),
+    outgoing: MemoryMessageSender = new MemoryMessageSender(),
     stepName: String = randomAlphanumericWithLength(),
     expectedReplicaCount: Int = 1
   )(testWith: TestWith[ReplicaAggregatorWorker[String, String], R]): R =

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -40,7 +40,7 @@ class ReplicaAggregatorTest
 
     val result =
       withAggregator(versionedStore) {
-        _.aggregate(primaryLocation.toStorageLocation)
+        _.aggregate(primaryLocation)
       }
 
     val expectedRecord =
@@ -54,7 +54,7 @@ class ReplicaAggregatorTest
     }
 
     it("stores the replica in the underlying store") {
-      val path = ReplicaPath(primaryLocation.toStorageLocation.prefix.path)
+      val path = ReplicaPath(primaryLocation.prefix)
 
       versionedStore
         .getLatest(path)
@@ -74,7 +74,7 @@ class ReplicaAggregatorTest
 
     val result =
       withAggregator(versionedStore) {
-        _.aggregate(secondaryLocation.toStorageLocation)
+        _.aggregate(secondaryLocation)
       }
 
     val expectedRecord =
@@ -122,7 +122,7 @@ class ReplicaAggregatorTest
       withAggregator(versionedStore) { aggregator =>
         locations
           .map { loc =>
-            aggregator.aggregate(loc.toStorageLocation)
+            aggregator.aggregate(loc)
           }
           .map { _.right.value }
       }
@@ -173,7 +173,7 @@ class ReplicaAggregatorTest
     withAggregator(versionedStore) { aggregator =>
       Seq(primaryLocation1, primaryLocation2)
         .foreach { loc =>
-          aggregator.aggregate(loc.toStorageLocation)
+          aggregator.aggregate(loc)
         }
     }
 
@@ -202,7 +202,7 @@ class ReplicaAggregatorTest
 
     val result =
       withAggregator(brokenStore)(
-        _.aggregate(createPrimaryLocation.toStorageLocation)
+        _.aggregate(createPrimaryLocation)
       )
 
     result.left.value shouldBe UpdateWriteError(err)
@@ -220,7 +220,7 @@ class ReplicaAggregatorTest
     withAggregator() { aggregator =>
       (1 to 5).map { _ =>
         aggregator
-          .aggregate(primaryLocation.toStorageLocation)
+          .aggregate(primaryLocation)
           .right
           .value shouldBe expectedRecord
       }
@@ -240,7 +240,7 @@ class ReplicaAggregatorTest
 
     withAggregator() { aggregator =>
       val result =
-        aggregator.aggregate(primaryLocation1.toStorageLocation).right.value
+        aggregator.aggregate(primaryLocation1).right.value
 
       result shouldBe AggregatorInternalRecord(
         location = Some(primaryLocation1),
@@ -248,7 +248,7 @@ class ReplicaAggregatorTest
       )
 
       val err =
-        aggregator.aggregate(primaryLocation2.toStorageLocation).left.get
+        aggregator.aggregate(primaryLocation2).left.get
       err.e.getMessage should startWith(
         "Record already has a different PrimaryStorageLocation"
       )
@@ -256,7 +256,7 @@ class ReplicaAggregatorTest
   }
 
   it("only stores unique replica results") {
-    val location = createSecondaryLocation.toStorageLocation
+    val location = createSecondaryLocation
 
     val results =
       withAggregator() { aggregator =>

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -273,10 +273,12 @@ class ReplicaAggregatorWorkerTest
     )
 
   it("handles ConditionalUpdate errors from DynamoDB") {
+    val path = randomAlphanumeric
+
     val locations = Seq(
-      createPrimaryLocation,
-      createSecondaryLocation,
-      createSecondaryLocation
+      PrimaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)),
+      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)),
+      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path))
     )
 
     val payloads = locations.map { dstLocation =>

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -273,10 +273,6 @@ class ReplicaAggregatorWorkerTest
     )
 
   it("handles ConditionalUpdate errors from DynamoDB") {
-    val ingests = new MemoryMessageSender()
-    val outgoing = new MemoryMessageSender()
-
-    val path = randomAlphanumeric
     val locations = Seq(
       createPrimaryLocation,
       createSecondaryLocation,
@@ -298,8 +294,6 @@ class ReplicaAggregatorWorkerTest
       val future: Future[Seq[IngestStepResult[ReplicationAggregationSummary]]] =
         withReplicaAggregatorWorker(
           versionedStore = versionedStore,
-          ingests = ingests,
-          outgoing = outgoing,
           expectedReplicaCount = 3
         ) { service =>
           Future.sequence(

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -66,7 +66,9 @@ class ReplicaAggregatorWorkerTest
 
       val completeAggregation =
         result.summary.asInstanceOf[ReplicationAggregationComplete]
-      completeAggregation.replicaPath shouldBe ReplicaPath(payload.dstLocation.prefix)
+      completeAggregation.replicaPath shouldBe ReplicaPath(
+        payload.dstLocation.prefix
+      )
       completeAggregation.knownReplicas shouldBe expectedKnownReplicas
     }
 
@@ -118,9 +120,12 @@ class ReplicaAggregatorWorkerTest
 
       val incompleteAggregation =
         result.summary.asInstanceOf[ReplicationAggregationIncomplete]
-      incompleteAggregation.replicaPath shouldBe ReplicaPath(payload.dstLocation.prefix)
+      incompleteAggregation.replicaPath shouldBe ReplicaPath(
+        payload.dstLocation.prefix
+      )
       incompleteAggregation.aggregatorRecord shouldBe AggregatorInternalRecord(
-        location = Some(payload.dstLocation.asInstanceOf[PrimaryReplicaLocation]),
+        location =
+          Some(payload.dstLocation.asInstanceOf[PrimaryReplicaLocation]),
         replicas = List.empty
       )
       incompleteAggregation.counterError shouldBe NotEnoughReplicas(
@@ -276,9 +281,15 @@ class ReplicaAggregatorWorkerTest
     val path = randomAlphanumeric
 
     val locations = Seq(
-      PrimaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)),
-      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)),
-      SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefixWith(keyPrefix = path))
+      PrimaryS3ReplicaLocation(
+        prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)
+      ),
+      SecondaryS3ReplicaLocation(
+        prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)
+      ),
+      SecondaryS3ReplicaLocation(
+        prefix = createS3ObjectLocationPrefixWith(keyPrefix = path)
+      )
     )
 
     val payloads = locations.map { dstLocation =>


### PR DESCRIPTION
Follows #648, part of https://github.com/wellcomecollection/platform/issues/4596

Both apps are using ReplicaLocation internally, so we can strip off a translation layer and pass it between them.