### PR TITLE
Better scripts for doing Azure authentication

### DIFF
--- a/scripts/_aws.py
+++ b/scripts/_aws.py
@@ -3,6 +3,7 @@ from botocore.exceptions import ClientError
 
 
 READ_ONLY_ROLE_ARN = "arn:aws:iam::975596993436:role/storage-read_only"
+DEV_ROLE_ARN = "arn:aws:iam::975596993436:role/storage-developer"
 
 
 sts_client = boto3.client("sts")
@@ -40,7 +41,7 @@ def get_dynamo_client(*, role_arn=READ_ONLY_ROLE_ARN):
     return get_aws_resource("dynamodb", role_arn=role_arn).meta.client
 
 
-def find_elastic_ip():
+def get_elastic_ip():
     """
     Our VPCs have exactly one elastic IP associated with them.
 
@@ -64,10 +65,12 @@ def find_elastic_ip():
         return ipv4_addresses[0]
 
 
-def store_secret(secrets_client, *, secret_id, secret_string):
+def store_secret(*, secret_id, secret_string):
     """
     Store a SecretString in Secrets Manager.
     """
+    secrets_client = get_aws_client("secretsmanager", role_arn=DEV_ROLE_ARN)
+
     try:
         secrets_client.put_secret_value(SecretId=secret_id, SecretString=secret_string)
     except ClientError as err:

--- a/scripts/_azure.py
+++ b/scripts/_azure.py
@@ -1,0 +1,55 @@
+import datetime
+
+from azure.storage.blob import (
+    generate_container_sas,
+    BlobSasPermissions,
+    BlobServiceClient,
+)
+
+from _aws import get_elastic_ip
+
+
+def _create_sas_uris(connection_string, *, expiry, ip):
+    """
+    Creates read/write SAS URIs for all the containers in our Azure storage account.
+
+    Generates (container_name, sas_uri) pairs.
+    """
+    blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+
+    for container in blob_service_client.list_containers():
+        container_name = container["name"]
+
+        token = generate_container_sas(
+            blob_service_client.account_name,
+            container_name=container_name,
+            account_key=blob_service_client.credential.account_key,
+            expiry=expiry,
+            ip=ip,
+            # These permissions are fairly blunt -- there's a single "write"
+            # permission for any modifications to a blob, whether that's the
+            # content or the metadata.
+            permission=BlobSasPermissions(read=True, write=True, delete=False),
+        )
+
+        yield (container_name, f"{blob_service_client.url}?{token}")
+
+
+def create_prod_sas_uris(connection_string):
+    """
+    Creates read/write SAS URIs for services running in our AWS account.
+
+    These URIs are:
+    -   set to never expire
+    -   bound to the Elastic IP of the storage account
+
+    We consider IP restrictions a good enough security check on their use.
+
+    """
+    elastic_ip = get_elastic_ip()
+
+    yield from _create_sas_uris(
+        connection_string=connection_string,
+        expiry=None,
+        ip=elastic_ip
+    )

--- a/scripts/azure_create_replicator_credentials.py
+++ b/scripts/azure_create_replicator_credentials.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     log_event("Looking up your storage accounts...")
     storage_accounts = get_storage_accounts()
     log_outcome(
-        f"You have access to {len(storage_accounts)} storage account{'s' if len(storage_accounts) != 1 else ''}",
+        f"You have access to {len(storage_accounts)} storage account{'s' if len(storage_accounts) != 1 else ''}"
     )
 
     for account in storage_accounts:

--- a/scripts/azure_create_replicator_credentials.py
+++ b/scripts/azure_create_replicator_credentials.py
@@ -12,6 +12,8 @@ by rotating the storage Access Key in the Azure console.
 
 """
 
+import sys
+
 import termcolor
 
 from _aws import store_secret
@@ -27,10 +29,11 @@ def log_outcome(s):
 
 
 if __name__ == "__main__":
-    log_event("Logging in to Azure...")
-    az("login")
+    if "--skip-login" not in sys.argv:
+        log_event("Logging in to Azure...")
+        az("login")
 
-    print("")
+        print("")
 
     log_event("Looking up your storage accounts...")
     storage_accounts = get_storage_accounts()

--- a/scripts/azure_renew_storage_keys.py
+++ b/scripts/azure_renew_storage_keys.py
@@ -1,0 +1,70 @@
+"""
+Regenerate the account keys for our Azure storage account.
+
+Use this script if you suspect the keys have been leaked or compromised.
+
+It will automatically regenerate new credentials for the replicator unless you
+tell it not to by passing --skip-replicator-credentials as a flag.
+"""
+
+import subprocess
+import sys
+
+import termcolor
+
+from _azure import az, get_storage_accounts
+
+
+def log_event(s):
+    print(termcolor.colored(s, "blue"))
+
+
+def log_outcome(s):
+    print(termcolor.colored(s, "yellow"))
+
+
+if __name__ == "__main__":
+    if "--skip-login" not in sys.argv:
+        log_event("Logging in to Azure...")
+        az("login")
+
+        print("")
+
+    log_event("Looking up your storage accounts...")
+    storage_accounts = get_storage_accounts()
+    log_outcome(
+        f"You have access to {len(storage_accounts)} storage account{'s' if len(storage_accounts) != 1 else ''}",
+    )
+
+    for account in storage_accounts:
+        print("")
+        account_name = account["name"]
+        resource_group = account["resourceGroup"]
+        log_event(f"Renewing account keys for {account_name}...")
+
+        for key in ("primary", "secondary"):
+            az(
+                "storage",
+                "account",
+                "keys",
+                "renew",
+                "--key",
+                key,
+                "--account-name",
+                account_name,
+                "--resource-group",
+                resource_group,
+            )
+
+        log_outcome(f"Renewed primary and secondary account keys for {account_name}")
+
+    print("")
+
+    if "--skip-replicator-credentials" in sys.argv:
+        log_event("Not creating new replicator credentials")
+    else:
+        log_event("Creating new replicator credentials")
+        print("")
+        subprocess.check_call([
+            sys.executable, "azure_create_replicator_credentials.py", "--skip-login"
+        ])

--- a/scripts/azure_renew_storage_keys.py
+++ b/scripts/azure_renew_storage_keys.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     log_event("Looking up your storage accounts...")
     storage_accounts = get_storage_accounts()
     log_outcome(
-        f"You have access to {len(storage_accounts)} storage account{'s' if len(storage_accounts) != 1 else ''}",
+        f"You have access to {len(storage_accounts)} storage account{'s' if len(storage_accounts) != 1 else ''}"
     )
 
     for account in storage_accounts:
@@ -65,6 +65,6 @@ if __name__ == "__main__":
     else:
         log_event("Creating new replicator credentials")
         print("")
-        subprocess.check_call([
-            sys.executable, "azure_create_replicator_credentials.py", "--skip-login"
-        ])
+        subprocess.check_call(
+            [sys.executable, "azure_create_replicator_credentials.py", "--skip-login"]
+        )


### PR DESCRIPTION
This patch includes two scripts:

* `azure_create_replicator_credentials.py` will log you in using the Azure CLI, create an SAS URI for our two storage accounts that's IP-limited to our Elastic IPs, then put a copy of that URI in Secrets Manager
* `azure_renew_storage_keys.py` will renew our storage account keys, effectively revoking the existing SAS URIs. It then calls the first script to create a new set of replicator credentials.

Part of https://github.com/wellcomecollection/platform/issues/4658