### PR TITLE
Another fix for an empty External-Description

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParser.scala
@@ -244,7 +244,7 @@ object BagInfoParser extends Logging {
   //      Contact-Name: Jane Doe
   //
   private val BAG_INFO_FIELD_REGEX = """(.+)\s*:\s(.+)\s*""".r
-  private val BAG_INFO_LABEL_ONLY_REGEX = """(.+)\s*:""".r
+  private val BAG_INFO_LABEL_ONLY_REGEX = """(.+)\s*:\s*""".r
 
   private def parseSingleLine(line: String): Either[String, (String, String)] =
     line match {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParserTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParserTest.scala
@@ -224,7 +224,8 @@ class BagInfoParserTest
 
     it("allows an External-Description with extra whitespace") {
       // Based on a real bag; digitised/b31366752/v8 in the staging service
-      val bagInfoString = "External-Description: \nExternal-Identifier: b31366752\nPayload-Oxum: 1777806903.3821\nBagging-Date: 2019-09-18"
+      val bagInfoString =
+        "External-Description: \nExternal-Identifier: b31366752\nPayload-Oxum: 1777806903.3821\nBagging-Date: 2019-09-18"
 
       val bagInfo =
         BagInfoParser.create(toInputStream(bagInfoString)).success.value

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParserTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagInfoParserTest.scala
@@ -222,6 +222,15 @@ class BagInfoParserTest
       bagInfo.externalDescription shouldBe Some(ExternalDescription(""))
     }
 
+    it("allows an External-Description with extra whitespace") {
+      // Based on a real bag; digitised/b31366752/v8 in the staging service
+      val bagInfoString = "External-Description: \nExternal-Identifier: b31366752\nPayload-Oxum: 1777806903.3821\nBagging-Date: 2019-09-18"
+
+      val bagInfo =
+        BagInfoParser.create(toInputStream(bagInfoString)).success.value
+      bagInfo.externalDescription shouldBe Some(ExternalDescription(""))
+    }
+
     it("blocks an empty External-Identifier") {
       val bagInfoString =
         s"""|External-Identifier:


### PR DESCRIPTION
The trailing whitespace is stripped in the previous test, so a line with extra whitespace, e.g., `External-Description: `, doesn't get parsed.

Closes https://github.com/wellcomecollection/platform/issues/4760 (again)