### PR TITLE
Grant container-level Azure permissions to the replicator/verifier, not blob-level

### DIFF
--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -46,7 +46,7 @@ def should_run_sbt_project(repo, project_name, changed_paths):
         if path.startswith((".travis", "docs/")):
             continue
 
-        if path.endswith(".tf"):
+        if path.endswith((".py", ".tf")):
             continue
 
         if path.startswith(("python_client/", "nginx/")):

--- a/scripts/_azure.py
+++ b/scripts/_azure.py
@@ -4,7 +4,7 @@ import subprocess
 
 from azure.storage.blob import (
     generate_container_sas,
-    BlobSasPermissions,
+    ContainerSasPermissions,
     BlobServiceClient,
 )
 
@@ -38,7 +38,12 @@ def _create_sas_uris(connection_string, *, expiry, ip):
             # These permissions are fairly blunt -- there's a single "write"
             # permission for any modifications to a blob, whether that's the
             # content or the metadata.
-            permission=BlobSasPermissions(read=True, write=True, delete=False),
+            permission=ContainerSasPermissions(
+                read=True,
+                write=True,
+                delete=False,
+                list=True
+            ),
         )
 
         yield (container_name, f"{blob_service_client.url}?{token}")

--- a/scripts/_azure.py
+++ b/scripts/_azure.py
@@ -39,10 +39,7 @@ def _create_sas_uris(connection_string, *, expiry, ip):
             # permission for any modifications to a blob, whether that's the
             # content or the metadata.
             permission=ContainerSasPermissions(
-                read=True,
-                write=True,
-                delete=False,
-                list=True
+                read=True, write=True, delete=False, list=True
             ),
         )
 


### PR DESCRIPTION
I tested the connection strings this script generates with a local version of AzureListing, and I was able to see blobs in the staging container. I then regenerated all the keys, so the plaintext string on my machine is useless now.

Closes https://github.com/wellcomecollection/platform/issues/4658, closes https://github.com/wellcomecollection/platform/issues/4719