### PR TITLE
Reflect the primacy of S3 in the storage service in the verifier tests

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -159,11 +159,7 @@ trait BagRegisterFixtures
         payloadFileCount = dataFileCount
       )
 
-    uploadBagObjects(
-      bagRoot = bagContents.bagRoot,
-      objects = bagContents.bagObjects,
-      fetchObjects = bagContents.fetchObjects
-    )
+    storeBagContents(bagContents)
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -151,7 +151,7 @@ trait BagRegisterFixtures
     implicit val typedStore: S3TypedStore[String] =
       S3TypedStore[String]
 
-    val (bagObjects, bagRoot, bagInfo) =
+    val bagContents =
       createBagContentsWith(
         space = space,
         externalIdentifier = externalIdentifier,
@@ -159,8 +159,12 @@ trait BagRegisterFixtures
         payloadFileCount = dataFileCount
       )
 
-    uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+    uploadBagObjects(
+      bagRoot = bagContents.bagRoot,
+      objects = bagContents.bagObjects,
+      fetchObjects = bagContents.fetchObjects
+    )
 
-    (bagRoot, bagInfo)
+    (bagContents.bagRoot, bagContents.bagInfo)
   }
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -411,9 +411,10 @@ class StorageManifestServiceTest
           payloadFileCount
 
         override def buildFetchEntryLine(
+          primaryBucket: Bucket,
           entry: PayloadEntry
-        )(implicit bucket: Bucket): String =
-          s"""s3://$bucket/${entry.path} ${entry.contents.getBytes.length} ${entry.bagPath}"""
+        ): String =
+          s"""s3://$primaryBucket/${entry.path} ${entry.contents.getBytes.length} ${entry.bagPath}"""
       }
 
       val version = createBagVersion
@@ -487,17 +488,21 @@ class StorageManifestServiceTest
     implicit val typedStore: S3TypedStore[String] =
       S3TypedStore[String]
 
-    val (bagObjects, bagRoot, _) =
+    val bagContents =
       bagBuilder.createBagContentsWith(
         space = space,
         version = version
       )
 
-    bagBuilder.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+    bagBuilder.uploadBagObjects(
+      bagRoot = bagContents.bagRoot,
+      objects = bagContents.bagObjects,
+      fetchObjects = bagContents.fetchObjects
+    )
 
     (
-      bagRoot,
-      new S3BagReader().get(bagRoot).right.value
+      bagContents.bagRoot,
+      new S3BagReader().get(bagContents.bagRoot).right.value
     )
   }
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -494,11 +494,7 @@ class StorageManifestServiceTest
         version = version
       )
 
-    bagBuilder.uploadBagObjects(
-      bagRoot = bagContents.bagRoot,
-      objects = bagContents.bagObjects,
-      fetchObjects = bagContents.fetchObjects
-    )
+    bagBuilder.storeBagContents(bagContents)
 
     (
       bagContents.bagRoot,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -75,9 +75,7 @@ object BagVerifierWorkerBuilder {
     mc: MetricsMonitoringClient,
     as: ActorSystem,
     sc: SqsAsyncClient
-  ): BagVerifierWorker[BagRootLocationPayload, StandaloneBagVerifyContext[
-    S3ObjectLocationPrefix
-  ], IngestDestination, OutgoingDestination] = {
+  ): BagVerifierWorker[BagRootLocationPayload, StandaloneBagVerifyContext, IngestDestination, OutgoingDestination] = {
     val verifier = new S3StandaloneBagVerifier(primaryBucket)
 
     new BagVerifierWorker(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -104,7 +104,7 @@ object BagVerifierWorkerBuilder {
     sc: SqsAsyncClient
   ): BagVerifierWorker[
     ReplicaCompletePayload,
-    ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix],
+    ReplicatedBagVerifyContext[S3ObjectLocationPrefix],
     IngestDestination,
     OutgoingDestination
   ] = {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/builder/BagVerifierWorkerBuilder.scala
@@ -75,7 +75,12 @@ object BagVerifierWorkerBuilder {
     mc: MetricsMonitoringClient,
     as: ActorSystem,
     sc: SqsAsyncClient
-  ): BagVerifierWorker[BagRootLocationPayload, StandaloneBagVerifyContext, IngestDestination, OutgoingDestination] = {
+  ): BagVerifierWorker[
+    BagRootLocationPayload,
+    StandaloneBagVerifyContext,
+    IngestDestination,
+    OutgoingDestination
+  ] = {
     val verifier = new S3StandaloneBagVerifier(primaryBucket)
 
     new BagVerifierWorker(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagverifier.models
 
+import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.{Location, Prefix}
 
 sealed trait BagVerifyContext[BagPrefix <: Prefix[_ <: Location]] {
@@ -11,9 +12,8 @@ case class StandaloneBagVerifyContext[BagPrefix <: Prefix[_ <: Location]](
 ) extends BagVerifyContext[BagPrefix]
 
 case class ReplicatedBagVerifyContext[
-  SrcBagPrefix <: Prefix[_ <: Location],
   ReplicaBagPrefix <: Prefix[_ <: Location]
-](srcRoot: SrcBagPrefix, replicaRoot: ReplicaBagPrefix)
+](srcRoot: S3ObjectLocationPrefix, replicaRoot: ReplicaBagPrefix)
     extends BagVerifyContext[ReplicaBagPrefix] {
 
   val root: ReplicaBagPrefix = replicaRoot

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/BagVerifyContext.scala
@@ -7,9 +7,9 @@ sealed trait BagVerifyContext[BagPrefix <: Prefix[_ <: Location]] {
   val root: BagPrefix
 }
 
-case class StandaloneBagVerifyContext[BagPrefix <: Prefix[_ <: Location]](
-  root: BagPrefix
-) extends BagVerifyContext[BagPrefix]
+case class StandaloneBagVerifyContext(
+  root: S3ObjectLocationPrefix
+) extends BagVerifyContext[S3ObjectLocationPrefix]
 
 case class ReplicatedBagVerifyContext[
   ReplicaBagPrefix <: Prefix[_ <: Location]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -12,20 +12,19 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.listing.Listing
-import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.{Location, Prefix}
 
 import scala.util.Try
 
-trait StandaloneBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
-  BagLocation
-]] extends BagVerifier[
-      StandaloneBagVerifyContext[BagPrefix],
-      BagLocation,
-      BagPrefix
+trait StandaloneBagVerifier
+  extends BagVerifier[
+      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+      S3ObjectLocation,
+      S3ObjectLocationPrefix
     ] {
   override def verifyReplicatedBag(
-    root: StandaloneBagVerifyContext[BagPrefix],
+    root: StandaloneBagVerifyContext[S3ObjectLocationPrefix],
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
     bag: Bag
@@ -33,18 +32,16 @@ trait StandaloneBagVerifier[BagLocation <: Location, BagPrefix <: Prefix[
 }
 
 trait ReplicatedBagVerifier[
-  SrcBagLocation <: Location,
-  SrcBagPrefix <: Prefix[SrcBagLocation],
   ReplicaBagLocation <: Location,
   ReplicaBagPrefix <: Prefix[ReplicaBagLocation]
 ] extends BagVerifier[
-      ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
+      ReplicatedBagVerifyContext[ReplicaBagPrefix],
       ReplicaBagLocation,
       ReplicaBagPrefix
     ]
-    with VerifySourceTagManifest[SrcBagLocation, ReplicaBagLocation] {
+    with VerifySourceTagManifest[ReplicaBagLocation] {
   override def verifyReplicatedBag(
-    root: ReplicatedBagVerifyContext[SrcBagPrefix, ReplicaBagPrefix],
+    root: ReplicatedBagVerifyContext[ReplicaBagPrefix],
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
     bag: Bag

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -12,24 +12,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.listing.Listing
-import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.{Location, Prefix}
 
 import scala.util.Try
-
-trait StandaloneBagVerifier
-  extends BagVerifier[
-      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
-      S3ObjectLocation,
-      S3ObjectLocationPrefix
-    ] {
-  override def verifyReplicatedBag(
-    root: StandaloneBagVerifyContext[S3ObjectLocationPrefix],
-    space: StorageSpace,
-    externalIdentifier: ExternalIdentifier,
-    bag: Bag
-  ): Either[BagVerifierError, Unit] = Right(())
-}
 
 trait ReplicatedBagVerifier[
   ReplicaBagLocation <: Location,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -4,19 +4,24 @@ import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.s3.S3FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  BagVerifierError,
   BagVerifyContext,
   ReplicatedBagVerifyContext,
   StandaloneBagVerifyContext
 }
 import uk.ac.wellcome.platform.archive.bagverifier.services.{
   BagVerifier,
-  ReplicatedBagVerifier,
-  StandaloneBagVerifier
+  ReplicatedBagVerifier
 }
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Resolvable
 import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  Bag,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.listing.Listing
 import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
 import uk.ac.wellcome.storage.store.StreamStore
@@ -52,8 +57,14 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
 
 class S3StandaloneBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
-) extends StandaloneBagVerifier
-    with S3BagVerifier[StandaloneBagVerifyContext[S3ObjectLocationPrefix]]
+) extends BagVerifier[
+  StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+  S3ObjectLocation,
+  S3ObjectLocationPrefix
+]
+    with S3BagVerifier[StandaloneBagVerifyContext[S3ObjectLocationPrefix]] {
+  override def verifyReplicatedBag(root: StandaloneBagVerifyContext[S3ObjectLocationPrefix], space: StorageSpace, externalIdentifier: ExternalIdentifier, bag: Bag): Either[BagVerifierError, Unit] = Right(())
+}
 
 class S3ReplicatedBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -58,12 +58,17 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
 class S3StandaloneBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
 ) extends BagVerifier[
-  StandaloneBagVerifyContext,
-  S3ObjectLocation,
-  S3ObjectLocationPrefix
-]
+      StandaloneBagVerifyContext,
+      S3ObjectLocation,
+      S3ObjectLocationPrefix
+    ]
     with S3BagVerifier[StandaloneBagVerifyContext] {
-  override def verifyReplicatedBag(root: StandaloneBagVerifyContext, space: StorageSpace, externalIdentifier: ExternalIdentifier, bag: Bag): Either[BagVerifierError, Unit] = Right(())
+  override def verifyReplicatedBag(
+    root: StandaloneBagVerifyContext,
+    space: StorageSpace,
+    externalIdentifier: ExternalIdentifier,
+    bag: Bag
+  ): Either[BagVerifierError, Unit] = Right(())
 }
 
 class S3ReplicatedBagVerifier(val primaryBucket: String)(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -58,12 +58,12 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
 class S3StandaloneBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
 ) extends BagVerifier[
-  StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+  StandaloneBagVerifyContext,
   S3ObjectLocation,
   S3ObjectLocationPrefix
 ]
-    with S3BagVerifier[StandaloneBagVerifyContext[S3ObjectLocationPrefix]] {
-  override def verifyReplicatedBag(root: StandaloneBagVerifyContext[S3ObjectLocationPrefix], space: StorageSpace, externalIdentifier: ExternalIdentifier, bag: Bag): Either[BagVerifierError, Unit] = Right(())
+    with S3BagVerifier[StandaloneBagVerifyContext] {
+  override def verifyReplicatedBag(root: StandaloneBagVerifyContext, space: StorageSpace, externalIdentifier: ExternalIdentifier, bag: Bag): Either[BagVerifierError, Unit] = Right(())
 }
 
 class S3ReplicatedBagVerifier(val primaryBucket: String)(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -52,23 +52,18 @@ trait S3BagVerifier[B <: BagVerifyContext[S3ObjectLocationPrefix]]
 
 class S3StandaloneBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
-) extends StandaloneBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix]
+) extends StandaloneBagVerifier
     with S3BagVerifier[StandaloneBagVerifyContext[S3ObjectLocationPrefix]]
 
 class S3ReplicatedBagVerifier(val primaryBucket: String)(
   implicit val s3Client: AmazonS3
 ) extends ReplicatedBagVerifier[
       S3ObjectLocation,
-      S3ObjectLocationPrefix,
-      S3ObjectLocation,
       S3ObjectLocationPrefix
     ]
     with S3BagVerifier[
-      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
+      ReplicatedBagVerifyContext[S3ObjectLocationPrefix]
     ] {
-
-  override val srcStreamStore: StreamStore[S3ObjectLocation] =
-    new S3StreamStore()
 
   override val replicaStreamStore: StreamStore[S3ObjectLocation] =
     new S3StreamStore()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
@@ -14,7 +14,8 @@ trait VerifySourceTagManifest[
 ] {
   implicit val s3Client: AmazonS3
 
-  protected val srcStreamStore: StreamStore[S3ObjectLocation] = new S3StreamStore()
+  protected val srcStreamStore: StreamStore[S3ObjectLocation] =
+    new S3StreamStore()
   protected val replicaStreamStore: StreamStore[ReplicaBagLocation]
 
   /** This step is here to check the bag created by the replica and the

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifySourceTagManifest.scala
@@ -1,16 +1,20 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
+import com.amazonaws.services.s3.AmazonS3
 import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.{Identified, Location, Prefix}
 
 trait VerifySourceTagManifest[
-  SrcBagLocation <: Location,
   ReplicaBagLocation <: Location
 ] {
-  protected val srcStreamStore: StreamStore[SrcBagLocation]
+  implicit val s3Client: AmazonS3
+
+  protected val srcStreamStore: StreamStore[S3ObjectLocation] = new S3StreamStore()
   protected val replicaStreamStore: StreamStore[ReplicaBagLocation]
 
   /** This step is here to check the bag created by the replica and the
@@ -24,7 +28,7 @@ trait VerifySourceTagManifest[
     *
     */
   def verifySourceTagManifestIsTheSame(
-    srcPrefix: Prefix[SrcBagLocation],
+    srcPrefix: S3ObjectLocationPrefix,
     replicaPrefix: Prefix[ReplicaBagLocation]
   ): Either[BagVerifierError, Unit] = {
     for {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -79,7 +79,6 @@ trait BagVerifierFixtures
     testWith: TestWith[BagVerifierWorker[
       ReplicaCompletePayload,
       ReplicatedBagVerifyContext[
-        S3ObjectLocationPrefix,
         S3ObjectLocationPrefix
       ],
       String,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -104,7 +104,9 @@ trait BagVerifierFixtures
       }
     }
 
-  def withVerifier[R](bucket: Bucket)(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
+  def withVerifier[R](
+    bucket: Bucket
+  )(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
     testWith(
       new S3StandaloneBagVerifier(primaryBucket = bucket.name)
     )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -12,10 +12,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
   StandaloneBagVerifyContext
 }
 import uk.ac.wellcome.platform.archive.bagverifier.services.s3.S3StandaloneBagVerifier
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.BagVerifierWorker
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
   ReplicaCompletePayload
@@ -23,7 +20,7 @@ import uk.ac.wellcome.platform.archive.common.{
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -42,7 +39,7 @@ trait BagVerifierFixtures
   )(
     testWith: TestWith[BagVerifierWorker[
       BagRootLocationPayload,
-      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+      StandaloneBagVerifyContext,
       String,
       String
     ], R]
@@ -107,13 +104,7 @@ trait BagVerifierFixtures
       }
     }
 
-  def withVerifier[R](bucket: Bucket)(
-    testWith: TestWith[BagVerifier[
-      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
-      S3ObjectLocation,
-      S3ObjectLocationPrefix
-    ], R]
-  ): R =
+  def withVerifier[R](bucket: Bucket)(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
     testWith(
       new S3StandaloneBagVerifier(primaryBucket = bucket.name)
     )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -457,7 +457,11 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           bagObjects: Map[BagLocation, String],
           fetchObjects: Map[S3ObjectLocation, String]
         )(implicit typedStore: TypedStore[BagLocation, String]): Unit = {
-          super.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+          super.uploadBagObjects(
+            bagRoot = bagRoot,
+            objects = bagObjects,
+            fetchObjects = fetchObjects
+          )
 
           val location = bagRoot.asLocation("unreferencedfile.txt")
           writeFile(location)
@@ -482,7 +486,11 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           bagObjects: Map[BagLocation, String],
           fetchObjects: Map[S3ObjectLocation, String]
         )(implicit typedStore: TypedStore[BagLocation, String]): Unit = {
-          super.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+          super.uploadBagObjects(
+            bagRoot = bagRoot,
+            objects = bagObjects,
+            fetchObjects = fetchObjects
+          )
 
           (1 to 3).foreach { i =>
             val location = bagRoot.asLocation(s"unreferencedfile_$i.txt")
@@ -510,7 +518,11 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           bagObjects: Map[BagLocation, String],
           fetchObjects: Map[S3ObjectLocation, String]
         )(implicit typedStore: TypedStore[BagLocation, String]): Unit = {
-          super.uploadBagObjects(bagRoot = bagRoot, objects = bagObjects)
+          super.uploadBagObjects(
+            bagRoot = bagRoot,
+            objects = bagObjects,
+            fetchObjects = fetchObjects
+          )
 
           val bag = createBagReader.get(bagRoot).right.value
 
@@ -654,7 +666,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
         result shouldBe a[IngestFailed[_]]
         assertion(result)
-
       }
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -20,7 +20,6 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.{
   BagReader,
   BagUnavailable
 }
-import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   BagBuilder,
   PayloadEntry
@@ -42,28 +41,6 @@ import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.{Location, Prefix}
-
-trait StandaloneBagVerifierTestCases[
-  BagLocation <: Location,
-  BagPrefix <: Prefix[
-    BagLocation
-  ],
-  Namespace
-] extends BagVerifierTestCases[
-      StandaloneBagVerifier,
-      StandaloneBagVerifyContext[BagPrefix],
-      BagLocation,
-      BagPrefix,
-      Namespace
-    ] {
-  override def withBagContext[R](
-    srcBagRoot: S3ObjectLocationPrefix,
-    replicaBagRoot: BagPrefix
-  )(testWith: TestWith[StandaloneBagVerifyContext[BagPrefix], R]): R =
-    testWith(
-      StandaloneBagVerifyContext(replicaBagRoot)
-    )
-}
 
 trait BagVerifierTestCases[Verifier <: BagVerifier[
   BagContext,
@@ -707,83 +684,4 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
       assertion(failedResult, summary)
     }
-}
-
-trait ReplicatedBagVerifierTestCases[
-  ReplicaBagLocation <: Location,
-  ReplicaBagPrefix <: Prefix[ReplicaBagLocation],
-  ReplicaNamespace
-] extends BagVerifierTestCases[
-      ReplicatedBagVerifier[
-        ReplicaBagLocation,
-        ReplicaBagPrefix
-      ],
-      ReplicatedBagVerifyContext[ReplicaBagPrefix],
-      ReplicaBagLocation,
-      ReplicaBagPrefix,
-      ReplicaNamespace
-    ] {
-  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: ReplicaBagPrefix)(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
-    testWith(ReplicatedBagVerifyContext(srcBagRoot,replicaBagRoot))
-
-  it("fails a bag if it doesn't match original tag manifest") {
-    val space = createStorageSpace
-    val externalIdentifier = createExternalIdentifier
-    withTypedStore { implicit typedStore =>
-      withBag(space, externalIdentifier) { case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
-
-        // Scramble the contents of the original tag manifest
-        putStream(srcBagRoot.asLocation("tagmanifest-sha256.txt"))
-
-        val ingestStep =
-          withVerifier(srcBucket) {
-            _.verify(
-              ingestId = createIngestID,
-              bagContext = ReplicatedBagVerifyContext(
-                srcRoot = srcBagRoot,
-                replicaRoot = replicaBagRoot
-              ),
-              space = space,
-              externalIdentifier = externalIdentifier
-            )
-          }
-
-        val result = ingestStep.success.get
-
-        result shouldBe a[IngestFailed[_]]
-        result.summary shouldBe a[VerificationIncompleteSummary]
-
-        result.maybeUserFacingMessage shouldNot be(defined)
-      }
-    }
-  }
-
-  it("fails a bag if it cannot read the original bag") {
-    val space = createStorageSpace
-    val externalIdentifier = createExternalIdentifier
-    withTypedStore { implicit typedStore =>
-      withBag(space, externalIdentifier) {
-        case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
-          val ingestStep =
-            withVerifier(srcBucket) {
-              _.verify(
-                ingestId = createIngestID,
-                bagContext = ReplicatedBagVerifyContext(
-                  srcRoot = srcBagRoot,
-                  replicaRoot = replicaBagRoot
-                ),
-                space = space,
-                externalIdentifier = externalIdentifier
-              )
-            }
-
-          val result = ingestStep.success.get
-
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationIncompleteSummary]
-
-          result.maybeUserFacingMessage shouldNot be(defined)
-      }
-    }
-  }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -129,7 +129,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    withTypedStore { implicit typedStore =>
       withBag(space, externalIdentifier) { case (primaryBucket, bagRoot) =>
         val ingestStep =
           withBagContext(bagRoot) { bagContext =>
@@ -158,7 +157,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         )
       }
     }
-  }
 
   it("fails a bag with an incorrect checksum in the file manifest") {
     val badBuilder: BagBuilderImpl = new BagBuilderImpl {
@@ -288,7 +286,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     val payloadExternalIdentifier =
       ExternalIdentifier(externalIdentifier + "_payload")
 
-    withTypedStore { implicit typedStore =>
       withBag(space, bagInfoExternalIdentifier) { case (primaryBucket, bagRoot) =>
         val ingestStep =
           withBagContext(bagRoot) { bagContext =>
@@ -312,7 +309,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         )
       }
     }
-  }
 
   describe("checks the fetch file") {
     it("fails if the fetch file refers to a file not in the manifest") {
@@ -653,7 +649,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    withTypedStore { implicit typedStore =>
       withBag(space, externalIdentifier, bagBuilder = badBuilder) { case (primaryBucket, bagRoot) =>
         val ingestStep =
           withBagContext(bagRoot) { bagContext =>
@@ -674,7 +669,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         assertion(result)
       }
     }
-  }
 
   private def assertBagIncomplete(badBuilder: BagBuilderImpl)(
     assertion: (

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -56,6 +56,19 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     with StorageSpaceGenerators with BagInfoGenerators
     with NamespaceFixtures[BagLocation, Namespace]
     with S3Fixtures {
+
+  def withTypedStore[R](
+    testWith: TestWith[TypedStore[BagLocation, String], R]
+  ): R
+
+  def withVerifier[R](primaryBucket: Bucket)(
+    testWith: TestWith[Verifier, R]
+  ): R
+
+  def withBagContext[R](bagRoot: BagPrefix)(
+    testWith: TestWith[BagContext, R]
+  ): R
+
   val bagBuilder: BagBuilder[BagLocation, BagPrefix, Namespace]
 
   def withBag[R](space: StorageSpace, externalIdentifier: ExternalIdentifier,
@@ -79,13 +92,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         }
       }
     }
-
-
-  def withTypedStore[R](testWith: TestWith[TypedStore[BagLocation, String], R]): R
-
-  def withVerifier[R](primaryBucket: Bucket)(testWith: TestWith[Verifier, R]): R
-
-  def withBagContext[R](bagRoot: BagPrefix)(testWith: TestWith[BagContext, R]): R
 
   val payloadFileCount: Int = randomInt(from = 1, to = 10)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -1,0 +1,89 @@
+package uk.ac.wellcome.platform.archive.bagverifier.services
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  ReplicatedBagVerifyContext,
+  VerificationIncompleteSummary
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
+import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.{Location, Prefix}
+
+trait ReplicatedBagVerifierTestCases[
+  ReplicaBagLocation <: Location,
+  ReplicaBagPrefix <: Prefix[ReplicaBagLocation],
+  ReplicaNamespace
+] extends BagVerifierTestCases[
+  ReplicatedBagVerifier[
+    ReplicaBagLocation,
+    ReplicaBagPrefix
+    ],
+  ReplicatedBagVerifyContext[ReplicaBagPrefix],
+  ReplicaBagLocation,
+  ReplicaBagPrefix,
+  ReplicaNamespace
+  ] {
+  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: ReplicaBagPrefix)(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
+    testWith(ReplicatedBagVerifyContext(srcBagRoot,replicaBagRoot))
+
+  it("fails a bag if it doesn't match original tag manifest") {
+    val space = createStorageSpace
+    val externalIdentifier = createExternalIdentifier
+    withTypedStore { implicit typedStore =>
+      withBag(space, externalIdentifier) { case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
+
+        // Scramble the contents of the original tag manifest
+        putStream(srcBagRoot.asLocation("tagmanifest-sha256.txt"))
+
+        val ingestStep =
+          withVerifier(srcBucket) {
+            _.verify(
+              ingestId = createIngestID,
+              bagContext = ReplicatedBagVerifyContext(
+                srcRoot = srcBagRoot,
+                replicaRoot = replicaBagRoot
+              ),
+              space = space,
+              externalIdentifier = externalIdentifier
+            )
+          }
+
+        val result = ingestStep.success.get
+
+        result shouldBe a[IngestFailed[_]]
+        result.summary shouldBe a[VerificationIncompleteSummary]
+
+        result.maybeUserFacingMessage shouldNot be(defined)
+      }
+    }
+  }
+
+  it("fails a bag if it cannot read the original bag") {
+    val space = createStorageSpace
+    val externalIdentifier = createExternalIdentifier
+    withTypedStore { implicit typedStore =>
+      withBag(space, externalIdentifier) {
+        case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
+          val ingestStep =
+            withVerifier(srcBucket) {
+              _.verify(
+                ingestId = createIngestID,
+                bagContext = ReplicatedBagVerifyContext(
+                  srcRoot = srcBagRoot,
+                  replicaRoot = replicaBagRoot
+                ),
+                space = space,
+                externalIdentifier = externalIdentifier
+              )
+            }
+
+          val result = ingestStep.success.get
+
+          result shouldBe a[IngestFailed[_]]
+          result.summary shouldBe a[VerificationIncompleteSummary]
+
+          result.maybeUserFacingMessage shouldNot be(defined)
+      }
+    }
+  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -41,10 +41,8 @@ trait ReplicatedBagVerifierTestCases[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    val primaryBucket = createBucketName
     withLocalS3Bucket { srcBucket =>
-      withTypedStore { implicit typedStore =>
-        withBag(space, externalIdentifier, primaryBucket) { replicaBagRoot =>
+        withBag(space, externalIdentifier) { case (primaryBucket, replicaBagRoot) =>
           val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
           S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(randomAlphanumeric)
           val ingestStep =
@@ -67,7 +65,6 @@ trait ReplicatedBagVerifierTestCases[
 
           result.maybeUserFacingMessage shouldNot be(defined)
         }
-      }
     }
   }
 
@@ -75,11 +72,8 @@ trait ReplicatedBagVerifierTestCases[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-
-    val primaryBucket = createBucketName
     withLocalS3Bucket { srcBucket =>
-      withTypedStore { implicit typedStore =>
-        withBag(space, externalIdentifier, primaryBucket) { replicaBagRoot =>
+        withBag(space, externalIdentifier) { case (primaryBucket, replicaBagRoot) =>
           val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
           val ingestStep =
             withVerifier(primaryBucket) {
@@ -103,5 +97,4 @@ trait ReplicatedBagVerifierTestCases[
         }
       }
     }
-  }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -15,16 +15,18 @@ trait ReplicatedBagVerifierTestCases[
   ReplicaBagPrefix <: Prefix[ReplicaBagLocation],
   ReplicaNamespace
 ] extends BagVerifierTestCases[
-  ReplicatedBagVerifier[
-    ReplicaBagLocation,
-    ReplicaBagPrefix
-    ],
-  ReplicatedBagVerifyContext[ReplicaBagPrefix],
-  ReplicaBagLocation,
-  ReplicaBagPrefix,
-  ReplicaNamespace
-] {
-  override def withBagContext[R](replicaBagRoot: ReplicaBagPrefix)(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
+      ReplicatedBagVerifier[
+        ReplicaBagLocation,
+        ReplicaBagPrefix
+      ],
+      ReplicatedBagVerifyContext[ReplicaBagPrefix],
+      ReplicaBagLocation,
+      ReplicaBagPrefix,
+      ReplicaNamespace
+    ] {
+  override def withBagContext[R](
+    replicaBagRoot: ReplicaBagPrefix
+  )(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
     withLocalS3Bucket { srcBucket =>
       withTypedStore { implicit typedStore =>
         val srcBagRoot = S3ObjectLocationPrefix(
@@ -33,8 +35,12 @@ trait ReplicatedBagVerifierTestCases[
         )
 
         val _ = for {
-          tagManifestContents <- typedStore.get(replicaBagRoot.asLocation("tagmanifest-sha256.txt"))
-          _ <- S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(tagManifestContents.identifiedT)
+          tagManifestContents <- typedStore.get(
+            replicaBagRoot.asLocation("tagmanifest-sha256.txt")
+          )
+          _ <- S3TypedStore[String].put(
+            srcBagRoot.asLocation("tagmanifest-sha256.txt")
+          )(tagManifestContents.identifiedT)
         } yield ()
 
         testWith(ReplicatedBagVerifyContext(srcBagRoot, replicaBagRoot))
@@ -46,9 +52,13 @@ trait ReplicatedBagVerifierTestCases[
     val externalIdentifier = createExternalIdentifier
 
     withLocalS3Bucket { srcBucket =>
-        withBag(space, externalIdentifier) { case (primaryBucket, replicaBagRoot) =>
-          val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
-          S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(randomAlphanumeric)
+      withBag(space, externalIdentifier) {
+        case (primaryBucket, replicaBagRoot) =>
+          val srcBagRoot =
+            S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
+          S3TypedStore[String].put(
+            srcBagRoot.asLocation("tagmanifest-sha256.txt")
+          )(randomAlphanumeric)
           val ingestStep =
             withVerifier(primaryBucket) {
               _.verify(
@@ -68,7 +78,7 @@ trait ReplicatedBagVerifierTestCases[
           result.summary shouldBe a[VerificationIncompleteSummary]
 
           result.maybeUserFacingMessage shouldNot be(defined)
-        }
+      }
     }
   }
 
@@ -77,8 +87,10 @@ trait ReplicatedBagVerifierTestCases[
     val externalIdentifier = createExternalIdentifier
 
     withLocalS3Bucket { srcBucket =>
-        withBag(space, externalIdentifier) { case (primaryBucket, replicaBagRoot) =>
-          val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
+      withBag(space, externalIdentifier) {
+        case (primaryBucket, replicaBagRoot) =>
+          val srcBagRoot =
+            S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
           val ingestStep =
             withVerifier(primaryBucket) {
               _.verify(
@@ -98,7 +110,7 @@ trait ReplicatedBagVerifierTestCases[
           result.summary shouldBe a[VerificationIncompleteSummary]
 
           result.maybeUserFacingMessage shouldNot be(defined)
-        }
       }
     }
+  }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -31,8 +31,12 @@ trait ReplicatedBagVerifierTestCases[
           bucket = srcBucket.name,
           keyPrefix = replicaBagRoot.pathPrefix
         )
-        val tagManifestContents = typedStore.get(replicaBagRoot.asLocation("tagmanifest-sha256.txt")).right.get.identifiedT
-        S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(tagManifestContents)
+
+        val _ = for {
+          tagManifestContents <- typedStore.get(replicaBagRoot.asLocation("tagmanifest-sha256.txt"))
+          _ <- S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(tagManifestContents.identifiedT)
+        } yield ()
+
         testWith(ReplicatedBagVerifyContext(srcBagRoot, replicaBagRoot))
       }
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.{Location, Prefix}
 
 trait ReplicatedBagVerifierTestCases[
@@ -22,50 +23,32 @@ trait ReplicatedBagVerifierTestCases[
   ReplicaBagLocation,
   ReplicaBagPrefix,
   ReplicaNamespace
-  ] {
-  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: ReplicaBagPrefix)(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
-    testWith(ReplicatedBagVerifyContext(srcBagRoot,replicaBagRoot))
+] {
+  override def withBagContext[R](replicaBagRoot: ReplicaBagPrefix)(testWith: TestWith[ReplicatedBagVerifyContext[ReplicaBagPrefix], R]): R =
+    withLocalS3Bucket { srcBucket =>
+      withTypedStore { implicit typedStore =>
+        val srcBagRoot = S3ObjectLocationPrefix(
+          bucket = srcBucket.name,
+          keyPrefix = replicaBagRoot.pathPrefix
+        )
+        val tagManifestContents = typedStore.get(replicaBagRoot.asLocation("tagmanifest-sha256.txt")).right.get.identifiedT
+        S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(tagManifestContents)
+        testWith(ReplicatedBagVerifyContext(srcBagRoot, replicaBagRoot))
+      }
+    }
 
   it("fails a bag if it doesn't match original tag manifest") {
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
-    withTypedStore { implicit typedStore =>
-      withBag(space, externalIdentifier) { case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
 
-        // Scramble the contents of the original tag manifest
-        putStream(srcBagRoot.asLocation("tagmanifest-sha256.txt"))
-
-        val ingestStep =
-          withVerifier(srcBucket) {
-            _.verify(
-              ingestId = createIngestID,
-              bagContext = ReplicatedBagVerifyContext(
-                srcRoot = srcBagRoot,
-                replicaRoot = replicaBagRoot
-              ),
-              space = space,
-              externalIdentifier = externalIdentifier
-            )
-          }
-
-        val result = ingestStep.success.get
-
-        result shouldBe a[IngestFailed[_]]
-        result.summary shouldBe a[VerificationIncompleteSummary]
-
-        result.maybeUserFacingMessage shouldNot be(defined)
-      }
-    }
-  }
-
-  it("fails a bag if it cannot read the original bag") {
-    val space = createStorageSpace
-    val externalIdentifier = createExternalIdentifier
-    withTypedStore { implicit typedStore =>
-      withBag(space, externalIdentifier) {
-        case (srcBucket, _, srcBagRoot, replicaBagRoot) =>
+    val primaryBucket = createBucketName
+    withLocalS3Bucket { srcBucket =>
+      withTypedStore { implicit typedStore =>
+        withBag(space, externalIdentifier, primaryBucket) { replicaBagRoot =>
+          val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
+          S3TypedStore[String].put(srcBagRoot.asLocation("tagmanifest-sha256.txt"))(randomAlphanumeric)
           val ingestStep =
-            withVerifier(srcBucket) {
+            withVerifier(primaryBucket) {
               _.verify(
                 ingestId = createIngestID,
                 bagContext = ReplicatedBagVerifyContext(
@@ -83,6 +66,41 @@ trait ReplicatedBagVerifierTestCases[
           result.summary shouldBe a[VerificationIncompleteSummary]
 
           result.maybeUserFacingMessage shouldNot be(defined)
+        }
+      }
+    }
+  }
+
+  it("fails a bag if it cannot read the original bag") {
+    val space = createStorageSpace
+    val externalIdentifier = createExternalIdentifier
+
+
+    val primaryBucket = createBucketName
+    withLocalS3Bucket { srcBucket =>
+      withTypedStore { implicit typedStore =>
+        withBag(space, externalIdentifier, primaryBucket) { replicaBagRoot =>
+          val srcBagRoot = S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
+          val ingestStep =
+            withVerifier(primaryBucket) {
+              _.verify(
+                ingestId = createIngestID,
+                bagContext = ReplicatedBagVerifyContext(
+                  srcRoot = srcBagRoot,
+                  replicaRoot = replicaBagRoot
+                ),
+                space = space,
+                externalIdentifier = externalIdentifier
+              )
+            }
+
+          val result = ingestStep.success.get
+
+          result shouldBe a[IngestFailed[_]]
+          result.summary shouldBe a[VerificationIncompleteSummary]
+
+          result.maybeUserFacingMessage shouldNot be(defined)
+        }
       }
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -85,18 +85,19 @@ class S3ReplicatedBagVerifierTest
 }
 
 class S3StandaloneBagVerifierTest
-    extends StandaloneBagVerifierTestCases[
-      S3ObjectLocation,
-      S3ObjectLocationPrefix,
+    extends BagVerifierTestCases[
+      S3StandaloneBagVerifier,
+      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+      S3ObjectLocation, S3ObjectLocationPrefix,
       Bucket
     ]
     with S3BagVerifierTests[
-      StandaloneBagVerifier,
+      S3StandaloneBagVerifier,
       StandaloneBagVerifyContext[S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
-      StandaloneBagVerifier,
+      S3StandaloneBagVerifier,
       R
     ]
   )(
@@ -107,4 +108,6 @@ class S3StandaloneBagVerifierTest
     )
 
   override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
+
+  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext[S3ObjectLocationPrefix], R]): R = testWith(StandaloneBagVerifyContext(replicaBagRoot))
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -87,13 +87,13 @@ class S3ReplicatedBagVerifierTest
 class S3StandaloneBagVerifierTest
     extends BagVerifierTestCases[
       S3StandaloneBagVerifier,
-      StandaloneBagVerifyContext[S3ObjectLocationPrefix],
+      StandaloneBagVerifyContext,
       S3ObjectLocation, S3ObjectLocationPrefix,
       Bucket
     ]
     with S3BagVerifierTests[
       S3StandaloneBagVerifier,
-      StandaloneBagVerifyContext[S3ObjectLocationPrefix]
+      StandaloneBagVerifyContext
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
@@ -109,5 +109,5 @@ class S3StandaloneBagVerifierTest
 
   override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
 
-  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext[S3ObjectLocationPrefix], R]): R = testWith(StandaloneBagVerifyContext(replicaBagRoot))
+  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext, R]): R = testWith(StandaloneBagVerifyContext(replicaBagRoot))
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -63,7 +63,7 @@ class S3ReplicatedBagVerifierTest
       ],
       ReplicatedBagVerifyContext[S3ObjectLocationPrefix]
     ] {
-  override def withVerifier[R](primaryBucket: Bucket)(
+  override def withVerifier[R](primaryBucket: String)(
     testWith: TestWith[
       ReplicatedBagVerifier[
         S3ObjectLocation,
@@ -71,11 +71,9 @@ class S3ReplicatedBagVerifierTest
       ],
       R
     ]
-  )(
-    implicit typedStore: TypedStore[S3ObjectLocation, String]
   ): R =
     testWith(
-      new S3ReplicatedBagVerifier(primaryBucket = primaryBucket.name)
+      new S3ReplicatedBagVerifier(primaryBucket = primaryBucket)
     )
 
   override val bagBuilder
@@ -95,19 +93,17 @@ class S3StandaloneBagVerifierTest
       S3StandaloneBagVerifier,
       StandaloneBagVerifyContext
     ] {
-  override def withVerifier[R](primaryBucket: Bucket)(
+  override def withVerifier[R](primaryBucket: String)(
     testWith: TestWith[
       S3StandaloneBagVerifier,
       R
     ]
-  )(
-    implicit typedStore: TypedStore[S3ObjectLocation, String]
   ): R =
     testWith(
-      new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
+      new S3StandaloneBagVerifier(primaryBucket = primaryBucket)
     )
 
   override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
 
-  override def withBagContext[R](srcBagRoot: S3ObjectLocationPrefix, replicaBagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext, R]): R = testWith(StandaloneBagVerifyContext(replicaBagRoot))
+  override def withBagContext[R](bagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext, R]): R = testWith(StandaloneBagVerifyContext(bagRoot))
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -86,19 +86,26 @@ class S3StandaloneBagVerifierTest
     extends BagVerifierTestCases[
       S3StandaloneBagVerifier,
       StandaloneBagVerifyContext,
-      S3ObjectLocation, S3ObjectLocationPrefix,
+      S3ObjectLocation,
+      S3ObjectLocationPrefix,
       Bucket
     ]
     with S3BagVerifierTests[
       S3StandaloneBagVerifier,
       StandaloneBagVerifyContext
     ] {
-  override def withVerifier[R](primaryBucket: Bucket)(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
+  override def withVerifier[R](
+    primaryBucket: Bucket
+  )(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
     testWith(
       new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
     )
 
-  override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
+  override val bagBuilder
+    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+    new S3BagBuilder {}
 
-  override def withBagContext[R](bagRoot: S3ObjectLocationPrefix)(testWith: TestWith[StandaloneBagVerifyContext, R]): R = testWith(StandaloneBagVerifyContext(bagRoot))
+  override def withBagContext[R](bagRoot: S3ObjectLocationPrefix)(
+    testWith: TestWith[StandaloneBagVerifyContext, R]
+  ): R = testWith(StandaloneBagVerifyContext(bagRoot))
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -63,7 +63,7 @@ class S3ReplicatedBagVerifierTest
       ],
       ReplicatedBagVerifyContext[S3ObjectLocationPrefix]
     ] {
-  override def withVerifier[R](primaryBucket: String)(
+  override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
       ReplicatedBagVerifier[
         S3ObjectLocation,
@@ -73,7 +73,7 @@ class S3ReplicatedBagVerifierTest
     ]
   ): R =
     testWith(
-      new S3ReplicatedBagVerifier(primaryBucket = primaryBucket)
+      new S3ReplicatedBagVerifier(primaryBucket = primaryBucket.name)
     )
 
   override val bagBuilder
@@ -93,14 +93,9 @@ class S3StandaloneBagVerifierTest
       S3StandaloneBagVerifier,
       StandaloneBagVerifyContext
     ] {
-  override def withVerifier[R](primaryBucket: String)(
-    testWith: TestWith[
-      S3StandaloneBagVerifier,
-      R
-    ]
-  ): R =
+  override def withVerifier[R](primaryBucket: Bucket)(testWith: TestWith[S3StandaloneBagVerifier, R]): R =
     testWith(
-      new S3StandaloneBagVerifier(primaryBucket = primaryBucket)
+      new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
     )
 
   override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifierTest.scala
@@ -54,25 +54,18 @@ class S3ReplicatedBagVerifierTest
     extends ReplicatedBagVerifierTestCases[
       S3ObjectLocation,
       S3ObjectLocationPrefix,
-      Bucket,
-      S3ObjectLocation,
-      S3ObjectLocationPrefix,
       Bucket
     ]
     with S3BagVerifierTests[
       ReplicatedBagVerifier[
         S3ObjectLocation,
-        S3ObjectLocationPrefix,
-        S3ObjectLocation,
         S3ObjectLocationPrefix
       ],
-      ReplicatedBagVerifyContext[S3ObjectLocationPrefix, S3ObjectLocationPrefix]
+      ReplicatedBagVerifyContext[S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
       ReplicatedBagVerifier[
-        S3ObjectLocation,
-        S3ObjectLocationPrefix,
         S3ObjectLocation,
         S3ObjectLocationPrefix
       ],
@@ -85,49 +78,10 @@ class S3ReplicatedBagVerifierTest
       new S3ReplicatedBagVerifier(primaryBucket = primaryBucket.name)
     )
 
-  override protected def copyTagManifest(
-    srcRoot: S3ObjectLocationPrefix,
-    replicaRoot: S3ObjectLocationPrefix
-  ): Unit =
-    s3Client.copyObject(
-      replicaRoot.bucket,
-      s"${replicaRoot.keyPrefix}/tagmanifest-sha256.txt",
-      srcRoot.bucket,
-      s"${srcRoot.keyPrefix}/tagmanifest-sha256.txt"
-    )
-
-  override def createSrcPrefix(
-    implicit bucket: Bucket
-  ): S3ObjectLocationPrefix =
-    createS3ObjectLocationPrefixWith(bucket)
-
-  override def withSrcNamespace[R](testWith: TestWith[Bucket, R]): R =
-    withLocalS3Bucket { bucket =>
-      testWith(bucket)
-    }
-
-  override def withReplicaNamespace[R](testWith: TestWith[Bucket, R]): R =
-    withLocalS3Bucket { bucket =>
-      testWith(bucket)
-    }
-
-  override def withSrcTypedStore[R](
-    testWith: TestWith[TypedStore[S3ObjectLocation, String], R]
-  ): R =
-    testWith(S3TypedStore[String])
-
-  override def withReplicaTypedStore[R](
-    testWith: TestWith[TypedStore[S3ObjectLocation, String], R]
-  ): R =
-    testWith(S3TypedStore[String])
-
-  override val srcBagBuilder
+  override val bagBuilder
     : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
     new S3BagBuilder {}
 
-  override val replicaBagBuilder
-    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
-    new S3BagBuilder {}
 }
 
 class S3StandaloneBagVerifierTest
@@ -137,12 +91,12 @@ class S3StandaloneBagVerifierTest
       Bucket
     ]
     with S3BagVerifierTests[
-      StandaloneBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
+      StandaloneBagVerifier,
       StandaloneBagVerifyContext[S3ObjectLocationPrefix]
     ] {
   override def withVerifier[R](primaryBucket: Bucket)(
     testWith: TestWith[
-      StandaloneBagVerifier[S3ObjectLocation, S3ObjectLocationPrefix],
+      StandaloneBagVerifier,
       R
     ]
   )(
@@ -152,7 +106,5 @@ class S3StandaloneBagVerifierTest
       new S3StandaloneBagVerifier(primaryBucket = primaryBucket.name)
     )
 
-  override val replicaBagBuilder
-    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
-    new S3BagBuilder {}
+  override val bagBuilder: BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] = new S3BagBuilder {}
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -208,7 +208,7 @@ trait BagReaderTestCases[
   ): (BagPrefix, BagInfo) = {
     val bagContents = createBagContentsWith()
 
-    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects)
+    storeBagContents(bagContents)
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -9,6 +9,8 @@ import uk.ac.wellcome.platform.archive.common.fixtures.{
   BagBuilder,
   StorageRandomThings
 }
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.{Location, Prefix}
 import uk.ac.wellcome.storage.store.TypedStore
 
@@ -21,7 +23,7 @@ trait BagReaderTestCases[
     with Matchers
     with EitherValues
     with StorageRandomThings
-    with BagBuilder[BagLocation, BagPrefix, Namespace] {
+    with BagBuilder[BagLocation, BagPrefix, Namespace] with S3Fixtures {
   def asLocation(root: BagPrefix, path: String): BagLocation
 
   def withContext[R](testWith: TestWith[Context, R]): R
@@ -50,21 +52,23 @@ trait BagReaderTestCases[
 
   def withFixtures[R](
     testWith: TestWith[
-      (Context, TypedStore[BagLocation, String], Namespace),
+      (Context, TypedStore[BagLocation, String], Namespace, Bucket),
       R
     ]
   ): R =
     withContext { implicit context =>
       withTypedStore { typedStore =>
         withNamespace { namespace =>
-          testWith((context, typedStore, namespace))
+          withLocalS3Bucket { bucket =>
+            testWith((context, typedStore, namespace, bucket))
+          }
         }
       }
     }
 
   it("gets a correctly formed bag") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, bagInfo) = createBag()
 
@@ -78,7 +82,7 @@ trait BagReaderTestCases[
 
   it("errors if the bag-info.txt file does not exist") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       deleteFile(bagRoot, path = "bag-info.txt")
@@ -93,7 +97,7 @@ trait BagReaderTestCases[
 
   it("errors if the bag-info.txt file is malformed") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       scrambleFile(bagRoot, path = "bag-info.txt")
@@ -108,7 +112,7 @@ trait BagReaderTestCases[
 
   it("errors if the file manifest does not exist") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       deleteFile(bagRoot, path = "manifest-sha256.txt")
@@ -123,7 +127,7 @@ trait BagReaderTestCases[
 
   it("errors if the file manifest is malformed") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       scrambleFile(bagRoot, path = "manifest-sha256.txt")
@@ -138,7 +142,7 @@ trait BagReaderTestCases[
 
   it("errors if the tag manifest does not exist") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       deleteFile(bagRoot, "tagmanifest-sha256.txt")
@@ -153,7 +157,7 @@ trait BagReaderTestCases[
 
   it("errors if the tag manifest is malformed") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       scrambleFile(bagRoot, path = "tagmanifest-sha256.txt")
@@ -168,7 +172,7 @@ trait BagReaderTestCases[
 
   it("passes if the fetch.txt does not exist") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       deleteFile(bagRoot, path = "fetch.txt")
@@ -181,7 +185,7 @@ trait BagReaderTestCases[
 
   it("errors if the fetch file is malformed") {
     withFixtures { fixtures =>
-      implicit val (context, typedStore, namespace) = fixtures
+      implicit val (context, typedStore, namespace, bucket) = fixtures
 
       val (bagRoot, _) = createBag()
       scrambleFile(bagRoot, path = "fetch.txt")
@@ -199,12 +203,13 @@ trait BagReaderTestCases[
   protected def createBag()(
     implicit
     namespace: Namespace,
+                         bucket: Bucket,
     typedStore: TypedStore[BagLocation, String]
   ): (BagPrefix, BagInfo) = {
-    val (bagObjects, bagRoot, bagInfo) = createBagContentsWith()
+    val bagContents = createBagContentsWith()
 
-    uploadBagObjects(bagRoot, objects = bagObjects)
+    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects)
 
-    (bagRoot, bagInfo)
+    (bagContents.bagRoot, bagContents.bagInfo)
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -23,7 +23,8 @@ trait BagReaderTestCases[
     with Matchers
     with EitherValues
     with StorageRandomThings
-    with BagBuilder[BagLocation, BagPrefix, Namespace] with S3Fixtures {
+    with BagBuilder[BagLocation, BagPrefix, Namespace]
+    with S3Fixtures {
   def asLocation(root: BagPrefix, path: String): BagLocation
 
   def withContext[R](testWith: TestWith[Context, R]): R
@@ -203,7 +204,7 @@ trait BagReaderTestCases[
   protected def createBag()(
     implicit
     namespace: Namespace,
-                         bucket: Bucket,
+    bucket: Bucket,
     typedStore: TypedStore[BagLocation, String]
   ): (BagPrefix, BagInfo) = {
     val bagContents = createBagContentsWith()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -25,8 +25,8 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     with S3Fixtures {
 
   case class BagContents(
-    fetchObjects:Map[S3ObjectLocation, String],
-    bagObjects:Map[BagLocation, String],
+    fetchObjects: Map[S3ObjectLocation, String],
+    bagObjects: Map[BagLocation, String],
     bagRoot: BagPrefix,
     bagInfo: BagInfo
   )
@@ -50,8 +50,11 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
       case (location, contents) =>
         typedStore.put(location)(contents) shouldBe a[Right[_, _]]
     }
-    bagContents.fetchObjects.foreach { case (fetchObjectLocation, fetchObjectContents) =>
-      S3TypedStore[String].put(fetchObjectLocation)(fetchObjectContents) shouldBe a[Right[_, _]]
+    bagContents.fetchObjects.foreach {
+      case (fetchObjectLocation, fetchObjectContents) =>
+        S3TypedStore[String].put(fetchObjectLocation)(fetchObjectContents) shouldBe a[
+          Right[_, _]
+        ]
     }
   }
 
@@ -62,7 +65,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     space: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
-    payloadFileCount: Int = randomInt(from = 5, to = 50),
+    payloadFileCount: Int = randomInt(from = 5, to = 50)
   )(
     implicit
     namespace: Namespace,
@@ -149,11 +152,16 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
         createBagLocation(bagRoot, path = payloadEntry.path) -> payloadEntry.contents
       }.toMap
 
-    val fetchObjects = fetchEntries .map{fetchEntry =>
+    val fetchObjects = fetchEntries.map { fetchEntry =>
       S3ObjectLocation(primaryBucket.name, fetchEntry.path) -> fetchEntry.contents
     }.toMap
 
-    BagContents(fetchObjects,manifestObjects ++ payloadObjects, bagRoot, bagInfo)
+    BagContents(
+      fetchObjects,
+      manifestObjects ++ payloadObjects,
+      bagRoot,
+      bagInfo
+    )
   }
 
   protected def createFetchFile(
@@ -165,7 +173,9 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     } else {
       Some(
         entries
-          .map { entry => buildFetchEntryLine(primaryBucket, entry) }
+          .map { entry =>
+            buildFetchEntryLine(primaryBucket, entry)
+          }
           .mkString("\n")
       )
     }
@@ -175,7 +185,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     entry: PayloadEntry
   ): String = {
     val displaySize =
-    if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
+      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
 
     s"""s3://${primaryBucket.name}/${entry.path} $displaySize ${entry.bagPath}"""
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -43,16 +43,14 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
 
   def createBagLocation(bagRoot: BagPrefix, path: String): BagLocation
 
-  def uploadBagObjects(
-    bagRoot: BagPrefix,
-    objects: Map[BagLocation, String],
-    fetchObjects: Map[S3ObjectLocation, String] = Map.empty
-  )(implicit typedStore: TypedStore[BagLocation, String]): Unit = {
-    objects.foreach {
+  def storeBagContents(bagContents: BagContents)(
+    implicit typedStore: TypedStore[BagLocation, String]
+  ): Unit = {
+    bagContents.bagObjects.foreach {
       case (location, contents) =>
         typedStore.put(location)(contents) shouldBe a[Right[_, _]]
     }
-   fetchObjects.foreach { case (fetchObjectLocation, fetchObjectContents) =>
+    bagContents.fetchObjects.foreach { case (fetchObjectLocation, fetchObjectContents) =>
       S3TypedStore[String].put(fetchObjectLocation)(fetchObjectContents) shouldBe a[Right[_, _]]
     }
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -49,7 +49,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
     payloadFileCount: Int = randomInt(from = 5, to = 50),
     // TODO: This should be Bucket
-    bucketName: String = randomAlphanumeric
+    primaryBucket: String = randomAlphanumeric
   )(
     implicit namespace: Namespace
   ): (Map[BagLocation, String], BagPrefix, BagInfo) = {
@@ -101,7 +101,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
           )
         }
 
-    val fetchFile = createFetchFile(bucketName, fetchEntries)
+    val fetchFile = createFetchFile(primaryBucket, fetchEntries)
       .map { contents =>
         ManifestFile(
           name = "fetch.txt",
@@ -138,7 +138,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
   }
 
   protected def createFetchFile(
-                               bucketName: String,
+    primaryBucket: String,
     entries: Seq[PayloadEntry]
   ): Option[String] =
     if (entries.isEmpty) {
@@ -146,19 +146,19 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     } else {
       Some(
         entries
-          .map { entry => buildFetchEntryLine(bucketName, entry) }
+          .map { entry => buildFetchEntryLine(primaryBucket, entry) }
           .mkString("\n")
       )
     }
 
   protected def buildFetchEntryLine(
-    bucketName: String,
+    primaryBucket: String,
     entry: PayloadEntry
   ): String = {
     val displaySize =
     if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
 
-    s"""s3://$bucketName/${entry.path} $displaySize ${entry.bagPath}"""
+    s"""s3://$primaryBucket/${entry.path} $displaySize ${entry.bagPath}"""
   }
 
   protected def createPayloadOxum(entries: Seq[PayloadEntry]): PayloadOxum =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/azure/AzureBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/azure/AzureBagBuilder.scala
@@ -4,16 +4,11 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
 }
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagBuilder,
-  PayloadEntry
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
-
-import scala.util.Random
 
 trait AzureBagBuilder
     extends BagBuilder[AzureBlobLocation, AzureBlobLocationPrefix, Container]
@@ -32,13 +27,4 @@ trait AzureBagBuilder
     bagRoot: AzureBlobLocationPrefix,
     path: String
   ): AzureBlobLocation = AzureBlobLocation(bagRoot.container, path)
-
-  override def buildFetchEntryLine(
-    entry: PayloadEntry
-  )(implicit container: Container): String = {
-    val displaySize =
-      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
-
-    s"""https://myaccount.blob.core.windows.net/${container.name}/${entry.path} $displaySize ${entry.bagPath}"""
-  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/memory/MemoryBagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/memory/MemoryBagBuilder.scala
@@ -4,18 +4,13 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
 }
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagBuilder,
-  PayloadEntry
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.storage.providers.memory.{
   MemoryLocation,
   MemoryLocationPrefix
 }
-
-import scala.util.Random
 
 trait MemoryBagBuilder
     extends BagBuilder[MemoryLocation, MemoryLocationPrefix, String] {
@@ -31,15 +26,6 @@ trait MemoryBagBuilder
       namespace = namespace,
       path = DestinationBuilder.buildPath(space, externalIdentifier, version)
     )
-
-  override def buildFetchEntryLine(
-    entry: PayloadEntry
-  )(implicit namespace: String): String = {
-    val displaySize =
-      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
-
-    s"""mem://$namespace/${entry.path} $displaySize ${entry.bagPath}"""
-  }
 
   override def createBagLocation(
     bagRoot: MemoryLocationPrefix,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -52,7 +52,7 @@ trait S3BagBuilder
     )
 
     implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
-    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects, bagContents.fetchObjects)
+    storeBagContents(bagContents)
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -45,15 +45,15 @@ trait S3BagBuilder
   ): (S3ObjectLocationPrefix, BagInfo) = {
     implicit val namespace: Bucket = bucket
 
-    val (bagObjects, bagRoot, bagInfo) = createBagContentsWith(
+    val bagContents = createBagContentsWith(
       space = space,
       externalIdentifier = externalIdentifier,
       payloadFileCount = payloadFileCount
     )
 
     implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
-    uploadBagObjects(bagRoot, objects = bagObjects)
+    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects)
 
-    (bagRoot, bagInfo)
+    (bagContents.bagRoot, bagContents.bagInfo)
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -52,7 +52,7 @@ trait S3BagBuilder
     )
 
     implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
-    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects)
+    uploadBagObjects(bagContents.bagRoot, objects = bagContents.bagObjects, bagContents.fetchObjects)
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -5,17 +5,12 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
 }
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagBuilder,
-  PayloadEntry
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-
-import scala.util.Random
 
 trait S3BagBuilder
     extends BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket]
@@ -41,15 +36,6 @@ trait S3BagBuilder
       bucket = bagRoot.bucket,
       key = path
     )
-
-  override def buildFetchEntryLine(
-    entry: PayloadEntry
-  )(implicit bucket: Bucket): String = {
-    val displaySize =
-      if (Random.nextBoolean()) entry.contents.getBytes.length.toString else "-"
-
-    s"""s3://${bucket.name}/${entry.path} $displaySize ${entry.bagPath}"""
-  }
 
   def createS3BagWith(
     bucket: Bucket,


### PR DESCRIPTION
This refactoring by @alicefuzier reflects the fact that:

* The source bag of a replication is always S3
* The primary copy of a bag is in S3

Until now we've been able to get by sort of implicitly assuming these, because the destination of a replicated bag was also S3. This patch makes this explicit, and lays the groundwork for writing bags to different locations.

A combination of 47ad3f8, 161e4a7, 798abcd, e4e1000, bc9aaef, bd2155f.

Part of wellcomecollection/platform#4595. Extracted as a set of standalone commits from #669. I've reviewed this and I'm happy it looks good, so we can merge it if it passes tests.