### PR TITLE
Expose the status of Azure immutability policies/legal holds in TF

### DIFF
--- a/terraform/critical_prod/outputs.tf
+++ b/terraform/critical_prod/outputs.tf
@@ -44,12 +44,17 @@ output "vhs_manifests_table_name" {
   value = module.critical.vhs_manifests_table_name
 }
 
+# These two outputs aren't actually sensitive, but they're verbose and clutter
+# up the CLI output.  Adding sensitive = true hides them from the CLI output.
+# See https://www.terraform.io/docs/configuration/outputs.html
 output "vhs_manifests_readonly_policy" {
-  value = module.critical.vhs_manifests_readonly_policy
+  value     = module.critical.vhs_manifests_readonly_policy
+  sensitive = true
 }
 
 output "vhs_manifests_readwrite_policy" {
-  value = module.critical.vhs_manifests_readwrite_policy
+  value     = module.critical.vhs_manifests_readwrite_policy
+  sensitive = true
 }
 
 #
@@ -66,3 +71,12 @@ output "versions_table_index" {
   value = module.critical.versions_table_index
 }
 
+# Azure containers
+
+output "azure_has_immutability_policy" {
+  value = module.critical.azure_has_immutability_policy
+}
+
+output "azure_has_legal_hold" {
+  value = module.critical.azure_has_legal_hold
+}

--- a/terraform/critical_staging/outputs.tf
+++ b/terraform/critical_staging/outputs.tf
@@ -44,12 +44,17 @@ output "vhs_manifests_table_name" {
   value = module.critical.vhs_manifests_table_name
 }
 
+# These two outputs aren't actually sensitive, but they're verbose and clutter
+# up the CLI output.  Adding sensitive = true hides them from the CLI output.
+# See https://www.terraform.io/docs/configuration/outputs.html
 output "vhs_manifests_readonly_policy" {
-  value = module.critical.vhs_manifests_readonly_policy
+  value     = module.critical.vhs_manifests_readonly_policy
+  sensitive = true
 }
 
 output "vhs_manifests_readwrite_policy" {
-  value = module.critical.vhs_manifests_readwrite_policy
+  value     = module.critical.vhs_manifests_readwrite_policy
+  sensitive = true
 }
 
 #
@@ -66,3 +71,12 @@ output "versions_table_index" {
   value = module.critical.versions_table_index
 }
 
+# Azure containers
+
+output "azure_has_immutability_policy" {
+  value = module.critical.azure_has_immutability_policy
+}
+
+output "azure_has_legal_hold" {
+  value = module.critical.azure_has_legal_hold
+}

--- a/terraform/modules/critical/azure_replica.tf
+++ b/terraform/modules/critical/azure_replica.tf
@@ -29,6 +29,13 @@ resource "azurerm_storage_account" "wellcome" {
   access_tier = "Cool"
 }
 
+# These containers both have legal holds enabled, as described in
+# https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-immutable-storage
+#
+# Unfortunately Legal Holds cannot be managed by Terraform (yet)
+# See https://github.com/terraform-providers/terraform-provider-azurerm/issues/3722
+#
+# If/when Legal Holds can be managed in Terraform, do that here.
 resource "azurerm_storage_container" "container" {
   name                  = "wellcomecollection-${var.namespace}-replica-netherlands"
   storage_account_name  = azurerm_storage_account.wellcome.name

--- a/terraform/modules/critical/outputs.tf
+++ b/terraform/modules/critical/outputs.tf
@@ -81,3 +81,13 @@ output "versions_table_name" {
 output "versions_table_index" {
   value = local.versioner_versions_table_index
 }
+
+# Azure containers
+
+output "azure_has_immutability_policy" {
+  value = azurerm_storage_container.container.has_immutability_policy
+}
+
+output "azure_has_legal_hold" {
+  value = azurerm_storage_container.container.has_legal_hold
+}


### PR DESCRIPTION
We can't actually manage legal holds in Terraform, but we can document their presence and expose whether or not they're enabled.

Closes https://github.com/wellcomecollection/platform/issues/4731

e.g.

![Screenshot 2020-08-18 at 11 07 43](https://user-images.githubusercontent.com/301220/90500628-0f103400-e143-11ea-9afb-ab2d153a41c0.png)
