### PR TITLE
Add a script for verifying every bag has a replica in Azure

### DIFF
--- a/scripts/migrations/2020-08-verify_azure_replicas.py
+++ b/scripts/migrations/2020-08-verify_azure_replicas.py
@@ -33,7 +33,7 @@ def get_bag_identifiers():
                 "label": label,
                 "space": space,
                 "external_identifier": external_identifier,
-                "version": f"v{int(item['version'])}"
+                "version": f"v{int(item['version'])}",
             }
 
 
@@ -54,9 +54,9 @@ def count_replicas(label, space, external_identifier, version):
     replica_id = f"{space}/{external_identifier}/{version}".replace("//", "/")
 
     try:
-        item = dynamodb.Table(replica_table_name).get_item(
-            Key={"id": replica_id}
-        )["Item"]
+        item = dynamodb.Table(replica_table_name).get_item(Key={"id": replica_id})[
+            "Item"
+        ]
     except KeyError:
         raise RuntimeError(f"Cannot find replica aggregator result for {replica_id}???")
 
@@ -75,8 +75,8 @@ def count_replicas(label, space, external_identifier, version):
 
         # The primary and secondary S3 buckets should be different
         assert (
-            location["PrimaryS3ReplicaLocation"]["prefix"]["bucket"] !=
-            replicas[0]["SecondaryS3ReplicaLocation"]["prefix"]["bucket"]
+            location["PrimaryS3ReplicaLocation"]["prefix"]["bucket"]
+            != replicas[0]["SecondaryS3ReplicaLocation"]["prefix"]["bucket"]
         )
 
         # The third replica (if present) is Azure
@@ -95,12 +95,11 @@ def count_replicas(label, space, external_identifier, version):
 
     # If there are three replicas in the aggregator table, we need to check they
     # all made it to the storage manifest.
-    client = {
-        "prod": prod_client,
-        "stage": stage_client,
-    }[label]
+    client = {"prod": prod_client, "stage": stage_client}[label]
 
-    bag = client.get_bag(space=space, external_identifier=external_identifier, version=version)
+    bag = client.get_bag(
+        space=space, external_identifier=external_identifier, version=version
+    )
 
     try:
         assert bag["id"] == f"{space}/{external_identifier}"
@@ -126,10 +125,7 @@ def count_replicas(label, space, external_identifier, version):
 
 
 if __name__ == "__main__":
-    summary_replica_counts = {
-        "stage": {2: 0, 3: 0},
-        "prod": {2: 0, 3: 0},
-    }
+    summary_replica_counts = {"stage": {2: 0, 3: 0}, "prod": {2: 0, 3: 0}}
 
     for bag in get_bag_identifiers():
         # TODO: Add some caching here.  Once we've seen that a bag has three replicas,
@@ -144,7 +140,9 @@ if __name__ == "__main__":
             print(f"Unexpected replica count for bag: {result}, {bag}", file=sys.stderr)
             assert 0
 
-        print(f" {bag['label']}: {bag['space']}/{bag['external_identifier']}/{bag['version']}")
+        print(
+            f" {bag['label']}: {bag['space']}/{bag['external_identifier']}/{bag['version']}"
+        )
         summary_replica_counts[bag["label"]][result] += 1
 
         # Only check the bags in staging for now; that's what we'll migrate first.
@@ -155,19 +153,19 @@ if __name__ == "__main__":
     print("staging:")
     print(
         termcolor.colored("  %6d" % summary_replica_counts["stage"][2], "red"),
-        "awaiting Azure replica"
+        "awaiting Azure replica",
     )
     print(
         termcolor.colored("  %6d" % summary_replica_counts["stage"][3], "green"),
-        "replicated to Azure"
+        "replicated to Azure",
     )
 
     print("\nprod:")
     print(
         termcolor.colored("  %6d" % summary_replica_counts["prod"][2], "red"),
-        "awaiting Azure replica"
+        "awaiting Azure replica",
     )
     print(
         termcolor.colored("  %6d" % summary_replica_counts["prod"][3], "green"),
-        "replicated to Azure"
+        "replicated to Azure",
     )

--- a/scripts/migrations/2020-08-verify_azure_replicas.py
+++ b/scripts/migrations/2020-08-verify_azure_replicas.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""
+This is the skeleton of a script that verifies we have an Azure replica for every
+bag in the storage service.
+
+Part of https://github.com/wellcomecollection/platform/issues/4640
+"""
+
+from pprint import pprint
+
+import termcolor
+
+from common import get_aws_resource, get_storage_client, scan_table
+
+
+dynamodb = get_aws_resource("dynamodb")
+
+prod_client = get_storage_client("https://api.wellcomecollection.org/storage/v1")
+stage_client = get_storage_client("https://api-stage.wellcomecollection.org/storage/v1")
+
+
+def get_bag_identifiers():
+    """
+    Find every bag in the storage service.
+    """
+    for label, TableName in [
+        ("stage", "vhs-storage-staging-manifests-2020-07-24"),
+        ("prod", "vhs-storage-manifests-2020-07-24"),
+    ]:
+        for item in scan_table(TableName=TableName):
+            space, external_identifier = item["id"].split("/", 1)
+            yield {
+                "label": label,
+                "space": space,
+                "external_identifier": external_identifier,
+                "version": f"v{int(item['version'])}"
+            }
+
+
+def count_replicas(label, space, external_identifier, version):
+    """
+    How many replicas of this bag do we have?
+    """
+    # First look in the replica aggregator table.  This is a fast lookup that we
+    # can use to see if a bag only has two replicas; if so, we can skip getting
+    # the full storage manifest.
+    replica_table_name = {
+        "prod": "storage_replicas_table",
+        "stage": "storage-staging_replicas_table",
+    }[label]
+
+    item = dynamodb.Table(replica_table_name).get_item(
+        Key={"id": f"{space}/{external_identifier}/{version}"}
+    )["Item"]
+
+    location = item["payload"]["location"]
+    replicas = item["payload"]["replicas"]
+
+    try:
+        # There should be 1 or 2 secondary replicas (without or with Azure)
+        assert len(replicas) in {1, 2}
+
+        # The first replica is an S3 replica
+        assert location.keys() == {"PrimaryS3ReplicaLocation"}
+
+        # The second replica is S3
+        assert replicas[0].keys() == {"SecondaryS3ReplicaLocation"}
+
+        # The primary and secondary S3 buckets should be different
+        assert (
+            location["PrimaryS3ReplicaLocation"]["prefix"]["bucket"] !=
+            replicas[0]["SecondaryS3ReplicaLocation"]["prefix"]["bucket"]
+        )
+
+        # The third replica (if present) is Azure
+        if len(replicas) == 2:
+            assert replicas[1].keys() == {"SecondaryAzureReplicaLocation"}
+    except AssertionError:
+        print("Something is wrong with this item:")
+        pprint(item)
+        raise
+
+    # If there's only one secondary replica in the replica aggregator table, we
+    # know there will only be one replica in the storage manifest.  We can skip
+    # actually looking it up.
+    if len(replicas) == 1:
+        return 2
+
+    # If there are three replicas in the aggregator table, we need to check they
+    # all made it to the storage manifest.
+    client = {
+        "prod": prod_client,
+        "stage": stage_client,
+    }[label]
+
+    bag = client.get_bag(space=space, external_identifier=external_identifier, version=version)
+
+    try:
+        assert bag["id"] == f"{space}/{external_identifier}"
+        assert bag["version"] == version
+
+        location = bag["location"]
+        replicas = bag["replicaLocations"]
+
+        assert len(replicas) in {1, 2}
+        assert location["provider"]["id"] == "amazon-s3"
+        assert replicas[0]["provider"]["id"] == "amazon-s3"
+
+        assert location["bucket"] != replicas[0]["bucket"]
+
+        if len(replicas) == 2:
+            assert replicas[1]["provider"]["id"] == "azure-blob-storage"
+
+        return len([location] + replicas)
+    except AssertionError:
+        print("Something is wrong with this bag:")
+        pprint(bag)
+        raise
+
+
+if __name__ == "__main__":
+    summary_replica_counts = {
+        "stage": {2: 0, 3: 0},
+        "prod": {2: 0, 3: 0},
+    }
+
+    for bag in get_bag_identifiers():
+        # TODO: Add some caching here.  Once we've seen that a bag has three replicas,
+        # we don't have to check again.
+        result = count_replicas(**bag)
+
+        if result == 2:
+            print(termcolor.colored("✗", "red"), end="")
+        elif result == 3:
+            print(termcolor.colored("✓", "green"), end="")
+        else:
+            print(f"Unexpected replica count for bag: {result}, {bag}", file=sys.stderr)
+            assert 0
+
+        print(f" {bag['label']}: {bag['space']}/{bag['external_identifier']}/{bag['version']}")
+        summary_replica_counts[bag["label"]][result] += 1
+
+        # Only check the bags in staging for now; that's what we'll migrate first.
+        if bag["label"] != "stage":
+            break
+
+    print("\n== SUMMARY ==")
+    print("staging:")
+    print(
+        termcolor.colored("  %6d" % summary_replica_counts["stage"][2], "red"),
+        "awaiting Azure replica"
+    )
+    print(
+        termcolor.colored("  %6d" % summary_replica_counts["stage"][3], "green"),
+        "replicated to Azure"
+    )
+
+    print("\nprod:")
+    print(
+        termcolor.colored("  %6d" % summary_replica_counts["prod"][2], "red"),
+        "awaiting Azure replica"
+    )
+    print(
+        termcolor.colored("  %6d" % summary_replica_counts["prod"][3], "green"),
+        "replicated to Azure"
+    )

--- a/scripts/migrations/2020-08-verify_azure_replicas.py
+++ b/scripts/migrations/2020-08-verify_azure_replicas.py
@@ -7,6 +7,7 @@ Part of https://github.com/wellcomecollection/platform/issues/4640
 """
 
 from pprint import pprint
+import sys
 
 import termcolor
 

--- a/scripts/migrations/common.py
+++ b/scripts/migrations/common.py
@@ -2,8 +2,10 @@
 
 import decimal
 import json
+import os
 
 import boto3
+from wellcome_storage_service import RequestsOAuthStorageServiceClient
 
 
 READ_ONLY_ROLE_ARN = "arn:aws:iam::975596993436:role/storage-read_only"
@@ -40,7 +42,7 @@ def scan_table(*, TableName, **kwargs):
 sts_client = boto3.client("sts")
 
 
-def get_aws_resource(resource, *, role_arn):
+def get_aws_resource(resource, *, role_arn=READ_ONLY_ROLE_ARN):
     assumed_role_object = sts_client.assume_role(
         RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
     )
@@ -63,4 +65,18 @@ def get_aws_client(resource, *, role_arn):
         aws_access_key_id=credentials["AccessKeyId"],
         aws_secret_access_key=credentials["SecretAccessKey"],
         aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_storage_client(api_url):
+    creds_path = os.path.join(
+        os.environ["HOME"], ".wellcome-storage", "oauth-credentials.json"
+    )
+    oauth_creds = json.load(open(creds_path))
+
+    return RequestsOAuthStorageServiceClient(
+        api_url=api_url,
+        client_id=oauth_creds["client_id"],
+        client_secret=oauth_creds["client_secret"],
+        token_url=oauth_creds["token_url"],
     )


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/4590. We don't have any successfully replicated bags to check yet, but most of this script can be written and just check for the presence of a 2-replica bag.

The plan is that we'd run this on an EC2 instance, possibly with some caching of successes so we can gradually crank towards completion. Checks stage + prod at the same time.

If I'm feeling fancy, I might add a pie chart that gets auto-posted to S3.

Example of output:

![Screenshot 2020-08-06 at 09 32 35](https://user-images.githubusercontent.com/301220/89509891-c6ae5900-d7c7-11ea-877a-e90e9b1865d7.png)