### PR TITLE
Move the StorageManifestDao classes into the bag tracker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,14 @@ SBT_APPS = notifier \
            bags_api \
            bag_register \
            bag_tagger \
+           bag_tracker \
            bag_replicator \
 		   bag_root_finder \
            bag_verifier \
            bag_unpacker \
            bag_versioner \
            replica_aggregator
-SBT_NO_DOCKER_APPS = bag_tracker
+SBT_NO_DOCKER_APPS =
 
 SBT_DOCKER_LIBRARIES    = common
 SBT_NO_DOCKER_LIBRARIES = bags_common display

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -14,7 +14,10 @@ import uk.ac.wellcome.platform.archive.bag_register.services.{
   Register,
   S3StorageManifestService
 }
-import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
+import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
+  BagTrackerFixtures,
+  StorageManifestDaoFixture
+}
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   BagVersion,

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
   BagTrackerFixtures,
   StorageManifestDaoFixture
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   BagVersion,
@@ -37,7 +38,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestStatusUpdate
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
@@ -7,12 +7,12 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
-import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  OperationFixtures,
+import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
+  BagTrackerFixtures,
   StorageManifestDaoFixture
 }
+import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
+import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
   StorageManifestFile

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
@@ -11,13 +11,13 @@ import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
   BagTrackerFixtures,
   StorageManifestDaoFixture
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
   StorageManifestFile
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.storage.bag_tagger.services.{
   ApplyTags,
   BagTaggerWorker,

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/BagTaggerWorkerTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/BagTaggerWorkerTest.scala
@@ -8,11 +8,11 @@ import uk.ac.wellcome.messaging.worker.models.{
   NonDeterministicFailure,
   Successful
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.storage.bag_tagger.fixtures.BagTaggerFixtures
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.tags.s3.S3Tags

--- a/bag_tracker/docker-compose.yml
+++ b/bag_tracker/docker-compose.yml
@@ -1,0 +1,10 @@
+dynamodb:
+  image: peopleperhour/dynamodb
+  ports:
+    - "45678:8000"
+s3:
+  image: "zenko/cloudserver:8.1.8"
+  environment:
+    - "S3BACKEND=mem"
+  ports:
+    - "33333:8000"

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.platform.archive.bag_tracker.services.{
   GetLatestBag,
   LookupBagVersions
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
   BagVersion,
@@ -22,7 +23,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
   StorageSpace
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContextExecutor, Future}

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/Main.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/Main.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.bag_tracker
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import uk.ac.wellcome.platform.archive.common.config.builders.StorageManifestDaoBuilder
+import uk.ac.wellcome.platform.archive.bag_tracker.config.builders.StorageManifestDaoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/config/builders/StorageManifestDaoBuilder.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/config/builders/StorageManifestDaoBuilder.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.config.builders
+package uk.ac.wellcome.platform.archive.bag_tracker.config.builders
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/config/builders/StorageManifestDaoBuilder.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/config/builders/StorageManifestDaoBuilder.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.archive.bag_tracker.config.builders
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.archive.common.storage.services.dynamo.DynamoStorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.dynamo.DynamoStorageManifestDao
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 
 object StorageManifestDaoBuilder {

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/CreateBag.scala
@@ -4,8 +4,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 
 trait CreateBag extends Logging {
   val storageManifestDao: StorageManifestDao

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetBag.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.{DoesNotExistError, NoVersionExistsError}
 
 trait GetBag extends Logging {

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/GetLatestBag.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.NoVersionExistsError
 
 trait GetLatestBag extends Logging {

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/LookupBagVersions.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/services/LookupBagVersions.scala
@@ -10,8 +10,8 @@ import uk.ac.wellcome.platform.archive.bag_tracker.models.{
   BagVersionEntry,
   BagVersionList
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 
 import scala.concurrent.ExecutionContext
 

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDao.scala
@@ -1,9 +1,9 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.bag_tracker.storage
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.VersionedStore
+import uk.ac.wellcome.storage.{ReadError, Version, WriteError}
 
 trait StorageManifestDao {
   val vhs: VersionedStore[

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services.dynamo
+package uk.ac.wellcome.platform.archive.bag_tracker.storage.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3
@@ -6,10 +6,10 @@ import org.scanamo.auto._
 import org.scanamo.{Scanamo, Table => ScanamoTable}
 import org.scanamo.syntax._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, DynamoHashRangeEntry}
 import uk.ac.wellcome.storage.s3.{
   S3Config,

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/memory/MemoryStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/memory/MemoryStorageManifestDao.scala
@@ -1,8 +1,8 @@
-package uk.ac.wellcome.platform.archive.common.storage.services.memory
+package uk.ac.wellcome.platform.archive.bag_tracker.storage.memory
 
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 
 import uk.ac.wellcome.storage.{ReadError, Version}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
@@ -4,10 +4,10 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bag_tracker.BagTrackerApi
 import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 trait BagTrackerClientTestBase extends Matchers with BagTrackerFixtures {

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/CreateBagTestCases.scala
@@ -3,10 +3,10 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.{StoreWriteError, WriteError}
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   StorageManifestGenerators
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.storage.{ReadError, StoreReadError}
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   StorageManifestGenerators
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.storage.{ReadError, StoreReadError}
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
@@ -7,13 +7,13 @@ import uk.ac.wellcome.platform.archive.bag_tracker.models.{
   BagVersionEntry,
   BagVersionList
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   StorageManifestGenerators
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.storage.{ReadError, StoreReadError}
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/BagTrackerFixtures.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/BagTrackerFixtures.scala
@@ -8,8 +8,7 @@ import uk.ac.wellcome.platform.archive.bag_tracker.client.{
   AkkaBagTrackerClient,
   BagTrackerClient
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 trait BagTrackerFixtures extends Akka {
   private val host: String = "localhost"
   private val port: Int = 8080

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/StorageManifestDaoFixture.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/StorageManifestDaoFixture.scala
@@ -2,10 +2,9 @@ package uk.ac.wellcome.platform.archive.bag_tracker.fixtures
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/StorageManifestDaoFixture.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/fixtures/StorageManifestDaoFixture.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.fixtures
+package uk.ac.wellcome.platform.archive.bag_tracker.fixtures
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.json.JsonUtil._

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.bag_tracker.storage
 
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDaoTest.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDaoTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services.dynamo
+package uk.ac.wellcome.platform.archive.bag_tracker.storage.dynamo
 
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
 import org.scanamo.auto._
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.{
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.{
   StorageManifestDao,
   StorageManifestDaoTestCases
 }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/memory/MemoryStorageManifestDaoTest.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/memory/MemoryStorageManifestDaoTest.scala
@@ -1,12 +1,12 @@
-package uk.ac.wellcome.platform.archive.common.storage.services.memory
+package uk.ac.wellcome.platform.archive.bag_tracker.storage.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.{
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.{
   StorageManifestDao,
   StorageManifestDaoTestCases
 }
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 class MemoryStorageManifestDaoTest

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -8,12 +8,14 @@ import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.platform.archive.bag_tracker.client.BagTrackerClient
-import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
+import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
+  BagTrackerFixtures,
+  StorageManifestDaoFixture
+}
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   HttpFixtures,
-  StorageManifestDaoFixture,
   StorageRandomThings
 }
 import uk.ac.wellcome.platform.archive.common.http.{

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -12,6 +12,8 @@ import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
   BagTrackerFixtures,
   StorageManifestDaoFixture
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.fixtures.{
@@ -23,9 +25,7 @@ import uk.ac.wellcome.platform.archive.common.http.{
   WellcomeHttpApp
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3Uploader
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.fixtures.S3Fixtures

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -4,10 +4,6 @@ s3:
     - "S3BACKEND=mem"
   ports:
     - "33333:8000"
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"
 azurite:
   image: "mcr.microsoft.com/azure-storage/azurite"
   ports:

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -8,4 +8,11 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="reactor.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestDaoFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestDaoFixture.scala
@@ -22,13 +22,8 @@ trait StorageManifestDaoFixture extends EitherValues {
       initialEntries = Map.empty
     ) with MemoryMaxima[String, String]
 
-  def createTypedStore: StorageManifestTypedStore = {
-    val memoryStoreForStreamStore =
-      new MemoryStore[String, Array[Byte]](Map.empty)
-    implicit val streamStore: MemoryStreamStore[String] =
-      new MemoryStreamStore[String](memoryStoreForStreamStore)
-    new MemoryTypedStore[String, StorageManifest](Map.empty)
-  }
+  def createTypedStore: StorageManifestTypedStore =
+    MemoryTypedStore[String, StorageManifest](initialEntries = Map.empty)
 
   def createStorageManifestDao(): StorageManifestDao =
     new MemoryStorageManifestDao(

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/BagIndexerWorkerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/BagIndexerWorkerTest.scala
@@ -9,11 +9,11 @@ import uk.ac.wellcome.messaging.worker.models.{
   DeterministicFailure,
   NonDeterministicFailure
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.archive.indexer.IndexerWorkerTestCases
 import uk.ac.wellcome.platform.archive.indexer.bag.fixtures.BagIndexerFixtures
 import uk.ac.wellcome.platform.archive.indexer.bags.BagIndexerWorker

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/fixtures/BagIndexerFixtures.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/fixtures/BagIndexerFixtures.scala
@@ -7,12 +7,14 @@ import org.scalatest.Suite
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
+import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
+  BagTrackerFixtures,
+  StorageManifestDaoFixture
+}
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
 }
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageManifestDaoFixture
 import uk.ac.wellcome.platform.archive.common.generators.{
   IngestGenerators,
   PayloadGenerators,

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/fixtures/BagIndexerFixtures.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/fixtures/BagIndexerFixtures.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
   BagTrackerFixtures,
   StorageManifestDaoFixture
 }
+import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
   ExternalIdentifier
@@ -24,7 +25,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
   StorageSpace
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.BagRegistrationNotification
 import uk.ac.wellcome.platform.archive.indexer.bags.models.IndexedStorageManifest
 import uk.ac.wellcome.platform.archive.indexer.bags.{


### PR DESCRIPTION
 These classes used to live in the common lib, but really they're only accessed directly by the bag tracker (and indirectly in the tests of apps that use the bag tracker). They don't really belong in the common lib.