### PR TITLE
Only make a GetObject API call if something goes wrong

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinder.scala
@@ -7,33 +7,45 @@ import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.s3.{S3Errors, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.RetryableReadable
 
+import scala.util.{Failure, Success, Try}
+
 class S3SizeFinder(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
     extends SizeFinder[S3ObjectLocation]
     with RetryableReadable[S3ObjectLocation, Long] {
 
   override def retryableGetFunction(location: S3ObjectLocation): Long = {
-    // We use getObject here rather than getObjectMetadata so we get more
-    // detailed errors from S3 about why a GetObject fails, if necessary.
+    // We default to using getObjectMetadata, which will return the size
+    // immediately on the happy path; we fall back to getObject if it fails
+    // because it gives us more more detailed errors from S3 about why
+    // a GetObject fails.  This helps us pass more informative messages upstream.
     //
     // e.g. GetObject will return "The bucket name was invalid" rather than
     // "Bad Request".
     //
-    val s3Object = s3Client.getObject(
-      new GetObjectRequest(location.bucket, location.key)
-    )
-    val metadata = s3Object.getObjectMetadata
-    val contentLength = metadata.getContentLength
+    Try {
+      s3Client
+        .getObjectMetadata(location.bucket, location.key)
+        .getContentLength
+    } match {
+      case Success(length) => length
+      case Failure(_) =>
+        val s3Object = s3Client.getObject(
+          new GetObjectRequest(location.bucket, location.key)
+        )
+        val metadata = s3Object.getObjectMetadata
+        val contentLength = metadata.getContentLength
 
-    // Abort the stream to avoid getting a warning:
-    //
-    //    Not all bytes were read from the S3ObjectInputStream, aborting
-    //    HTTP connection. This is likely an error and may result in
-    //    sub-optimal behavior.
-    //
-    s3Object.getObjectContent.abort()
-    s3Object.getObjectContent.close()
+        // Abort the stream to avoid getting a warning:
+        //
+        //    Not all bytes were read from the S3ObjectInputStream, aborting
+        //    HTTP connection. This is likely an error and may result in
+        //    sub-optimal behavior.
+        //
+        s3Object.getObjectContent.abort()
+        s3Object.getObjectContent.close()
 
-    contentLength
+        contentLength
+    }
   }
 
   override def buildGetError(throwable: Throwable): ReadError =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3LargeStreamReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3LargeStreamReaderTest.scala
@@ -69,7 +69,11 @@ class S3LargeStreamReaderTest
 
       // One to get the size of the object, two to read the contents
       Mockito
-        .verify(spyClient, Mockito.atLeast(3))
+        .verify(spyClient, Mockito.atLeast(1))
+        .getObjectMetadata(location.bucket, location.key)
+
+      Mockito
+        .verify(spyClient, Mockito.atLeast(2))
         .getObject(any[GetObjectRequest])
     }
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinderTest.scala
@@ -59,8 +59,12 @@ class S3SizeFinderTest
       val inputStream = randomInputStream()
 
       s3Client.putObject(
-        new PutObjectRequest(location.bucket, location.key, inputStream, new ObjectMetadata())
-          .withStorageClass(StorageClass.Glacier)
+        new PutObjectRequest(
+          location.bucket,
+          location.key,
+          inputStream,
+          new ObjectMetadata()
+        ).withStorageClass(StorageClass.Glacier)
       )
 
       val spyClient = spy(s3Client)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3SizeFinderTest.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
   SizeFinder,
   SizeFinderTestCases
 }
+import uk.ac.wellcome.storage.DoesNotExistError
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
@@ -37,6 +38,7 @@ class S3SizeFinderTest
 
     val result = sizeFinder.getSize(createS3ObjectLocation)
 
+    result.left.value shouldBe a[DoesNotExistError]
     result.left.value.e shouldBe a[AmazonS3Exception]
   }
 }


### PR DESCRIPTION
One of the changes I snuck into https://github.com/wellcomecollection/storage-service/pull/714 is that S3SizeFinder now does a GetObject instead of a HeadObject. This is to expose better error messages in the bag unpacker if something goes wrong, but on the vast majority of calls it won't.

Thus, the new behaviour:

* Try a HeadObject API call first.
* If it succeeds, great, otherwise try a GetObject API call.
* If the Get succeeds (which would be odd, but oh well), great, otherwise use the more detailed error to return to the user