### PR TITLE
Add an Azure implementation of FixityChecker

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
+
+import java.net.URI
+
+import com.azure.storage.blob.BlobServiceClient
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
+import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable
+import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
+import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
+import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.store.azure.AzureStreamStore
+import uk.ac.wellcome.storage.tags.Tags
+import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
+
+class AzureFixityChecker(implicit blobClient: BlobServiceClient) extends FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix] {
+  override protected val streamStore: StreamStore[AzureBlobLocation] = new AzureStreamStore()
+  override protected val sizeFinder: SizeFinder[AzureBlobLocation] = ???
+  override val tags: Tags[AzureBlobLocation] = new AzureBlobMetadata()
+  override implicit val locator: Locatable[AzureBlobLocation, AzureBlobLocationPrefix, URI] = ???
+}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -5,7 +5,9 @@ import java.net.URI
 import com.azure.storage.blob.BlobServiceClient
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable
+import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureLocatable
 import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
+import uk.ac.wellcome.platform.archive.common.storage.services.azure.AzureSizeFinder
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.azure.AzureStreamStore
@@ -14,7 +16,7 @@ import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
 
 class AzureFixityChecker(implicit blobClient: BlobServiceClient) extends FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix] {
   override protected val streamStore: StreamStore[AzureBlobLocation] = new AzureStreamStore()
-  override protected val sizeFinder: SizeFinder[AzureBlobLocation] = ???
+  override protected val sizeFinder: SizeFinder[AzureBlobLocation] = new AzureSizeFinder()
   override val tags: Tags[AzureBlobLocation] = new AzureBlobMetadata()
-  override implicit val locator: Locatable[AzureBlobLocation, AzureBlobLocationPrefix, URI] = ???
+  override implicit val locator: Locatable[AzureBlobLocation, AzureBlobLocationPrefix, URI] = new AzureLocatable
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -1,22 +1,22 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
 
-import java.net.URI
-
 import com.azure.storage.blob.BlobServiceClient
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
-import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable
 import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureLocatable
-import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
 import uk.ac.wellcome.platform.archive.common.storage.services.azure.AzureSizeFinder
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
-import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.azure.AzureStreamStore
-import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
 
-class AzureFixityChecker(implicit blobClient: BlobServiceClient) extends FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix] {
-  override protected val streamStore: StreamStore[AzureBlobLocation] = new AzureStreamStore()
-  override protected val sizeFinder: SizeFinder[AzureBlobLocation] = new AzureSizeFinder()
-  override val tags: Tags[AzureBlobLocation] = new AzureBlobMetadata()
-  override implicit val locator: Locatable[AzureBlobLocation, AzureBlobLocationPrefix, URI] = new AzureLocatable
+class AzureFixityChecker(implicit blobClient: BlobServiceClient)
+    extends FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix] {
+  override protected val streamStore =
+    new AzureStreamStore()
+
+  override protected val sizeFinder =
+    new AzureSizeFinder()
+
+  override val tags = new AzureBlobMetadata()
+
+  override implicit val locator: AzureLocatable = new AzureLocatable
 }

--- a/bag_verifier/src/test/resources/logback-test.xml
+++ b/bag_verifier/src/test/resources/logback-test.xml
@@ -14,4 +14,6 @@
   <logger name="io.netty" level="ERROR"/>
   <logger name="com.amazonaws" level="WARN"/>
   <logger name="software.amazon.awssdk" level="WARN"/>
+
+  <logger name="reactor.netty" level="ERROR"/>
 </configuration>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -11,7 +11,6 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureResolvable
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
-import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
 
 class AzureFixityCheckerTest extends FixityCheckerTestCases[
@@ -23,24 +22,28 @@ class AzureFixityCheckerTest extends FixityCheckerTestCases[
 ]
   with AzureFixtures {
 
-  implicit val streamStore: AzureStreamStore = new AzureStreamStore()
-  val azureTypedStore = new AzureTypedStore[String]()
+  val azureTypedStore: AzureTypedStore[String] = AzureTypedStore[String]
 
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 
   override def putString(location: AzureBlobLocation, contents: String)(implicit context: Unit): Unit = azureTypedStore.put(location)(contents)
 
-  override def withFixityChecker[R](s: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R = testWith(new AzureFixityChecker {
-    override val streamStore: StreamStore[AzureBlobLocation] = s
-  })
+  override def withFixityChecker[R](streamStore: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R =
+    testWith(new AzureFixityChecker())
 
-  override def withStreamStore[R](testWith: TestWith[AzureStreamStore, R])(implicit context: Unit): R = testWith(streamStore)
+  override def withStreamStore[R](
+    testWith: TestWith[AzureStreamStore, R])(implicit context: Unit
+  ): R =
+    testWith(new AzureStreamStore())
 
-  override def resolve(location: AzureBlobLocation): URI = new AzureResolvable().resolve(location)
+  override def resolve(location: AzureBlobLocation): URI =
+    new AzureResolvable().resolve(location)
 
-  override def withNamespace[R](testWith: TestWith[Container, R]): R = withAzureContainer{container =>
-    testWith(container)
-  }
+  override def withNamespace[R](testWith: TestWith[Container, R]): R =
+    withAzureContainer{ container =>
+      testWith(container)
+    }
 
-  override def createId(implicit container: Container): AzureBlobLocation = createAzureBlobLocationWith(container)
+  override def createId(implicit container: Container): AzureBlobLocation =
+    createAzureBlobLocationWith(container)
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureResolvable
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
+import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
 
 class AzureFixityCheckerTest extends FixityCheckerTestCases[
@@ -29,7 +30,9 @@ class AzureFixityCheckerTest extends FixityCheckerTestCases[
 
   override def putString(location: AzureBlobLocation, contents: String)(implicit context: Unit): Unit = azureTypedStore.put(location)(contents)
 
-  override def withFixityChecker[R](streamStore: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R = testWith(new AzureFixityChecker())
+  override def withFixityChecker[R](s: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R = testWith(new AzureFixityChecker {
+    override val streamStore: StreamStore[AzureBlobLocation] = s
+  })
 
   override def withStreamStore[R](testWith: TestWith[AzureStreamStore, R])(implicit context: Unit): R = testWith(streamStore)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
+
+import java.net.URI
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
+  FixityChecker,
+  FixityCheckerTestCases
+}
+import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureResolvable
+import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
+import uk.ac.wellcome.storage.fixtures.AzureFixtures
+import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
+import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
+
+class AzureFixityCheckerTest extends FixityCheckerTestCases[
+  AzureBlobLocation,
+  AzureBlobLocationPrefix,
+  Container,
+  Unit,
+  AzureStreamStore
+]
+  with AzureFixtures {
+
+  implicit val streamStore: AzureStreamStore = new AzureStreamStore()
+  val azureTypedStore = new AzureTypedStore[String]()
+
+  override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
+
+  override def putString(location: AzureBlobLocation, contents: String)(implicit context: Unit): Unit = azureTypedStore.put(location)(contents)
+
+  override def withFixityChecker[R](streamStore: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R = testWith(new AzureFixityChecker())
+
+  override def withStreamStore[R](testWith: TestWith[AzureStreamStore, R])(implicit context: Unit): R = testWith(streamStore)
+
+  override def resolve(location: AzureBlobLocation): URI = new AzureResolvable().resolve(location)
+
+  override def withNamespace[R](testWith: TestWith[Container, R]): R = withAzureContainer{container =>
+    testWith(container)
+  }
+
+  override def createId(implicit container: Container): AzureBlobLocation = createAzureBlobLocationWith(container)
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -31,13 +31,17 @@ class AzureFixityCheckerTest
     implicit context: Unit
   ): Unit = azureTypedStore.put(location)(contents)
 
-  override def withFixityChecker[R](streamStore: AzureStreamStore)(
+  override def withFixityChecker[R](underlyingStreamStore: AzureStreamStore)(
     testWith: TestWith[
       FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix],
       R
     ]
   )(implicit context: Unit): R =
-    testWith(new AzureFixityChecker())
+    testWith(new AzureFixityChecker() {
+      // We need to override the underlying StreamStore so Mockito can spy
+      // on its interactions during the tests.
+      override val streamStore: AzureStreamStore = underlyingStreamStore
+    })
 
   override def withStreamStore[R](
     testWith: TestWith[AzureStreamStore, R]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -13,34 +13,42 @@ import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
 
-class AzureFixityCheckerTest extends FixityCheckerTestCases[
-  AzureBlobLocation,
-  AzureBlobLocationPrefix,
-  Container,
-  Unit,
-  AzureStreamStore
-]
-  with AzureFixtures {
+class AzureFixityCheckerTest
+    extends FixityCheckerTestCases[
+      AzureBlobLocation,
+      AzureBlobLocationPrefix,
+      Container,
+      Unit,
+      AzureStreamStore
+    ]
+    with AzureFixtures {
 
   val azureTypedStore: AzureTypedStore[String] = AzureTypedStore[String]
 
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 
-  override def putString(location: AzureBlobLocation, contents: String)(implicit context: Unit): Unit = azureTypedStore.put(location)(contents)
+  override def putString(location: AzureBlobLocation, contents: String)(
+    implicit context: Unit
+  ): Unit = azureTypedStore.put(location)(contents)
 
-  override def withFixityChecker[R](streamStore: AzureStreamStore)(testWith: TestWith[FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix], R])(implicit context: Unit): R =
+  override def withFixityChecker[R](streamStore: AzureStreamStore)(
+    testWith: TestWith[
+      FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix],
+      R
+    ]
+  )(implicit context: Unit): R =
     testWith(new AzureFixityChecker())
 
   override def withStreamStore[R](
-    testWith: TestWith[AzureStreamStore, R])(implicit context: Unit
-  ): R =
+    testWith: TestWith[AzureStreamStore, R]
+  )(implicit context: Unit): R =
     testWith(new AzureStreamStore())
 
   override def resolve(location: AzureBlobLocation): URI =
     new AzureResolvable().resolve(location)
 
   override def withNamespace[R](testWith: TestWith[Container, R]): R =
-    withAzureContainer{ container =>
+    withAzureContainer { container =>
       testWith(container)
     }
 


### PR DESCRIPTION
These commits by @alicefuzier add the AzureFixityChecker, which is one of the classes we need for the Azure verifier.

A combination of 94469af and 9e4387a.

Part of wellcomecollection/platform#4595. Extracted as a set of standalone commits from #669, follows #686. I've reviewed this and I'm happy it looks good, so we can merge it if it passes tests.
