### PR TITLE
Pull out a bit more test refactoring

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -410,7 +410,7 @@ class StorageManifestServiceTest
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
 
-        override protected def buildFetchEntryLine(
+        override def buildFetchEntryLine(
           entry: PayloadEntry
         )(implicit bucket: Bucket): String =
           s"""s3://$bucket/${entry.path} ${entry.contents.getBytes.length} ${entry.bagPath}"""

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -22,7 +22,8 @@ import scala.util.{Failure, Success}
 /** Look up and check the fixity info (checksum, size) on an individual file.
   *
   */
-trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] extends Logging {
+trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
+    extends Logging {
   protected val streamStore: StreamStore[BagLocation]
   protected val sizeFinder: SizeFinder[BagLocation]
   val tags: Tags[BagLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -3,8 +3,9 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity
 import java.net.URI
 
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable._
 import uk.ac.wellcome.platform.archive.bagverifier.storage.{
-  LocateFailure,
+  Locatable,
   LocationError,
   LocationNotFound,
   LocationParsingError
@@ -14,19 +15,18 @@ import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.tags.Tags
-import uk.ac.wellcome.storage.{DoesNotExistError, Location, ReadError}
+import uk.ac.wellcome.storage.{DoesNotExistError, Location, Prefix, ReadError}
 
 import scala.util.{Failure, Success}
 
 /** Look up and check the fixity info (checksum, size) on an individual file.
   *
   */
-trait FixityChecker[BagLocation <: Location] extends Logging {
+trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] extends Logging {
   protected val streamStore: StreamStore[BagLocation]
   protected val sizeFinder: SizeFinder[BagLocation]
   val tags: Tags[BagLocation]
-
-  def locate(uri: URI): Either[LocateFailure[URI], BagLocation]
+  implicit val locator: Locatable[BagLocation, BagPrefix, URI]
 
   def check(
     expectedFileFixity: ExpectedFileFixity
@@ -81,7 +81,7 @@ trait FixityChecker[BagLocation <: Location] extends Logging {
   private def parseLocation(
     expectedFileFixity: ExpectedFileFixity
   ): Either[FileFixityCouldNotRead[BagLocation], BagLocation] =
-    locate(expectedFileFixity.uri) match {
+    expectedFileFixity.uri.locate match {
       case Right(location) => Right(location)
       case Left(locateError) =>
         Left(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -3,17 +3,17 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.s3.S3FixityChecker
-import uk.ac.wellcome.storage.Location
+import uk.ac.wellcome.storage.{Location, Prefix}
 
 /** Given some Container of files, get the expected fixity information for every
   * file in the container, then verify the fixity on each of them.
   *
   */
-class FixityListChecker[BagLocation <: Location, Container](
+class FixityListChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation],Container](
   implicit
   verifiable: ExpectedFixity[Container],
   s3Client: AmazonS3,
-  dataDirectoryFixityChecker: FixityChecker[BagLocation]
+  dataDirectoryFixityChecker: FixityChecker[BagLocation, BagPrefix]
 ) extends Logging {
   val fetchEntriesFixityChecker = new S3FixityChecker()
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -9,7 +9,9 @@ import uk.ac.wellcome.storage.{Location, Prefix}
   * file in the container, then verify the fixity on each of them.
   *
   */
-class FixityListChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation],Container](
+class FixityListChecker[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+], Container](
   implicit
   verifiable: ExpectedFixity[Container],
   s3Client: AmazonS3,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -3,26 +3,34 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity.memory
 import java.net.URI
 
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
-import uk.ac.wellcome.platform.archive.bagverifier.storage.LocateFailure
+import uk.ac.wellcome.platform.archive.bagverifier.storage.{
+  Locatable,
+  LocateFailure
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
 import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemorySizeFinder
-import uk.ac.wellcome.storage.providers.memory.MemoryLocation
+import uk.ac.wellcome.storage.providers.memory.{
+  MemoryLocation,
+  MemoryLocationPrefix
+}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityChecker(
   val streamStore: MemoryStreamStore[MemoryLocation],
   val tags: MemoryTags[MemoryLocation]
-) extends FixityChecker[MemoryLocation] {
+) extends FixityChecker[MemoryLocation, MemoryLocationPrefix] {
 
   override protected val sizeFinder: SizeFinder[MemoryLocation] =
     new MemorySizeFinder(streamStore.memoryStore)
 
-  override def locate(uri: URI): Either[LocateFailure[URI], MemoryLocation] =
-    Right(
-      MemoryLocation(
-        namespace = uri.getHost,
-        path = uri.getPath.stripPrefix("/")
+  override implicit val locator: Locatable[MemoryLocation, MemoryLocationPrefix, URI] =
+    new Locatable[MemoryLocation, MemoryLocationPrefix, URI] {
+      override def locate(uri: URI)(maybeRoot: Option[MemoryLocationPrefix]): Either[LocateFailure[URI], MemoryLocation] = Right(
+        MemoryLocation(
+          namespace = uri.getHost,
+          path = uri.getPath.stripPrefix("/")
+        )
       )
-    )
+  }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -24,13 +24,16 @@ class MemoryFixityChecker(
   override protected val sizeFinder: SizeFinder[MemoryLocation] =
     new MemorySizeFinder(streamStore.memoryStore)
 
-  override implicit val locator: Locatable[MemoryLocation, MemoryLocationPrefix, URI] =
+  override implicit val locator
+    : Locatable[MemoryLocation, MemoryLocationPrefix, URI] =
     new Locatable[MemoryLocation, MemoryLocationPrefix, URI] {
-      override def locate(uri: URI)(maybeRoot: Option[MemoryLocationPrefix]): Either[LocateFailure[URI], MemoryLocation] = Right(
+      override def locate(uri: URI)(
+        maybeRoot: Option[MemoryLocationPrefix]
+      ): Either[LocateFailure[URI], MemoryLocation] = Right(
         MemoryLocation(
           namespace = uri.getHost,
           path = uri.getPath.stripPrefix("/")
         )
       )
-  }
+    }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -5,20 +5,18 @@ import java.net.URI
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
-import uk.ac.wellcome.platform.archive.bagverifier.storage.LocateFailure
+import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable
+import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Locatable
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3SizeFinder
-import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.s3.S3Tags
 
 class S3FixityChecker(implicit s3Client: AmazonS3)
-    extends FixityChecker[S3ObjectLocation]
+    extends FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix]
     with Logging {
-
-  import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable._
-  import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Locatable._
 
   override protected val streamStore: StreamStore[S3ObjectLocation] =
     new S3StreamStore()
@@ -27,7 +25,5 @@ class S3FixityChecker(implicit s3Client: AmazonS3)
     new S3SizeFinder()
 
   override val tags: Tags[S3ObjectLocation] = new S3Tags()
-
-  override def locate(uri: URI): Either[LocateFailure[URI], S3ObjectLocation] =
-    uri.locate
+  override implicit val locator: Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] = S3Locatable.s3UriLocatable
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -25,5 +25,7 @@ class S3FixityChecker(implicit s3Client: AmazonS3)
     new S3SizeFinder()
 
   override val tags: Tags[S3ObjectLocation] = new S3Tags()
-  override implicit val locator: Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] = S3Locatable.s3UriLocatable
+  override implicit val locator
+    : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
+    S3Locatable.s3UriLocatable
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -67,7 +67,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
   implicit val bagReader: BagReader[BagLocation, BagPrefix]
   implicit val listing: Listing[BagPrefix, BagLocation]
   implicit val resolvable: Resolvable[BagLocation]
-  implicit val fixityChecker: FixityChecker[BagLocation]
+  implicit val fixityChecker: FixityChecker[BagLocation, BagPrefix]
 
   def verifyReplicatedBag(
     root: BagContext,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -35,7 +35,7 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
   override implicit val resolvable: Resolvable[S3ObjectLocation] =
     new S3Resolvable()
 
-  override implicit val fixityChecker: FixityChecker[S3ObjectLocation] =
+  override implicit val fixityChecker: FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix] =
     new S3FixityChecker()
 
   override implicit val listing

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -35,7 +35,8 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
   override implicit val resolvable: Resolvable[S3ObjectLocation] =
     new S3Resolvable()
 
-  override implicit val fixityChecker: FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix] =
+  override implicit val fixityChecker
+    : FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix] =
     new S3FixityChecker()
 
   override implicit val listing

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -18,7 +18,7 @@ trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
 ]] {
   implicit val resolvable: Resolvable[BagLocation]
-  implicit val fixityChecker: FixityChecker[BagLocation]
+  implicit val fixityChecker: FixityChecker[BagLocation, BagPrefix]
   implicit val s3Client: AmazonS3
 
   def verifyChecksumAndSize(
@@ -28,7 +28,7 @@ trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
     implicit val bagExpectedFixity: BagExpectedFixity[BagLocation, BagPrefix] =
       new BagExpectedFixity[BagLocation, BagPrefix](root)
 
-    implicit val fixityListChecker: FixityListChecker[BagLocation, Bag] =
+    implicit val fixityListChecker: FixityListChecker[BagLocation, BagPrefix, Bag] =
       new FixityListChecker()
 
     Try { fixityListChecker.check(bag) } match {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyChecksumAndSize.scala
@@ -28,7 +28,8 @@ trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
     implicit val bagExpectedFixity: BagExpectedFixity[BagLocation, BagPrefix] =
       new BagExpectedFixity[BagLocation, BagPrefix](root)
 
-    implicit val fixityListChecker: FixityListChecker[BagLocation, BagPrefix, Bag] =
+    implicit val fixityListChecker
+      : FixityListChecker[BagLocation, BagPrefix, Bag] =
       new FixityListChecker()
 
     Try { fixityListChecker.check(bag) } match {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -49,7 +49,9 @@ trait FixityCheckerTestCases[
     implicit context: Context
   ): R
 
-  def withFixityChecker[R](testWith: TestWith[FixityChecker[BagLocation, BagPrefix], R])(
+  def withFixityChecker[R](
+    testWith: TestWith[FixityChecker[BagLocation, BagPrefix], R]
+  )(
     implicit context: Context
   ): R =
     withStreamStore { streamStore =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTestCases.scala
@@ -9,12 +9,13 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.bagverifier.storage.LocationNotFound
 import uk.ac.wellcome.platform.archive.common.verify._
-import uk.ac.wellcome.storage.{Identified, Location}
+import uk.ac.wellcome.storage.{Identified, Location, Prefix}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
 trait FixityCheckerTestCases[
   BagLocation <: Location,
+  BagPrefix <: Prefix[BagLocation],
   Namespace,
   Context,
   StreamStoreImpl <: StreamStore[BagLocation]
@@ -39,7 +40,7 @@ trait FixityCheckerTestCases[
   ): Unit
 
   def withFixityChecker[R](streamStore: StreamStoreImpl)(
-    testWith: TestWith[FixityChecker[BagLocation], R]
+    testWith: TestWith[FixityChecker[BagLocation, BagPrefix], R]
   )(
     implicit context: Context
   ): R
@@ -48,7 +49,7 @@ trait FixityCheckerTestCases[
     implicit context: Context
   ): R
 
-  def withFixityChecker[R](testWith: TestWith[FixityChecker[BagLocation], R])(
+  def withFixityChecker[R](testWith: TestWith[FixityChecker[BagLocation, BagPrefix], R])(
     implicit context: Context
   ): R =
     withStreamStore { streamStore =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -9,6 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.memory.MemoryFixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.generators.FixityGenerators
 import uk.ac.wellcome.platform.archive.bagverifier.storage.{
+  Locatable,
   LocateFailure,
   LocationParsingError
 }
@@ -19,7 +20,10 @@ import uk.ac.wellcome.platform.archive.common.verify.{
   MD5
 }
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.providers.memory.MemoryLocation
+import uk.ac.wellcome.storage.providers.memory.{
+  MemoryLocation,
+  MemoryLocationPrefix
+}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStore}
 import uk.ac.wellcome.storage.streaming.Codec.stringCodec
 import uk.ac.wellcome.storage.streaming.{Codec, InputStreamWithLength}
@@ -45,10 +49,12 @@ class FixityCheckerTests
       val tags = createMemoryTags
 
       val brokenChecker = new MemoryFixityChecker(streamStore, tags) {
-        override def locate(
-          uri: URI
-        ): Either[LocateFailure[URI], MemoryLocation] =
-          Left(LocationParsingError(uri, msg = "BOOM!"))
+        override val locator = new Locatable[MemoryLocation, MemoryLocationPrefix, URI] {
+          def locate(
+            uri: URI
+          )(maybeRoot: Option[MemoryLocationPrefix]): Either[LocateFailure[URI], MemoryLocation] =
+            Left(LocationParsingError(uri, msg = "BOOM!"))
+        }
       }
 
       val expectedFileFixity = createExpectedFileFixity

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -49,12 +49,15 @@ class FixityCheckerTests
       val tags = createMemoryTags
 
       val brokenChecker = new MemoryFixityChecker(streamStore, tags) {
-        override val locator = new Locatable[MemoryLocation, MemoryLocationPrefix, URI] {
-          def locate(
-            uri: URI
-          )(maybeRoot: Option[MemoryLocationPrefix]): Either[LocateFailure[URI], MemoryLocation] =
-            Left(LocationParsingError(uri, msg = "BOOM!"))
-        }
+        override val locator =
+          new Locatable[MemoryLocation, MemoryLocationPrefix, URI] {
+            def locate(
+              uri: URI
+            )(
+              maybeRoot: Option[MemoryLocationPrefix]
+            ): Either[LocateFailure[URI], MemoryLocation] =
+              Left(LocationParsingError(uri, msg = "BOOM!"))
+          }
       }
 
       val expectedFileFixity = createExpectedFileFixity

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityCheckerTestCases
 }
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.providers.memory.MemoryLocation
+import uk.ac.wellcome.storage.providers.memory.{
+  MemoryLocation,
+  MemoryLocationPrefix
+}
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
@@ -17,6 +20,7 @@ import uk.ac.wellcome.storage.tags.memory.MemoryTags
 class MemoryFixityCheckerTest
     extends FixityCheckerTestCases[
       MemoryLocation,
+    MemoryLocationPrefix,
       String,
       (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation]),
       MemoryStreamStore[MemoryLocation]
@@ -66,7 +70,7 @@ class MemoryFixityCheckerTest
   override def withFixityChecker[R](
     streamStore: MemoryStreamStore[MemoryLocation]
   )(
-    testWith: TestWith[FixityChecker[MemoryLocation], R]
+    testWith: TestWith[FixityChecker[MemoryLocation, MemoryLocationPrefix], R]
   )(implicit context: MemoryContext): R = {
     val (_, tags) = context
     testWith(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.storage.tags.memory.MemoryTags
 class MemoryFixityCheckerTest
     extends FixityCheckerTestCases[
       MemoryLocation,
-    MemoryLocationPrefix,
+      MemoryLocationPrefix,
       String,
       (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation]),
       MemoryStreamStore[MemoryLocation]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -22,7 +22,7 @@ import uk.ac.wellcome.storage.store.s3.S3StreamStore
 class S3FixityCheckerTest
     extends FixityCheckerTestCases[
       S3ObjectLocation,
-    S3ObjectLocationPrefix,
+      S3ObjectLocationPrefix,
       Bucket,
       Unit,
       S3StreamStore
@@ -50,7 +50,10 @@ class S3FixityCheckerTest
   override def withFixityChecker[R](
     s3Store: S3StreamStore
   )(
-    testWith: TestWith[FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix], R]
+    testWith: TestWith[
+      FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix],
+      R
+    ]
   )(implicit context: Unit): R =
     testWith(new S3FixityChecker() {
       override val streamStore: StreamStore[S3ObjectLocation] = s3Store

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityCheckerTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.{
   LocationError,
   LocationNotFound
 }
-import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.StreamStore
@@ -22,6 +22,7 @@ import uk.ac.wellcome.storage.store.s3.S3StreamStore
 class S3FixityCheckerTest
     extends FixityCheckerTestCases[
       S3ObjectLocation,
+    S3ObjectLocationPrefix,
       Bucket,
       Unit,
       S3StreamStore
@@ -49,7 +50,7 @@ class S3FixityCheckerTest
   override def withFixityChecker[R](
     s3Store: S3StreamStore
   )(
-    testWith: TestWith[FixityChecker[S3ObjectLocation], R]
+    testWith: TestWith[FixityChecker[S3ObjectLocation, S3ObjectLocationPrefix], R]
   )(implicit context: Unit): R =
     testWith(new S3FixityChecker() {
       override val streamStore: StreamStore[S3ObjectLocation] = s3Store

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -136,11 +136,15 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
       withTypedStore { implicit typedStore =>
         val space = createStorageSpace
 
-        val (bagObjects, bagRoot, bagInfo) = replicaBagBuilder.createBagContentsWith(
-          space = space,
-          payloadFileCount = payloadFileCount
+        val (bagObjects, bagRoot, bagInfo) =
+          replicaBagBuilder.createBagContentsWith(
+            space = space,
+            payloadFileCount = payloadFileCount
+          )
+        replicaBagBuilder.uploadBagObjects(
+          bagRoot = bagRoot,
+          objects = bagObjects
         )
-        replicaBagBuilder.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
 
         val ingestStep =
           withBagContext(bagRoot) { bagContext =>
@@ -304,7 +308,10 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val (bagObjects, bagRoot, _) = replicaBagBuilder.createBagContentsWith(
           externalIdentifier = bagInfoExternalIdentifier
         )
-        replicaBagBuilder.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+        replicaBagBuilder.uploadBagObjects(
+          bagRoot = bagRoot,
+          objects = bagObjects
+        )
 
         val ingestStep =
           withBagContext(bagRoot) { bagContext =>
@@ -552,7 +559,10 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
           val (bagObjects, bagRoot, bagInfo) =
             replicaBagBuilder.createBagContentsWith(space = space)
-          replicaBagBuilder.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+          replicaBagBuilder.uploadBagObjects(
+            bagRoot = bagRoot,
+            objects = bagObjects
+          )
 
           val location = bagRoot.asLocation("tagmanifest-sha512.txt")
           writeFile(location)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -7,22 +7,14 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
   StandaloneBagVerifyContext
 }
 import uk.ac.wellcome.platform.archive.bagverifier.services._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagBuilder,
-  PayloadEntry
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 trait S3BagVerifierTests[Verifier <: BagVerifier[
   BagContext,
@@ -49,30 +41,6 @@ trait S3BagVerifierTests[Verifier <: BagVerifier[
 
   override def createId(implicit bucket: Bucket): S3ObjectLocation =
     createS3ObjectLocationWith(bucket)
-
-  override def createBagRootImpl(
-    space: StorageSpace,
-    externalIdentifier: ExternalIdentifier,
-    version: BagVersion
-  )(
-    implicit bucket: Bucket
-  ): S3ObjectLocationPrefix =
-    createBagRoot(
-      space = space,
-      externalIdentifier = externalIdentifier,
-      version = version
-    )
-
-  override def createBagLocationImpl(
-    bagRoot: S3ObjectLocationPrefix,
-    path: String
-  ): S3ObjectLocation =
-    createBagLocation(bagRoot, path = path)
-
-  override def buildFetchEntryLineImpl(
-    entry: PayloadEntry
-  )(implicit bucket: Bucket): String =
-    buildFetchEntryLine(entry)
 
   override def writeFile(location: S3ObjectLocation, contents: String): Unit =
     s3Client.putObject(location.bucket, location.key, contents)
@@ -133,11 +101,6 @@ class S3ReplicatedBagVerifierTest
   ): S3ObjectLocationPrefix =
     createS3ObjectLocationPrefixWith(bucket)
 
-  override def createReplicaPrefix(
-    implicit bucket: Bucket
-  ): S3ObjectLocationPrefix =
-    createS3ObjectLocationPrefixWith(bucket)
-
   override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
       testWith(bucket)
@@ -188,4 +151,6 @@ class S3StandaloneBagVerifierTest
     testWith(
       new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
     )
+
+  override val replicaBagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -152,5 +152,7 @@ class S3StandaloneBagVerifierTest
       new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
     )
 
-  override val replicaBagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
+  override val replicaBagBuilder
+    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+    new S3BagBuilder {}
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -148,7 +148,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
       )
     }
 
-  protected def buildFetchEntryLine(
+  def buildFetchEntryLine(
     entry: PayloadEntry
   )(implicit namespace: Namespace): String
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/azure/AzureBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/azure/AzureBagBuilder.scala
@@ -33,7 +33,7 @@ trait AzureBagBuilder
     path: String
   ): AzureBlobLocation = AzureBlobLocation(bagRoot.container, path)
 
-  override protected def buildFetchEntryLine(
+  override def buildFetchEntryLine(
     entry: PayloadEntry
   )(implicit container: Container): String = {
     val displaySize =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/memory/MemoryBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/memory/MemoryBagBuilder.scala
@@ -32,7 +32,7 @@ trait MemoryBagBuilder
       path = DestinationBuilder.buildPath(space, externalIdentifier, version)
     )
 
-  override protected def buildFetchEntryLine(
+  override def buildFetchEntryLine(
     entry: PayloadEntry
   )(implicit namespace: String): String = {
     val displaySize =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -42,7 +42,7 @@ trait S3BagBuilder
       key = path
     )
 
-  override protected def buildFetchEntryLine(
+  override def buildFetchEntryLine(
     entry: PayloadEntry
   )(implicit bucket: Bucket): String = {
     val displaySize =


### PR DESCRIPTION
Part of wellcomecollection/platform#4595. Extracted as a standalone piece from #669.

This was pulled out of ea696bd (“Add AzureReplicatedBagVerifierTests”) and edf4e36 (“Starting to add a AzureFixityChecker”) as some refactoring that lays groundwork for the Azure verifier stuff, but doesn’t change any functionality – lots of diff churn. I’ve read it and I’m confident it is correct and it works.

I'm not sure if we want to merge this as a standalone thing, but I'm putting this as a stick in the ground “I got this far”.