### PR TITLE
Allow an empty External-Description in bag-info.txt

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
@@ -256,7 +256,7 @@ object BagInfoParser extends Logging {
       //
       // Some values cannot be empty, e.g. ExternalIdentifier; this is enforced
       // by the type.
-      case BAG_INFO_LABEL_ONLY_REGEX(label)   => Right((label, ""))
-      case _                                  => Left(line)
+      case BAG_INFO_LABEL_ONLY_REGEX(label) => Right((label, ""))
+      case _                                => Left(line)
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
@@ -244,10 +244,19 @@ object BagInfoParser extends Logging {
   //      Contact-Name: Jane Doe
   //
   private val BAG_INFO_FIELD_REGEX = """(.+)\s*:\s(.+)\s*""".r
+  private val BAG_INFO_LABEL_ONLY_REGEX = """(.+)\s*:""".r
 
   private def parseSingleLine(line: String): Either[String, (String, String)] =
     line match {
       case BAG_INFO_FIELD_REGEX(label, value) => Right((label, value))
+      // The BagIt spec is a little ambiguous on whether empty values are
+      // allowed.  We do have bag-info.txt files with empty values in the
+      // storage service (e.g. staging, digitised/b20442713/v1), so we
+      // allow them.
+      //
+      // Some values cannot be empty, e.g. ExternalIdentifier; this is enforced
+      // by the type.
+      case BAG_INFO_LABEL_ONLY_REGEX(label)   => Right((label, ""))
       case _                                  => Left(line)
     }
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4760