### PR TITLE
Give read-only credentials to the Azure verifier

### DIFF
--- a/monitoring/end_to_end_bag_test/src/end_to_end_bag_test.py
+++ b/monitoring/end_to_end_bag_test/src/end_to_end_bag_test.py
@@ -52,6 +52,9 @@ def main(*args):
 
     print(ingest_location)
 
+    ingest_id = ingest_location.split("/")[-1]
+    return f"https://wellcome-ingest-inspector.glitch.me/ingests/{ingest_id}"
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/_azure.py
+++ b/scripts/_azure.py
@@ -29,15 +29,9 @@ def _create_sas_uris(connection_string, *, expiry, ip):
         if expiry is None:
             raise TypeError(f"expiry cannot be None!")
 
-        for mode, allow_write in (
-            ("read_only", False),
-            ("read_write", True),
-        ):
+        for mode, allow_write in (("read_only", False), ("read_write", True)):
             permission = ContainerSasPermissions(
-                read=True,
-                write=allow_write,
-                delete=False,
-                list=True
+                read=True, write=allow_write, delete=False, list=True
             )
 
             token = generate_container_sas(

--- a/scripts/azure_create_replicator_credentials.py
+++ b/scripts/azure_create_replicator_credentials.py
@@ -49,8 +49,8 @@ if __name__ == "__main__":
 
         log_event(f"Creating SAS URIs for containers in {account_name}...")
 
-        for container_name, sas_uri in create_prod_sas_uris(connection_string):
-            secret_id = f"azure/{account_name}/{container_name}/read_write_sas_url"
+        for container_name, mode, sas_uri in create_prod_sas_uris(connection_string):
+            secret_id = f"azure/{account_name}/{container_name}/{mode}_sas_url"
             store_secret(secret_id=secret_id, secret_string=sas_uri)
             log_outcome(
                 f"Stored secret:\n - container: {container_name}\n - secret ID: {secret_id}"

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -511,9 +511,15 @@ module "replicator_verifier_azure" {
   topic_arns = [
     module.bag_versioner_output_topic.arn,
   ]
-  secrets = {
-    azure_endpoint = var.azure_endpoint_ssm_parameter
+
+  verifier_secrets = {
+    azure_endpoint = "${var.azure_ssm_parameter_base}/read_only_sas_url"
   }
+
+  replicator_secrets = {
+    azure_endpoint = "${var.azure_ssm_parameter_base}/read_write_sas_url"
+  }
+
   destination_namespace = var.azure_container_name
   primary_bucket_name   = var.replica_primary_bucket_name
   unpacker_bucket_name  = aws_s3_bucket.unpacked_bags.id

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -30,7 +30,7 @@ module "bag_replicator" {
     JAVA_OPTS             = "${local.java_opts_heap_size} ${local.java_opts_metrics_base},metricNameSpace=${local.bag_replicator_service_name}"
   }
 
-  secrets = var.secrets
+  secrets = var.replicator_secrets
 
   cpu    = 1024
   memory = 2048
@@ -70,7 +70,7 @@ module "bag_verifier" {
 
     primary_storage_bucket_name = var.primary_bucket_name
   }
-  secrets = var.secrets
+  secrets = var.verifier_secrets
 
   cpu    = 2048
   memory = 4096

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -97,7 +97,12 @@ variable "bag_verifier_image" {
   type = string
 }
 
-variable "secrets" {
+variable "verifier_secrets" {
+  type    = map(string)
+  default = {}
+}
+
+variable "replicator_secrets" {
   type    = map(string)
   default = {}
 }

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -77,7 +77,7 @@ variable "static_content_bucket_name" {
   type = string
 }
 
-variable "azure_endpoint_ssm_parameter" {
+variable "azure_ssm_parameter_base" {
   type = string
 }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -16,7 +16,7 @@ module "stack_prod" {
   min_capacity = 0
   max_capacity = 10
 
-  azure_endpoint_ssm_parameter = "azure/wecostorageprod/wellcomecollection-storage-replica-netherlands/read_write_sas_url"
+  azure_ssm_parameter_base = "azure/wecostorageprod/wellcomecollection-storage-replica-netherlands"
 
   vpc_id = local.vpc_id
 

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -16,7 +16,7 @@ module "stack_staging" {
   min_capacity = 0
   max_capacity = 3
 
-  azure_endpoint_ssm_parameter = "azure/wecostoragestage/wellcomecollection-storage-staging-replica-netherlands/read_write_sas_url"
+  azure_ssm_parameter_base = "azure/wecostoragestage/wellcomecollection-storage-staging-replica-netherlands"
 
   vpc_id = local.vpc_id
 


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4730

Previously we gave the Azure verifier read-write credentials, so it could tag blobs in Azure. (The SAS permissions aren't as granular as IAM permissions, so we couldn't give it "write tags but not blobs".)

Because we no longer tag objects in Azure, we can reduce the permissions we give the verifier to read-only.

This change is tested and applied in both staging and prod.