### PR TITLE
Bump the visibilityTimeout in this bag root finder test

### DIFF
--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -39,7 +39,7 @@ class BagRootFinderFeatureTest
         bagRoot = unpackedBagRoot
       )
 
-      withLocalSqsQueue() { queue =>
+      withLocalSqsQueue(visibilityTimeout = 5) { queue =>
         val ingests = new MemoryMessageSender()
         val outgoing = new MemoryMessageSender()
         withWorkerService(


### PR DESCRIPTION
Occasionally it doesn't quite complete in the default timeout (1 second), so the test fails because it sees two ingest results instead of one.

See https://travis-ci.org/github/wellcomecollection/storage-service/jobs/721042247