### PR TITLE
Grant s3 access to digirati account, rather than roles

### DIFF
--- a/terraform/critical_prod/locals.tf
+++ b/terraform/critical_prod/locals.tf
@@ -14,4 +14,6 @@ locals {
   workflow_account_principal           = "arn:aws:iam::299497370133:root"
   digitisation_account_principal       = "arn:aws:iam::404315009621:root"
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
+
+  digirati_account_principal = "arn:aws:iam:653428163053:root"
 }

--- a/terraform/critical_prod/locals.tf
+++ b/terraform/critical_prod/locals.tf
@@ -15,5 +15,5 @@ locals {
   digitisation_account_principal       = "arn:aws:iam::404315009621:root"
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
 
-  digirati_account_principal = "arn:aws:iam:653428163053:root"
+  digirati_account_principal = "arn:aws:iam::653428163053:root"
 }

--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -19,6 +19,7 @@ module "critical" {
 
     "arn:aws:iam::653428163053:user/api",
     "arn:aws:iam::653428163053:user/echo-fs",
+    local.digirati_account_principal
   ]
 
   azure_storage_account_name = "wecostorageprod"

--- a/terraform/critical_staging/locals.tf
+++ b/terraform/critical_staging/locals.tf
@@ -14,4 +14,6 @@ locals {
   workflow_account_principal           = "arn:aws:iam::299497370133:root"
   digitisation_account_principal       = "arn:aws:iam::404315009621:root"
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
+
+  digirati_account_principal = "arn:aws:iam:653428163053:root"
 }

--- a/terraform/critical_staging/locals.tf
+++ b/terraform/critical_staging/locals.tf
@@ -15,5 +15,5 @@ locals {
   digitisation_account_principal       = "arn:aws:iam::404315009621:root"
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
 
-  digirati_account_principal = "arn:aws:iam:653428163053:root"
+  digirati_account_principal = "arn:aws:iam::653428163053:root"
 }

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -19,6 +19,7 @@ module "critical" {
 
     "arn:aws:iam::653428163053:user/api",
     "arn:aws:iam::653428163053:user/echo-fs",
+    local.digirati_account_principal
   ]
 
   azure_storage_account_name = "wecostoragestage"

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -93,11 +93,6 @@ data "aws_iam_policy_document" "replica_primary_read" {
         # Beta version of the DLCS orchestrator.
         # See https://wellcome.slack.com/archives/CBT40CMKQ/p1573742247457800
         "AROAZQI22QHWTHLN4QHJU:*",
-
-        # Dashboard for iiif-builder staging + staging-prd + prod
-        "AROAZQI22QHW3RRRIYDN3:*",
-        "AROAZQI22QHWQI2FAIMQ5:*",
-        "AROAZQI22QHWZ755Z5O5K:*",
       ]
     }
 


### PR DESCRIPTION
As discussed in Slack, this is an interim change to test with iiif-builder as these are not live yet. When we have it working we can create a follow-up PR which removes all Digirati specific access for DLCS to use.