### PR TITLE
Send the new ReplicaLocations between the replica aggregator and the bag register

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -53,8 +53,8 @@ class BagRegisterWorker[IngestDestination, NotificationDestination](
 
       registrationSummary <- register.update(
         ingestId = payload.ingestId,
-        location = payload.knownReplicas.location,
-        replicas = payload.knownReplicas.replicas,
+        location = payload.knownReplicas.location.toStorageLocation,
+        replicas = payload.knownReplicas.replicas.map { _.toStorageLocation },
         version = payload.version,
         space = payload.storageSpace,
         externalIdentifier = payload.externalIdentifier

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -54,7 +54,7 @@ class BagRegisterFeatureTest
       )
 
       val knownReplicas = KnownReplicas(
-        location = primaryLocation.toStorageLocation,
+        location = primaryLocation,
         replicas = List.empty
       )
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -46,7 +46,7 @@ class BagRegisterWorkerTest
       val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
 
       val knownReplicas = KnownReplicas(
-        location = primaryLocation.toStorageLocation,
+        location = primaryLocation,
         replicas = List.empty
       )
 
@@ -116,7 +116,7 @@ class BagRegisterWorkerTest
       val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
 
       val knownReplicas = KnownReplicas(
-        location = primaryLocation.toStorageLocation,
+        location = primaryLocation,
         replicas = List.empty
       )
 
@@ -173,7 +173,7 @@ class BagRegisterWorkerTest
       )
 
       val knownReplicas1 = KnownReplicas(
-        location = PrimaryS3ReplicaLocation(prefix = bagRoot1).toStorageLocation,
+        location = PrimaryS3ReplicaLocation(prefix = bagRoot1),
         replicas = List.empty
       )
 
@@ -186,7 +186,7 @@ class BagRegisterWorkerTest
       )
 
       val knownReplicas2 = KnownReplicas(
-        location = PrimaryS3ReplicaLocation(prefix = bagRoot2).toStorageLocation,
+        location = PrimaryS3ReplicaLocation(prefix = bagRoot2),
         replicas = List.empty
       )
 
@@ -253,8 +253,8 @@ class BagRegisterWorkerTest
       }
 
       val knownReplicas = KnownReplicas(
-        location = primaryLocation.toStorageLocation,
-        replicas = replicas.map { _.toStorageLocation }
+        location = primaryLocation,
+        replicas = replicas
       )
 
       val payload = createKnownReplicasPayloadWith(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/KnownReplicas.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/KnownReplicas.scala
@@ -8,6 +8,6 @@ package uk.ac.wellcome.platform.archive.common.storage.models
   *
   */
 case class KnownReplicas(
-  location: PrimaryStorageLocation,
-  replicas: Seq[SecondaryStorageLocation]
+  location: PrimaryReplicaLocation,
+  replicas: Seq[SecondaryReplicaLocation]
 )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -68,9 +68,9 @@ trait PayloadGenerators
 
   def createKnownReplicas = KnownReplicas(
     location = createPrimaryLocation,
-    replicas = (1 to randomInt(from = 0, to = 5))
-      .map { _ => createSecondaryLocation }
-      .toList
+    replicas = (1 to randomInt(from = 0, to = 5)).map { _ =>
+      createSecondaryLocation
+    }.toList
   )
 
   def createKnownReplicasPayload: KnownReplicasPayload =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -67,18 +67,9 @@ trait PayloadGenerators
     )
 
   def createKnownReplicas = KnownReplicas(
-    location = PrimaryStorageLocation(
-      provider = AmazonS3StorageProvider,
-      prefix = createObjectLocationPrefix
-    ),
+    location = createPrimaryLocation,
     replicas = (1 to randomInt(from = 0, to = 5))
-      .map(
-        _ =>
-          SecondaryStorageLocation(
-            provider = AmazonS3StorageProvider,
-            prefix = createObjectLocationPrefix
-          )
-      )
+      .map { _ => createSecondaryLocation }
       .toList
   )
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
@@ -33,8 +33,8 @@ class ReplicaCounter(val expectedReplicaCount: Int) {
         if (actualReplicaCount >= expectedReplicaCount) {
           Right(
             KnownReplicas(
-              location = primaryLocation.toStorageLocation,
-              replicas = record.replicas.map { _.toStorageLocation }
+              location = primaryLocation,
+              replicas = record.replicas
             )
           )
         } else {

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -84,7 +84,7 @@ class ReplicaAggregatorFeatureTest
             context = payload.context,
             version = payload.version,
             knownReplicas = KnownReplicas(
-              location = primaryLocation.toStorageLocation,
+              location = primaryLocation,
               replicas = List.empty
             )
           )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -46,7 +46,7 @@ class ReplicaAggregatorWorkerTest
     val payload = createReplicaCompletePayloadWith(dstLocation = dstLocation)
 
     val expectedKnownReplicas = KnownReplicas(
-      location = dstLocation.toStorageLocation,
+      location = dstLocation,
       replicas = List.empty
     )
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
@@ -51,7 +51,7 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location.toStorageLocation,
+      location = location,
       replicas = List.empty
     )
   }
@@ -68,8 +68,8 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location.toStorageLocation,
-      replicas = replicas.map { _.toStorageLocation }
+      location = location,
+      replicas = replicas
     )
   }
 
@@ -104,8 +104,8 @@ class ReplicaCounterTest
     )
 
     counter.countReplicas(record).right.value shouldBe KnownReplicas(
-      location = location.toStorageLocation,
-      replicas = replicas.map { _.toStorageLocation }
+      location = location,
+      replicas = replicas
     )
   }
 }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4596

Still not changing any of the bag register behaviour, but inching closer towards it…