### PR TITLE
Remove some unneeded Materializer instances

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bag_register
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -37,8 +36,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val ec: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val s3Client: AmazonS3 =
       S3Builder.buildS3Client(config)

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagreplicator
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
 import com.typesafe.config.Config
@@ -55,9 +54,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val s3Client: AmazonS3 =
       S3Builder.buildS3Client(config)

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/Main.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.storage.bag_root_finder
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -33,8 +32,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 

--- a/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/Main.scala
+++ b/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.storage.bag_tagger
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -31,8 +30,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/Main.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagunpacker
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -31,9 +30,6 @@ object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagverifier
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -29,9 +28,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val s3Client: AmazonS3 =
       S3Builder.buildS3Client(config)

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/Main.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.storage.bag_versioner
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import cats.Id
 import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
@@ -45,8 +44,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
@@ -8,7 +8,6 @@ import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.DebuggingDirectives
-import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.typesafe.Runnable
@@ -24,8 +23,7 @@ class WellcomeHttpApp(
 )(
   implicit
   val as: ActorSystem,
-  val ec: ExecutionContext,
-  mt: Materializer
+  val ec: ExecutionContext
 ) extends Runnable
     with WellcomeExceptionHandler
     with WellcomeRejectionHandler

--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.indexer.bags
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -27,9 +26,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
+++ b/indexer/ingests_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/ingests/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.indexer.ingests
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -26,9 +25,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/ingests/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
+++ b/ingests/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
@@ -4,7 +4,6 @@ import java.net.URL
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.SNSConfig
@@ -32,8 +31,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val httpServerConfigMain = HTTPServerBuilder.buildHTTPServerConfig(config)
     val contextURLMain = HTTPServerBuilder.buildContextURL(config)

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{get, _}
 import akka.http.scaladsl.server.Route
-import akka.stream.Materializer
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
@@ -32,8 +31,7 @@ class IngestsTrackerApi[CallbackDestination, IngestsDestination](
   host: String = "localhost",
   port: Int = 8080
 )(
-  implicit sys: ActorSystem,
-  mat: Materializer
+  implicit sys: ActorSystem
 ) extends Runnable
     with Logging {
 

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.storage.ingests_tracker
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSMessageSender}
@@ -20,8 +19,6 @@ object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val dynamoClient: AmazonDynamoDB =
       DynamoBuilder.buildDynamoClient(config)

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -34,27 +34,24 @@ trait IngestsTrackerApiFixture
     updatedIngestsMessageSender: MemoryMessageSender = new MemoryMessageSender()
   )(testWith: TestWith[IngestsTrackerApi[String, String], R]): R = {
     withActorSystem { implicit actorSystem =>
-      withMaterializer(actorSystem) { implicit materializer =>
-        val callbackNotificationService =
-          new CallbackNotificationService(callbackNotificationMessageSender)
+      val callbackNotificationService =
+        new CallbackNotificationService(callbackNotificationMessageSender)
 
-        val messagingService: MessagingService[String, String] =
-          new MessagingService(
-            callbackNotificationService,
-            updatedIngestsMessageSender
-          )
+      val messagingService: MessagingService[String, String] =
+        new MessagingService(
+          callbackNotificationService,
+          updatedIngestsMessageSender
+        )
 
-        val app = new IngestsTrackerApi[String, String](
-          ingestTrackerTest,
-          messagingService
-        )()
+      val app = new IngestsTrackerApi[String, String](
+        ingestTrackerTest,
+        messagingService
+      )()
 
-        app.run()
+      app.run()
 
-        testWith(app)
-      }
+      testWith(app)
     }
-
   }
 
   def withBrokenIngestsTrackerApi[R](

--- a/ingests/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/Main.scala
+++ b/ingests/ingests_worker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_worker/Main.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.storage.ingests_worker
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.ac.wellcome.messaging.typesafe.{
   AlpakkaSqsWorkerConfigBuilder,
@@ -25,8 +24,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.notifier
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.ac.wellcome.messaging.typesafe.{
@@ -28,8 +27,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
@@ -43,9 +42,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val executionContext: ExecutionContextExecutor =
       actorSystem.dispatcher
-
-    implicit val mat: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     implicit val monitoringClient: CloudwatchMetricsMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)


### PR DESCRIPTION
Spotted while doing some refactoring for https://github.com/wellcomecollection/platform/issues/4596

In [Akka 2.6][1], you don't need to supply an implicit Materializer if there's an implicit ActorSystem:

> A default materializer is now provided out of the box. For the Java API just pass system when running streams, for Scala an implicit materializer is provided if there is an implicit ActorSystem available. This avoids leaking materializers and simplifies most stream use cases somewhat.

The Materializer instances are often boilerplate that we can delete without losing anything; this highlights places where we *do* need a Materializer (e.g. for Akka flows).

[1]: https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html#materializer-changes