### PR TITLE
FixityListChecker always checks for fetch files in S3

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.platform.archive.common.verify.Checksum
 
-sealed trait ExpectedFileFixity{
+sealed trait ExpectedFileFixity {
   val uri: URI
   val path: BagPath
   val checksum: Checksum

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
@@ -4,9 +4,23 @@ import java.net.URI
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.platform.archive.common.verify.Checksum
 
-case class ExpectedFileFixity(
+sealed trait ExpectedFileFixity{
+  val uri: URI
+  val path: BagPath
+  val checksum: Checksum
+  val length: Option[Long]
+}
+
+case class FetchFileFixity(
   uri: URI,
   path: BagPath,
   checksum: Checksum,
   length: Option[Long]
-)
+) extends ExpectedFileFixity
+
+case class DataDirectoryFileFixity(
+  uri: URI,
+  path: BagPath,
+  checksum: Checksum,
+  length: Option[Long]
+) extends ExpectedFileFixity

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/ExpectedFileFixity.scala
@@ -21,6 +21,7 @@ case class FetchFileFixity(
 case class DataDirectoryFileFixity(
   uri: URI,
   path: BagPath,
-  checksum: Checksum,
-  length: Option[Long]
-) extends ExpectedFileFixity
+  checksum: Checksum
+) extends ExpectedFileFixity {
+  val length: Option[Long] = None
+}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -25,7 +25,8 @@ class FixityListChecker[BagLocation <: Location, Container](
         expectedFileFixities
           .map {
             case f: FetchFileFixity => fetchEntriesFixityChecker.check(f)
-            case d: DataDirectoryFileFixity => dataDirectoryFixityChecker.check(d)
+            case d: DataDirectoryFileFixity =>
+              dataDirectoryFixityChecker.check(d)
           }
           .foldLeft[FixityListCheckingResult[BagLocation]](
             FixityListAllCorrect(Nil)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -21,8 +21,8 @@ class FixityListChecker[BagLocation <: Location, Container](
     debug(s"Checking the fixity info for $container")
     verifiable.create(container) match {
       case Left(err) => CouldNotCreateExpectedFixityList(err.msg)
-      case Right(verifiableLocations) =>
-        verifiableLocations
+      case Right(expectedFileFixities) =>
+        expectedFileFixities
           .map {
             case f: FetchFileFixity => fetchEntriesFixityChecker.check(f)
             case d: DataDirectoryFileFixity => dataDirectoryFixityChecker.check(d)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -3,10 +3,10 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity.bag
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   CannotCreateExpectedFixity,
+  DataDirectoryFileFixity,
   ExpectedFileFixity,
   ExpectedFixity,
-  FetchFileFixity,
-  DataDirectoryFileFixity
+  FetchFileFixity
 }
 import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   Locatable,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -80,8 +80,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
               DataDirectoryFileFixity(
                 uri = resolvable.resolve(location),
                 path = bagPath,
-                checksum = checksum,
-                length = None
+                checksum = checksum
               )
             )
         }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixity.scala
@@ -4,7 +4,9 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   CannotCreateExpectedFixity,
   ExpectedFileFixity,
-  ExpectedFixity
+  ExpectedFixity,
+  FetchFileFixity,
+  DataDirectoryFileFixity
 }
 import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   Locatable,
@@ -62,7 +64,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
           Some(fetchEntry)
           ) =>
         Right(
-          ExpectedFileFixity(
+          FetchFileFixity(
             uri = fetchEntry.uri,
             path = bagPath,
             checksum = checksum,
@@ -75,7 +77,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
           case Left(e) => Left(CannotCreateExpectedFixity(e.msg))
           case Right(location) =>
             Right(
-              ExpectedFileFixity(
+              DataDirectoryFileFixity(
                 uri = resolvable.resolve(location),
                 path = bagPath,
                 checksum = checksum,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
+import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityChecker,
   FixityListChecker,
@@ -18,6 +19,7 @@ trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
 ]] {
   implicit val resolvable: Resolvable[BagLocation]
   implicit val fixityChecker: FixityChecker[BagLocation]
+  implicit val s3Client: AmazonS3
 
   def verifyChecksumAndSize(
     root: BagPrefix,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -166,7 +166,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-        val expectedFileFixity = createDataDirectoryFileFixityWith(
+        val expectedFileFixity = createFetchFileFixityWith(
           location = location,
           checksum = checksum,
           length = Some(contentString.getBytes().length - 1)
@@ -208,8 +208,7 @@ trait FixityCheckerTestCases[
 
         val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
-          checksum = checksum,
-          length = Some(contentString.getBytes().length)
+          checksum = checksum
         )
 
         putString(location, contentString)
@@ -381,7 +380,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createDataDirectoryFileFixityWith(
+          val expectedFileFixity = createFetchFileFixityWith(
             location = location,
             checksum = checksum
           )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -71,7 +71,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         putString(location, contentString)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum
         )
@@ -97,7 +97,7 @@ trait FixityCheckerTestCases[
 
         val location = createLocationWith(namespace)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum
         )
@@ -129,7 +129,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         putString(location, randomAlphanumeric)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum
         )
@@ -166,7 +166,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum,
           length = Some(contentString.getBytes().length - 1)
@@ -206,7 +206,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum,
           length = Some(contentString.getBytes().length)
@@ -241,7 +241,7 @@ trait FixityCheckerTestCases[
         val location = createLocationWith(namespace)
         val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-        val expectedFileFixity = createExpectedFileFixityWith(
+        val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
           checksum = checksum
         )
@@ -273,7 +273,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createExpectedFileFixityWith(
+          val expectedFileFixity = createDataDirectoryFileFixityWith(
             location = location,
             checksum = checksum
           )
@@ -300,7 +300,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createExpectedFileFixityWith(
+          val expectedFileFixity = createDataDirectoryFileFixityWith(
             location = location,
             checksum = checksum
           )
@@ -335,7 +335,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createExpectedFileFixityWith(
+          val expectedFileFixity = createDataDirectoryFileFixityWith(
             location = location,
             checksum = checksum
           )
@@ -381,7 +381,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createExpectedFileFixityWith(
+          val expectedFileFixity = createDataDirectoryFileFixityWith(
             location = location,
             checksum = checksum
           )
@@ -423,7 +423,7 @@ trait FixityCheckerTestCases[
           val location = createLocationWith(namespace)
           putString(location, contentString)
 
-          val expectedFileFixity = createExpectedFileFixityWith(
+          val expectedFileFixity = createDataDirectoryFileFixityWith(
             location = location
           )
 
@@ -465,7 +465,7 @@ trait FixityCheckerTestCases[
 
           withFixityChecker { fixityChecker =>
             allChecksums.foreach { checksum =>
-              val expectedFileFixity = createExpectedFileFixityWith(
+              val expectedFileFixity = createDataDirectoryFileFixityWith(
                 location = location,
                 checksum = checksum
               )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -181,7 +181,8 @@ class FixityCheckerTests
           Right(Identified(location, inputStream))
       }
 
-      val expectedFileFixity = createDataDirectoryFileFixityWith(checksum = checksum)
+      val expectedFileFixity =
+        createDataDirectoryFileFixityWith(checksum = checksum)
 
       val tags = createMemoryTags
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -79,7 +79,7 @@ class FixityCheckerTests
           Right(Identified(location, closedStream))
       }
 
-      val expectedFileFixity = createDataDirectoryFileFixityWith(length = None)
+      val expectedFileFixity = createDataDirectoryFileFixity
 
       val tags = createMemoryTags
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -79,7 +79,7 @@ class FixityCheckerTests
           Right(Identified(location, closedStream))
       }
 
-      val expectedFileFixity = createExpectedFileFixityWith(length = None)
+      val expectedFileFixity = createDataDirectoryFileFixityWith(length = None)
 
       val tags = createMemoryTags
 
@@ -132,7 +132,7 @@ class FixityCheckerTests
       val inputStream = stringCodec.toStream(contentString).right.value
       streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]
 
-      val expectedFileFixity = createExpectedFileFixityWith(
+      val expectedFileFixity = createDataDirectoryFileFixityWith(
         location = location,
         checksum = checksum
       )
@@ -181,7 +181,7 @@ class FixityCheckerTests
           Right(Identified(location, inputStream))
       }
 
-      val expectedFileFixity = createExpectedFileFixityWith(checksum = checksum)
+      val expectedFileFixity = createDataDirectoryFileFixityWith(checksum = checksum)
 
       val tags = createMemoryTags
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
@@ -4,7 +4,11 @@ import java.net.URI
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.ExpectedFileFixity
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  DataDirectoryFileFixity,
+  ExpectedFileFixity,
+  FetchFileFixity
+}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagFetchMetadata,
@@ -201,7 +205,7 @@ class BagExpectedFixityTest
   ): Seq[ExpectedFileFixity] =
     manifestEntries.map {
       case (bagPath, checksumValue) =>
-        ExpectedFileFixity(
+        DataDirectoryFileFixity(
           path = bagPath,
           uri = new URI(root.asLocation(bagPath.toString).toString),
           checksum = Checksum(
@@ -221,12 +225,13 @@ class BagExpectedFixityTest
       case (bagPath, checksumValue) =>
         val fetchMetadata = fetchEntries(bagPath)
 
-        ExpectedFileFixity(
+        FetchFileFixity(
           uri = fetchMetadata.uri,
           path = bagPath,
           checksum = Checksum(
             algorithm = checksumAlgorithm,
             value = checksumValue
+
           ),
           length = fetchMetadata.length
         )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
@@ -211,8 +211,7 @@ class BagExpectedFixityTest
           checksum = Checksum(
             algorithm = checksumAlgorithm,
             value = checksumValue
-          ),
-          length = None
+          )
         )
     }.toSeq
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/bag/BagExpectedFixityTest.scala
@@ -230,7 +230,6 @@ class BagExpectedFixityTest
           checksum = Checksum(
             algorithm = checksumAlgorithm,
             value = checksumValue
-
           ),
           length = fetchMetadata.length
         )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -73,7 +73,7 @@ class S3FixityCheckerTest
   it("fails if the bucket doesn't exist") {
     val location = createS3ObjectLocationWith(bucket = createBucket)
 
-    val expectedFileFixity = createExpectedFileFixityWith(
+    val expectedFileFixity = createDataDirectoryFileFixityWith(
       location = location
     )
 
@@ -97,7 +97,7 @@ class S3FixityCheckerTest
   it("fails if the bucket name is invalid") {
     val location = createS3ObjectLocationWith(bucket = createInvalidBucket)
 
-    val expectedFileFixity = createExpectedFileFixityWith(
+    val expectedFileFixity = createDataDirectoryFileFixityWith(
       location = location
     )
 
@@ -122,7 +122,7 @@ class S3FixityCheckerTest
     withLocalS3Bucket { bucket =>
       val location = createS3ObjectLocationWith(bucket)
 
-      val expectedFileFixity = createExpectedFileFixityWith(
+      val expectedFileFixity = createDataDirectoryFileFixityWith(
         location = location
       )
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.bagverifier.generators
 
 import java.net.URI
 
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.ExpectedFileFixity
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  DataDirectoryFileFixity,
+  ExpectedFileFixity
+}
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
@@ -15,16 +18,16 @@ trait FixityGenerators[BagLocation <: Location] extends StorageRandomThings {
   def resolve(location: BagLocation): URI
 
   def createExpectedFileFixity: ExpectedFileFixity =
-    createExpectedFileFixityWith()
+    createDataDirectoryFileFixityWith()
 
   def createLocation: BagLocation
 
-  def createExpectedFileFixityWith(
+  def createDataDirectoryFileFixityWith(
     location: BagLocation = createLocation,
     checksum: Checksum = randomChecksum,
     length: Option[Long] = None
-  ): ExpectedFileFixity =
-    ExpectedFileFixity(
+  ): DataDirectoryFileFixity =
+    DataDirectoryFileFixity(
       uri = resolve(location),
       path = BagPath(randomAlphanumeric),
       checksum = checksum,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/generators/FixityGenerators.scala
@@ -4,9 +4,9 @@ import java.net.URI
 
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   DataDirectoryFileFixity,
-  ExpectedFileFixity
+  ExpectedFileFixity,
+  FetchFileFixity
 }
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.verify.{Checksum, MD5, SHA256}
 import uk.ac.wellcome.storage.Location
@@ -22,15 +22,28 @@ trait FixityGenerators[BagLocation <: Location] extends StorageRandomThings {
 
   def createLocation: BagLocation
 
-  def createDataDirectoryFileFixityWith(
+  def createFetchFileFixityWith(
     location: BagLocation = createLocation,
     checksum: Checksum = randomChecksum,
     length: Option[Long] = None
-  ): DataDirectoryFileFixity =
-    DataDirectoryFileFixity(
+  ): FetchFileFixity =
+    FetchFileFixity(
       uri = resolve(location),
-      path = BagPath(randomAlphanumeric),
+      path = createBagPath,
       checksum = checksum,
       length = length
     )
+
+  def createDataDirectoryFileFixityWith(
+    location: BagLocation = createLocation,
+    checksum: Checksum = randomChecksum
+  ): DataDirectoryFileFixity =
+    DataDirectoryFileFixity(
+      uri = resolve(location),
+      path = createBagPath,
+      checksum = checksum
+    )
+
+  def createDataDirectoryFileFixity: DataDirectoryFileFixity =
+    createDataDirectoryFileFixityWith()
 }


### PR DESCRIPTION
Part of wellcomecollection/platform#4595. Extracted as a standalone piece from #669; follows #682.

This is @alicefuzier’s commit https://github.com/wellcomecollection/storage-service/pull/669/commits/3d2e3b7c762c624683ead63200509b3d348213ae cherry-picked into its own branch, as another piece that can be reviewed and merged separately.

She realised that when we verify bags in Azure, we'll need to use a different fixity checker depending on whether the file is from a fetch.txt (so in S3) or in the data directory (so in Azure). Although this is really only useful when we have an Azure fixity checker, we can do that in a separate PR, and further reduce the size of #669.

I made one change – the DataDirectoryFileFixity will never have an expected size, so we can hard-code it as None rather than get it through the constructor.