### PR TITLE
We don't need to re-define asLocation in the BagReader tests

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -25,7 +25,6 @@ trait BagReaderTestCases[
     with StorageRandomThings
     with BagBuilder[BagLocation, BagPrefix, Namespace]
     with S3Fixtures {
-  def asLocation(root: BagPrefix, path: String): BagLocation
 
   def withContext[R](testWith: TestWith[Context, R]): R
   def withTypedStore[R](
@@ -47,7 +46,7 @@ trait BagReaderTestCases[
   def scrambleFile(root: BagPrefix, path: String)(
     implicit typedStore: TypedStore[BagLocation, String]
   ): Assertion =
-    typedStore.put(asLocation(root, path = path))(randomAlphanumeric) shouldBe a[
+    typedStore.put(root.asLocation(path))(randomAlphanumeric) shouldBe a[
       Right[_, _]
     ]
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/azure/AzureBagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/azure/AzureBagReaderTest.scala
@@ -19,11 +19,6 @@ class AzureBagReaderTest
       AzureBlobLocationPrefix
     ]
     with AzureBagBuilder {
-  override def asLocation(
-    root: AzureBlobLocationPrefix,
-    path: String
-  ): AzureBlobLocation = root.asLocation(path)
-
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 
   override def withTypedStore[R](

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
@@ -17,12 +17,6 @@ class MemoryBagReaderTest
     extends BagReaderTestCases[MemoryStreamStore[MemoryLocation], String, MemoryLocation, MemoryLocationPrefix]
     with MemoryBagBuilder {
 
-  override def asLocation(
-    prefix: MemoryLocationPrefix,
-    path: String
-  ): MemoryLocation =
-    prefix.asLocation(path)
-
   override def withContext[R](
     testWith: TestWith[MemoryStreamStore[MemoryLocation], R]
   ): R =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
@@ -20,12 +20,6 @@ class S3BagReaderTest
     ]
     with S3BagBuilder {
 
-  override def asLocation(
-    prefix: S3ObjectLocationPrefix,
-    path: String
-  ): S3ObjectLocation =
-    prefix.asLocation(path)
-
   override def withTypedStore[R](
     testWith: TestWith[TypedStore[S3ObjectLocation, String], R]
   )(implicit context: Unit): R = {


### PR DESCRIPTION
In the newest versions of scala-libs, the asLocation method is required on definitions of Prefix[_].