### PR TITLE
Allow a replicated bag to have different source/replica locations

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -104,7 +104,7 @@ object BagVerifierWorkerBuilder {
     sc: SqsAsyncClient
   ): BagVerifierWorker[
     ReplicaCompletePayload,
-    ReplicatedBagVerifyContext[S3ObjectLocationPrefix],
+    ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix],
     IngestDestination,
     OutgoingDestination
   ] = {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
@@ -10,13 +10,10 @@ case class StandaloneBagVerifyContext[BagPrefix <: Prefix[_ <: Location]](
   root: BagPrefix
 ) extends BagVerifyContext[BagPrefix]
 
-
 case class ReplicatedBagVerifyContext[
   SrcBagPrefix <: Prefix[_ <: Location],
   ReplicaBagPrefix <: Prefix[_ <: Location]
-](
-  srcRoot: SrcBagPrefix,
-  replicaRoot: ReplicaBagPrefix)
+](srcRoot: SrcBagPrefix, replicaRoot: ReplicaBagPrefix)
     extends BagVerifyContext[ReplicaBagPrefix] {
 
   val root: ReplicaBagPrefix = replicaRoot

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
@@ -10,10 +10,14 @@ case class StandaloneBagVerifyContext[BagPrefix <: Prefix[_ <: Location]](
   root: BagPrefix
 ) extends BagVerifyContext[BagPrefix]
 
-case class ReplicatedBagVerifyContext[BagPrefix <: Prefix[_ <: Location]](
-  srcRoot: BagPrefix,
-  replicaRoot: BagPrefix
-) extends BagVerifyContext[BagPrefix] {
 
-  val root: BagPrefix = replicaRoot
+case class ReplicatedBagVerifyContext[
+  SrcBagPrefix <: Prefix[_ <: Location],
+  ReplicaBagPrefix <: Prefix[_ <: Location]
+](
+  srcRoot: SrcBagPrefix,
+  replicaRoot: ReplicaBagPrefix)
+    extends BagVerifyContext[ReplicaBagPrefix] {
+
+  val root: ReplicaBagPrefix = replicaRoot
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -38,7 +38,7 @@ trait ReplicatedBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
       BagLocation,
       BagPrefix
     ]
-    with VerifySourceTagManifest[BagLocation] {
+    with VerifySourceTagManifest[BagLocation, BagLocation] {
   override def verifyReplicatedBag(
     root: ReplicatedBagVerifyContext[BagPrefix],
     space: StorageSpace,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -32,8 +32,10 @@ trait StandaloneBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
 }
 
 trait ReplicatedBagVerifier[
-  SrcBagLocation <: Location, SrcBagPrefix <: Prefix[SrcBagLocation],
-  ReplicaBagLocation <: Location, ReplicaBagPrefix <: Prefix[ReplicaBagLocation]
+  SrcBagLocation <: Location,
+  SrcBagPrefix <: Prefix[SrcBagLocation],
+  ReplicaBagLocation <: Location,
+  ReplicaBagPrefix <: Prefix[ReplicaBagLocation]
 ] extends BagVerifier[
       ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
       ReplicaBagLocation,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -31,16 +31,17 @@ trait StandaloneBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
   ): Either[BagVerifierError, Unit] = Right(())
 }
 
-trait ReplicatedBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
-  BagLocation
-]] extends BagVerifier[
-      ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
-      BagLocation,
-      BagPrefix
+trait ReplicatedBagVerifier[
+  SrcBagLocation <: Location, SrcBagPrefix <: Prefix[SrcBagLocation],
+  ReplicaBagLocation <: Location, ReplicaBagPrefix <: Prefix[ReplicaBagLocation]
+] extends BagVerifier[
+      ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
+      ReplicaBagLocation,
+      ReplicaBagPrefix
     ]
-    with VerifySourceTagManifest[BagLocation, BagLocation] {
+    with VerifySourceTagManifest[SrcBagLocation, ReplicaBagLocation] {
   override def verifyReplicatedBag(
-    root: ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
+    root: ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
     bag: Bag

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -34,13 +34,13 @@ trait StandaloneBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
 trait ReplicatedBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
 ]] extends BagVerifier[
-      ReplicatedBagVerifyContext[BagPrefix],
+      ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
       BagLocation,
       BagPrefix
     ]
     with VerifySourceTagManifest[BagLocation, BagLocation] {
   override def verifyReplicatedBag(
-    root: ReplicatedBagVerifyContext[BagPrefix],
+    root: ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
     bag: Bag

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -64,6 +64,9 @@ class S3ReplicatedBagVerifier(val primaryBucket: String)(
 ) extends ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix]
     with S3BagVerifier[ReplicatedBagVerifyContext[S3ObjectLocationPrefix]] {
 
-  override val streamStore: StreamStore[S3ObjectLocation] =
+  override val srcStreamStore: StreamStore[S3ObjectLocation] =
+    new S3StreamStore()
+
+  override val replicaStreamStore: StreamStore[S3ObjectLocation] =
     new S3StreamStore()
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -61,7 +61,10 @@ class S3StandaloneBagVerifier(val primaryBucket: String)(
 
 class S3ReplicatedBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
-) extends ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix]
+) extends ReplicatedBagVerifier[
+  S3ObjectLocation, S3ObjectLocationPrefix,
+  S3ObjectLocation, S3ObjectLocationPrefix
+]
     with S3BagVerifier[ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]] {
 
   override val srcStreamStore: StreamStore[S3ObjectLocation] =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -62,10 +62,14 @@ class S3StandaloneBagVerifier(val primaryBucket: String)(
 class S3ReplicatedBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
 ) extends ReplicatedBagVerifier[
-  S3ObjectLocation, S3ObjectLocationPrefix,
-  S3ObjectLocation, S3ObjectLocationPrefix
-]
-    with S3BagVerifier[ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]] {
+      S3ObjectLocation,
+      S3ObjectLocationPrefix,
+      S3ObjectLocation,
+      S3ObjectLocationPrefix
+    ]
+    with S3BagVerifier[
+      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
+    ] {
 
   override val srcStreamStore: StreamStore[S3ObjectLocation] =
     new S3StreamStore()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -62,7 +62,7 @@ class S3StandaloneBagVerifier(val primaryBucket: String)(
 class S3ReplicatedBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
 ) extends ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix]
-    with S3BagVerifier[ReplicatedBagVerifyContext[S3ObjectLocationPrefix]] {
+    with S3BagVerifier[ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]] {
 
   override val srcStreamStore: StreamStore[S3ObjectLocation] =
     new S3StreamStore()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
@@ -6,8 +6,9 @@ import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{Identified, Location, Prefix}
 
-trait VerifySourceTagManifest[BagLocation <: Location] {
-  val streamStore: StreamStore[BagLocation]
+trait VerifySourceTagManifest[SrcBagLocation <: Location, ReplicaBagLocation <: Location] {
+  protected val srcStreamStore: StreamStore[SrcBagLocation]
+  protected val replicaStreamStore: StreamStore[ReplicaBagLocation]
 
   /** This step is here to check the bag created by the replica and the
     * original bag are the same; the verifier can only check that a
@@ -20,12 +21,12 @@ trait VerifySourceTagManifest[BagLocation <: Location] {
     *
     */
   def verifySourceTagManifestIsTheSame(
-    srcPrefix: Prefix[BagLocation],
-    replicaPrefix: Prefix[BagLocation]
+    srcPrefix: Prefix[SrcBagLocation],
+    replicaPrefix: Prefix[ReplicaBagLocation]
   ): Either[BagVerifierError, Unit] = {
     for {
-      srcManifest <- getTagManifest(srcPrefix)
-      replicaManifest <- getTagManifest(replicaPrefix)
+      srcManifest <- getTagManifest(srcPrefix, srcStreamStore)
+      replicaManifest <- getTagManifest(replicaPrefix, replicaStreamStore)
 
       result <- if (IOUtils.contentEquals(srcManifest, replicaManifest)) {
         Right(())
@@ -41,8 +42,8 @@ trait VerifySourceTagManifest[BagLocation <: Location] {
     } yield result
   }
 
-  private def getTagManifest(
-    prefix: Prefix[BagLocation]
+  private def getTagManifest[BagLocation <: Location](
+    prefix: Prefix[BagLocation], streamStore: StreamStore[BagLocation]
   ): Either[BagVerifierError, InputStreamWithLength] =
     streamStore.get(prefix.asLocation("tagmanifest-sha256.txt")) match {
       case Right(Identified(_, inputStream)) => Right(inputStream)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{Identified, Location, Prefix}
 
-trait VerifySourceTagManifest[SrcBagLocation <: Location, ReplicaBagLocation <: Location] {
+trait VerifySourceTagManifest[
+  SrcBagLocation <: Location,
+  ReplicaBagLocation <: Location
+] {
   protected val srcStreamStore: StreamStore[SrcBagLocation]
   protected val replicaStreamStore: StreamStore[ReplicaBagLocation]
 
@@ -43,7 +46,8 @@ trait VerifySourceTagManifest[SrcBagLocation <: Location, ReplicaBagLocation <: 
   }
 
   private def getTagManifest[BagLocation <: Location](
-    prefix: Prefix[BagLocation], streamStore: StreamStore[BagLocation]
+    prefix: Prefix[BagLocation],
+    streamStore: StreamStore[BagLocation]
   ): Either[BagVerifierError, InputStreamWithLength] =
     streamStore.get(prefix.asLocation("tagmanifest-sha256.txt")) match {
       case Right(Identified(_, inputStream)) => Right(inputStream)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -78,7 +78,10 @@ trait BagVerifierFixtures
   )(
     testWith: TestWith[BagVerifierWorker[
       ReplicaCompletePayload,
-      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix],
+      ReplicatedBagVerifyContext[
+        S3ObjectLocationPrefix,
+        S3ObjectLocationPrefix
+      ],
       String,
       String
     ], R]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -78,7 +78,7 @@ trait BagVerifierFixtures
   )(
     testWith: TestWith[BagVerifierWorker[
       ReplicaCompletePayload,
-      ReplicatedBagVerifyContext[S3ObjectLocationPrefix],
+      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix],
       String,
       String
     ], R]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -701,7 +701,7 @@ trait ReplicatedBagVerifierTestCases[
   Namespace
 ] extends BagVerifierTestCases[
       ReplicatedBagVerifier[BagLocation, BagPrefix],
-      ReplicatedBagVerifyContext[BagPrefix],
+      ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
       BagLocation,
       BagPrefix,
       Namespace
@@ -709,7 +709,7 @@ trait ReplicatedBagVerifierTestCases[
   override def createBagContext(
     bagRoot: BagPrefix,
     srcRoot: Option[BagPrefix]
-  ): ReplicatedBagVerifyContext[BagPrefix] =
+  ): ReplicatedBagVerifyContext[BagPrefix, BagPrefix] =
     ReplicatedBagVerifyContext(
       srcRoot = srcRoot.getOrElse(bagRoot),
       replicaRoot = bagRoot

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -700,7 +700,7 @@ trait ReplicatedBagVerifierTestCases[
   BagPrefix <: Prefix[BagLocation],
   Namespace
 ] extends BagVerifierTestCases[
-      ReplicatedBagVerifier[BagLocation, BagPrefix],
+      ReplicatedBagVerifier[BagLocation, BagPrefix, BagLocation, BagPrefix],
       ReplicatedBagVerifyContext[BagPrefix, BagPrefix],
       BagLocation,
       BagPrefix,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -58,7 +58,9 @@ trait StandaloneBagVerifierTestCases[
       BagPrefix,
       Namespace
     ] {
-  def withBagContext[R](bagRoot: BagPrefix)(testWith: TestWith[StandaloneBagVerifyContext[BagPrefix], R]): R =
+  def withBagContext[R](
+    bagRoot: BagPrefix
+  )(testWith: TestWith[StandaloneBagVerifyContext[BagPrefix], R]): R =
     testWith(
       StandaloneBagVerifyContext(bagRoot)
     )
@@ -87,7 +89,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     testWith: TestWith[Verifier, R]
   )(implicit typedStore: TypedStore[BagLocation, String]): R
 
-  def withBagContext[R](bagRoot: BagPrefix)(testWith: TestWith[BagContext, R]): R
+  def withBagContext[R](bagRoot: BagPrefix)(
+    testWith: TestWith[BagContext, R]
+  ): R
 
   val payloadFileCount: Int = randomInt(from = 1, to = 10)
 
@@ -702,13 +706,23 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 }
 
 trait ReplicatedBagVerifierTestCases[
-  SrcBagLocation <: Location, SrcBagPrefix <: Prefix[SrcBagLocation], SrcNamespace,
-  ReplicaBagLocation <: Location, ReplicaBagPrefix <: Prefix[ReplicaBagLocation], ReplicaNamespace
-] extends BagVerifierTestCases[
-      ReplicatedBagVerifier[SrcBagLocation, SrcBagPrefix, ReplicaBagLocation, ReplicaBagPrefix],
-      ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
-      ReplicaBagLocation, ReplicaBagPrefix,
+  SrcBagLocation <: Location,
+  SrcBagPrefix <: Prefix[SrcBagLocation],
+  SrcNamespace,
+  ReplicaBagLocation <: Location,
+  ReplicaBagPrefix <: Prefix[ReplicaBagLocation],
   ReplicaNamespace
+] extends BagVerifierTestCases[
+      ReplicatedBagVerifier[
+        SrcBagLocation,
+        SrcBagPrefix,
+        ReplicaBagLocation,
+        ReplicaBagPrefix
+      ],
+      ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
+      ReplicaBagLocation,
+      ReplicaBagPrefix,
+      ReplicaNamespace
     ] {
 
   protected def copyTagManifest(
@@ -717,30 +731,44 @@ trait ReplicatedBagVerifierTestCases[
   ): Unit
 
   def createSrcPrefix(implicit namespace: SrcNamespace): SrcBagPrefix
-  def createReplicaPrefix(implicit namespace: ReplicaNamespace): ReplicaBagPrefix
+  def createReplicaPrefix(
+    implicit namespace: ReplicaNamespace
+  ): ReplicaBagPrefix
 
   def withSrcNamespace[R](testWith: TestWith[SrcNamespace, R]): R
   def withReplicaNamespace[R](testWith: TestWith[ReplicaNamespace, R]): R
 
-  def withSrcTypedStore[R](testWith: TestWith[TypedStore[SrcBagLocation, String], R]): R
-  def withReplicaTypedStore[R](testWith: TestWith[TypedStore[ReplicaBagLocation, String], R]): R
+  def withSrcTypedStore[R](
+    testWith: TestWith[TypedStore[SrcBagLocation, String], R]
+  ): R
+  def withReplicaTypedStore[R](
+    testWith: TestWith[TypedStore[ReplicaBagLocation, String], R]
+  ): R
 
   val srcBagBuilder: BagBuilder[SrcBagLocation, SrcBagPrefix, SrcNamespace]
-  val replicaBagBuilder: BagBuilder[ReplicaBagLocation, ReplicaBagPrefix, ReplicaNamespace]
+  val replicaBagBuilder: BagBuilder[
+    ReplicaBagLocation,
+    ReplicaBagPrefix,
+    ReplicaNamespace
+  ]
 
   def withNamespace[R](testWith: TestWith[ReplicaNamespace, R]): R =
     withReplicaNamespace { namespace =>
       testWith(namespace)
     }
 
-  def withTypedStore[R](testWith: TestWith[TypedStore[ReplicaBagLocation, String], R]): R =
+  def withTypedStore[R](
+    testWith: TestWith[TypedStore[ReplicaBagLocation, String], R]
+  ): R =
     withReplicaTypedStore { typedStore =>
       testWith(typedStore)
     }
 
-  override def withBagContext[R](
-    replicaRoot: ReplicaBagPrefix)(
-    testWith: TestWith[ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix], R]
+  override def withBagContext[R](replicaRoot: ReplicaBagPrefix)(
+    testWith: TestWith[
+      ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
+      R
+    ]
   ): R =
     withSrcNamespace { implicit srcNamespace =>
       val srcRoot = createSrcPrefix
@@ -765,11 +793,16 @@ trait ReplicatedBagVerifierTestCases[
           withReplicaTypedStore { implicit replicaTypedStore =>
             val space = createStorageSpace
 
-            val (srcObjects, srcRoot, _) = srcBagBuilder.createBagContentsWith(space = space)
+            val (srcObjects, srcRoot, _) =
+              srcBagBuilder.createBagContentsWith(space = space)
             srcBagBuilder.uploadBagObjects(srcRoot, objects = srcObjects)
 
-            val (replicaObjects, replicaRoot, bagInfo) = replicaBagBuilder.createBagContentsWith(space = space)
-            replicaBagBuilder.uploadBagObjects(replicaRoot, objects = replicaObjects)
+            val (replicaObjects, replicaRoot, bagInfo) =
+              replicaBagBuilder.createBagContentsWith(space = space)
+            replicaBagBuilder.uploadBagObjects(
+              replicaRoot,
+              objects = replicaObjects
+            )
 
             val ingestStep =
               withVerifier(replicaNamespace) {
@@ -802,7 +835,8 @@ trait ReplicatedBagVerifierTestCases[
         withReplicaTypedStore { implicit replicaTypedStore =>
           val space = createStorageSpace
 
-          val (bagObjects, bagRoot, bagInfo) = replicaBagBuilder.createBagContentsWith(space = space)
+          val (bagObjects, bagRoot, bagInfo) =
+            replicaBagBuilder.createBagContentsWith(space = space)
           replicaBagBuilder.uploadBagObjects(bagRoot, objects = bagObjects)
 
           val srcRoot = createSrcPrefix

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -1,12 +1,22 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services.s3
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bagverifier.models.{BagVerifyContext, ReplicatedBagVerifyContext, StandaloneBagVerifyContext}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  BagVerifyContext,
+  ReplicatedBagVerifyContext,
+  StandaloneBagVerifyContext
+}
 import uk.ac.wellcome.platform.archive.bagverifier.services._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagBuilder, PayloadEntry}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagBuilder,
+  PayloadEntry
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -74,16 +84,30 @@ trait S3BagVerifierTests[Verifier <: BagVerifier[
 
 class S3ReplicatedBagVerifierTest
     extends ReplicatedBagVerifierTestCases[
-      S3ObjectLocation, S3ObjectLocationPrefix, Bucket,
-      S3ObjectLocation, S3ObjectLocationPrefix, Bucket
+      S3ObjectLocation,
+      S3ObjectLocationPrefix,
+      Bucket,
+      S3ObjectLocation,
+      S3ObjectLocationPrefix,
+      Bucket
     ]
     with S3BagVerifierTests[
-      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix],
+      ReplicatedBagVerifier[
+        S3ObjectLocation,
+        S3ObjectLocationPrefix,
+        S3ObjectLocation,
+        S3ObjectLocationPrefix
+      ],
       ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
-      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix],
+      ReplicatedBagVerifier[
+        S3ObjectLocation,
+        S3ObjectLocationPrefix,
+        S3ObjectLocation,
+        S3ObjectLocationPrefix
+      ],
       R
     ]
   )(
@@ -101,13 +125,17 @@ class S3ReplicatedBagVerifierTest
       replicaRoot.bucket,
       s"${replicaRoot.keyPrefix}/tagmanifest-sha256.txt",
       srcRoot.bucket,
-      s"${srcRoot.keyPrefix}/tagmanifest-sha256.txt",
+      s"${srcRoot.keyPrefix}/tagmanifest-sha256.txt"
     )
 
-  override def createSrcPrefix(implicit bucket: Bucket): S3ObjectLocationPrefix =
+  override def createSrcPrefix(
+    implicit bucket: Bucket
+  ): S3ObjectLocationPrefix =
     createS3ObjectLocationPrefixWith(bucket)
 
-  override def createReplicaPrefix(implicit bucket: Bucket): S3ObjectLocationPrefix =
+  override def createReplicaPrefix(
+    implicit bucket: Bucket
+  ): S3ObjectLocationPrefix =
     createS3ObjectLocationPrefixWith(bucket)
 
   override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
@@ -120,16 +148,22 @@ class S3ReplicatedBagVerifierTest
       testWith(bucket)
     }
 
-  override def withSrcTypedStore[R](testWith: TestWith[TypedStore[S3ObjectLocation, String], R]): R =
+  override def withSrcTypedStore[R](
+    testWith: TestWith[TypedStore[S3ObjectLocation, String], R]
+  ): R =
     testWith(S3TypedStore[String])
 
-  override def withReplicaTypedStore[R](testWith: TestWith[TypedStore[S3ObjectLocation, String], R]): R =
+  override def withReplicaTypedStore[R](
+    testWith: TestWith[TypedStore[S3ObjectLocation, String], R]
+  ): R =
     testWith(S3TypedStore[String])
 
-  override val srcBagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+  override val srcBagBuilder
+    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
     new S3BagBuilder {}
 
-  override val replicaBagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+  override val replicaBagBuilder
+    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
     new S3BagBuilder {}
 }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -86,12 +86,12 @@ class S3ReplicatedBagVerifierTest
       Bucket
     ]
     with S3BagVerifierTests[
-      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
+      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix],
       ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
-      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
+      ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix, S3ObjectLocation, S3ObjectLocationPrefix],
       R
     ]
   )(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -87,7 +87,7 @@ class S3ReplicatedBagVerifierTest
     ]
     with S3BagVerifierTests[
       ReplicatedBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
-      ReplicatedBagVerifyContext[S3ObjectLocationPrefix]
+      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4595; follows #665 

Currently the original and replica location are both instances of `S3ObjectLocation`; when we want to verify bags from Azure, that's going to change. This replumbs the verifier so that it takes different type parameters everywhere it cares about these locations, which will allow us to have different locations in a later patch.

As a side note, I think it'd be worth breaking the BagVerifier/Standalone/Replicated classes into separate files (but not here; it would muddy the diffs enormously).