### PR TITLE
Don't fail a verification if we can't write tags to Azure

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -11,7 +11,7 @@ sealed trait FileFixityError[BagLocation]
 
 case class FileFixityCorrect[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: BagLocation,
+  location: BagLocation,
   // We record the size of the files as we verify them, so we can verify
   // the Payload-Oxum in the bag metadata.
   size: Long
@@ -19,7 +19,7 @@ case class FileFixityCorrect[BagLocation](
 
 case class FileFixityMismatch[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: BagLocation,
+  location: BagLocation,
   e: Throwable
 ) extends FileFixityError[BagLocation]
 
@@ -30,12 +30,12 @@ case class FileFixityCouldNotRead[BagLocation](
 
 case class FileFixityCouldNotGetChecksum[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: BagLocation,
+  location: BagLocation,
   e: Throwable
 ) extends FileFixityError[BagLocation]
 
 case class FileFixityCouldNotWriteTag[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
-  objectLocation: BagLocation,
+  location: BagLocation,
   e: Throwable
 ) extends FileFixityError[BagLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FileFixityResult.scala
@@ -37,5 +37,8 @@ case class FileFixityCouldNotGetChecksum[BagLocation](
 case class FileFixityCouldNotWriteTag[BagLocation](
   expectedFileFixity: ExpectedFileFixity,
   location: BagLocation,
-  e: Throwable
+  e: Throwable,
+  // If we're at the point where we're writing a fixity checksum to an object,
+  // we've already verified its checksum and size.  Record the size.
+  size: Long
 ) extends FileFixityError[BagLocation]

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -126,7 +126,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           Left(
             FileFixityMismatch(
               expectedFileFixity = expectedFileFixity,
-              objectLocation = location,
+              location = location,
               e = new Throwable(
                 s"Lengths do not match: $expectedLength (expected) != $actualLength (actual)"
               )
@@ -150,7 +150,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Right(
           FileFixityCorrect(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             size = size
           )
         )
@@ -159,7 +159,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Left(
           FileFixityMismatch(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             e = new Throwable(
               s"Cached verification tag doesn't match expected checksum for $location: $existingTags (${expectedFileFixity.checksum})"
             )
@@ -204,7 +204,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Left(
           FileFixityCouldNotGetChecksum(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             e = FailedChecksumCreation(algorithm, e)
           )
         )
@@ -213,7 +213,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Right(
           FileFixityCorrect(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             size = inputStream.length
           )
         )
@@ -222,7 +222,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Left(
           FileFixityMismatch(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             e = FailedChecksumNoMatch(
               actual = checksum,
               expected = expectedFileFixity.checksum
@@ -269,7 +269,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         Left(
           FileFixityCouldNotWriteTag(
             expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
+            location = location,
             e = writeError.e
           )
         )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -68,7 +68,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         size = size
       )
 
-      _ <- writeFixityTags(expectedFileFixity, location)
+      _ <- writeFixityTags(expectedFileFixity, location, size)
     } yield result
 
     debug(s"Fixity check result for ${expectedFileFixity.uri}: $fixityResult")
@@ -241,7 +241,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
 
   private def writeFixityTags(
     expectedFileFixity: ExpectedFileFixity,
-    location: BagLocation
+    location: BagLocation,
+    size: Long
   ): Either[FileFixityCouldNotWriteTag[BagLocation], Unit] =
     tags
       .update(location) { existingTags =>
@@ -270,7 +271,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           FileFixityCouldNotWriteTag(
             expectedFileFixity = expectedFileFixity,
             location = location,
-            e = writeError.e
+            e = writeError.e,
+            size = size
           )
         )
     }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListChecker.scala
@@ -39,8 +39,15 @@ class FixityListChecker[BagLocation <: Location, BagPrefix <: Prefix[
           // so for now we ignore these errors rather than write mismatched tags.
           // See https://github.com/wellcomecollection/platform/issues/4730
           .map {
-            case FileFixityCouldNotWriteTag(expectedFileFixity, location: AzureBlobLocation, e, size) =>
-              warn(s"Ignoring error writing fixity tags to Azure at $location: $e")
+            case FileFixityCouldNotWriteTag(
+                expectedFileFixity,
+                location: AzureBlobLocation,
+                e,
+                size
+                ) =>
+              warn(
+                s"Ignoring error writing fixity tags to Azure at $location: $e"
+              )
               FileFixityCorrect(
                 expectedFileFixity = expectedFileFixity,
                 location = location,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -36,7 +36,7 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[
     verificationResult match {
       case FixityListAllCorrect(locations) =>
         val expectedLocations =
-          locations.map { _.objectLocation }.toSet
+          locations.map { _.location }.toSet
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListCheckerTest.scala
@@ -1,0 +1,46 @@
+package uk.ac.wellcome.platform.archive.bagverifier.fixity
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.bag.BagExpectedFixity
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.s3.S3FixityChecker
+import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Resolvable
+import uk.ac.wellcome.platform.archive.common.bagit.models.Bag
+import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
+import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
+import uk.ac.wellcome.storage.{StoreWriteError, WriteError}
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.tags.Tags
+import uk.ac.wellcome.storage.tags.s3.S3Tags
+
+class FixityListCheckerTest extends AnyFunSpec with Matchers with S3Fixtures {
+  describe("handles a failure during tagging") {
+    it("a tagging error from S3 is raised") {
+      implicit val resolvable: S3Resolvable = new S3Resolvable()
+
+      implicit val verifiable: S3FixityChecker = new S3FixityChecker() {
+        override val tags: Tags[S3ObjectLocation] = new S3Tags() {
+          override def writeTags(location: S3ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+            Left(StoreWriteError(new Throwable("BOOM!")))
+        }
+      }
+
+      val bagBuilder = new S3BagBuilder {}
+
+      withLocalS3Bucket { bucket =>
+        val (bagRoot, _) = bagBuilder.createS3BagWith(bucket)
+
+        implicit val bagExpectedFixity: BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix] =
+          new BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix](bagRoot)
+
+        val fixityListChecker: FixityListChecker[S3ObjectLocation, S3ObjectLocationPrefix, Bag] =
+          new FixityListChecker()
+
+        val bag = new S3BagReader().get(bagRoot).right.get
+
+        fixityListChecker.check(bag) shouldBe a[FixityListWithErrors[_]]
+      }
+    }
+  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityListCheckerTest.scala
@@ -21,7 +21,10 @@ class FixityListCheckerTest extends AnyFunSpec with Matchers with S3Fixtures {
 
       implicit val verifiable: S3FixityChecker = new S3FixityChecker() {
         override val tags: Tags[S3ObjectLocation] = new S3Tags() {
-          override def writeTags(location: S3ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+          override def writeTags(
+            location: S3ObjectLocation,
+            tags: Map[String, String]
+          ): Either[WriteError, Map[String, String]] =
             Left(StoreWriteError(new Throwable("BOOM!")))
         }
       }
@@ -31,10 +34,14 @@ class FixityListCheckerTest extends AnyFunSpec with Matchers with S3Fixtures {
       withLocalS3Bucket { bucket =>
         val (bagRoot, _) = bagBuilder.createS3BagWith(bucket)
 
-        implicit val bagExpectedFixity: BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix] =
-          new BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix](bagRoot)
+        implicit val bagExpectedFixity
+          : BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix] =
+          new BagExpectedFixity[S3ObjectLocation, S3ObjectLocationPrefix](
+            bagRoot
+          )
 
-        val fixityListChecker: FixityListChecker[S3ObjectLocation, S3ObjectLocationPrefix, Bag] =
+        val fixityListChecker
+          : FixityListChecker[S3ObjectLocation, S3ObjectLocationPrefix, Bag] =
           new FixityListChecker()
 
         val bag = new S3BagReader().get(bagRoot).right.get

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -607,7 +607,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
   ): Assertion =
     if (successes
           .map { fixityEntry =>
-            fixityEntry.objectLocation match {
+            fixityEntry.location match {
               case azureBlobLocation: AzureBlobLocation =>
                 azureBlobLocation.name
               case s3ObjectLocation: S3ObjectLocation => s3ObjectLocation.key


### PR DESCRIPTION
Because we know there are issues with the fixity tag we write to S3 if we write it to Azure: https://github.com/wellcomecollection/platform/issues/4730

We're not ignoring all errors in tagging (in particular, if we have a tagging issue in S3, it should still bubble up as a failure), nor are we injecting config deep into the heart of the verifier to decide whether to tag. It always tries to tag, and sometimes ignores the failure.

(So if Azure ever change their mind about what metadata is allowed, this code will quietly start working.)

Still needs a test that it actually lets an Azure tagging failure pass through.