### PR TITLE
Make the Azure transfer more reliable and cheaper

### DIFF
--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.storage.store.azure.AzureTypedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.transfer.{TransferNoOp, TransferOverwriteFailure}
 
-class AzurePutBlockFromURLTransferTest extends AnyFunSpec with Matchers with S3Fixtures with AzureFixtures {
+class AzurePutBlockFromURLTransferTest
+    extends AnyFunSpec
+    with Matchers
+    with S3Fixtures
+    with AzureFixtures {
   val srcStore: S3TypedStore[String] = S3TypedStore[String]
   val dstStore: AzureTypedStore[String] = AzureTypedStore[String]
 
@@ -23,7 +27,10 @@ class AzurePutBlockFromURLTransferTest extends AnyFunSpec with Matchers with S3F
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
           dstStore.put(dst)("Hello world") shouldBe a[Right[_, _]]
 
-          transfer.transfer(src, dst, checkForExisting = true).right.value shouldBe TransferNoOp(src, dst)
+          transfer
+            .transfer(src, dst, checkForExisting = true)
+            .right
+            .value shouldBe TransferNoOp(src, dst)
         }
       }
     }
@@ -37,7 +44,10 @@ class AzurePutBlockFromURLTransferTest extends AnyFunSpec with Matchers with S3F
           srcStore.put(src)("hello world") shouldBe a[Right[_, _]]
           dstStore.put(dst)("HELLO WORLD") shouldBe a[Right[_, _]]
 
-          transfer.transfer(src, dst, checkForExisting = true).right.value shouldBe TransferNoOp(src, dst)
+          transfer
+            .transfer(src, dst, checkForExisting = true)
+            .right
+            .value shouldBe TransferNoOp(src, dst)
         }
       }
     }
@@ -51,7 +61,10 @@ class AzurePutBlockFromURLTransferTest extends AnyFunSpec with Matchers with S3F
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
           dstStore.put(dst)("Greetings, humans") shouldBe a[Right[_, _]]
 
-          transfer.transfer(src, dst, checkForExisting = true).left.value shouldBe a[TransferOverwriteFailure[_, _]]
+          transfer
+            .transfer(src, dst, checkForExisting = true)
+            .left
+            .value shouldBe a[TransferOverwriteFailure[_, _]]
         }
       }
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
@@ -1,0 +1,59 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage.azure
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
+import uk.ac.wellcome.storage.store.azure.AzureTypedStore
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.transfer.{TransferNoOp, TransferOverwriteFailure}
+
+class AzurePutBlockFromURLTransferTest extends AnyFunSpec with Matchers with S3Fixtures with AzureFixtures {
+  val srcStore: S3TypedStore[String] = S3TypedStore[String]
+  val dstStore: AzureTypedStore[String] = AzureTypedStore[String]
+
+  val transfer = new AzurePutBlockFromUrlTransfer()
+
+  describe("does a no-op transfer for similar-looking objects") {
+    it("identical contents => no-op") {
+      withLocalS3Bucket { srcBucket =>
+        withAzureContainer { dstContainer =>
+          val src = createS3ObjectLocationWith(srcBucket)
+          val dst = createAzureBlobLocationWith(dstContainer)
+
+          srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
+          dstStore.put(dst)("Hello world") shouldBe a[Right[_, _]]
+
+          transfer.transfer(src, dst, checkForExisting = true).right.value shouldBe TransferNoOp(src, dst)
+        }
+      }
+    }
+
+    it("identical sizes, different contents => no-op") {
+      withLocalS3Bucket { srcBucket =>
+        withAzureContainer { dstContainer =>
+          val src = createS3ObjectLocationWith(srcBucket)
+          val dst = createAzureBlobLocationWith(dstContainer)
+
+          srcStore.put(src)("hello world") shouldBe a[Right[_, _]]
+          dstStore.put(dst)("HELLO WORLD") shouldBe a[Right[_, _]]
+
+          transfer.transfer(src, dst, checkForExisting = true).right.value shouldBe TransferNoOp(src, dst)
+        }
+      }
+    }
+
+    it("different sizes => failure") {
+      withLocalS3Bucket { srcBucket =>
+        withAzureContainer { dstContainer =>
+          val src = createS3ObjectLocationWith(srcBucket)
+          val dst = createAzureBlobLocationWith(dstContainer)
+
+          srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
+          dstStore.put(dst)("Greetings, humans") shouldBe a[Right[_, _]]
+
+          transfer.transfer(src, dst, checkForExisting = true).left.value shouldBe a[TransferOverwriteFailure[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
@@ -167,7 +167,11 @@ class AzurePutBlockTransferTest
 
         val blockId = BlobRangeUtil.getBlockIdentifiers(count = 3).head
 
-        blockClient.stageBlock(blockId, new ByteArrayInputStream("Hello".getBytes()), 5)
+        blockClient.stageBlock(
+          blockId,
+          new ByteArrayInputStream("Hello".getBytes()),
+          5
+        )
 
         var howManyBlocksWritten = 0
 
@@ -195,7 +199,8 @@ class AzurePutBlockTransferTest
   }
 
   describe("retrying a failed Put Block operation") {
-    class AzureFlakyBlockTransfer(maxFailures: Int) extends AzurePutBlockTransfer(blockSize = 5L) {
+    class AzureFlakyBlockTransfer(maxFailures: Int)
+        extends AzurePutBlockTransfer(blockSize = 5L) {
       var failures = 0
 
       override def writeBlockToAzure(
@@ -228,7 +233,11 @@ class AzurePutBlockTransferTest
           val result = transfer.transfer(src, dst)
           result.right.value shouldBe TransferPerformed(src, dst)
 
-          AzureTypedStore[String].get(dst).right.value.identifiedT shouldBe "Hello world"
+          AzureTypedStore[String]
+            .get(dst)
+            .right
+            .value
+            .identifiedT shouldBe "Hello world"
       }
     }
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.storage.store.azure.AzureTypedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.transfer.{
   Transfer,
+  TransferDestinationFailure,
   TransferPerformed,
   TransferTestCases
 }
@@ -190,6 +191,60 @@ class AzurePutBlockTransferTest
         // "Hello world" is 11 bytes long.  Bytes 1-5 were already written, which means
         // the transfer should have written 6-10 and 11-.
         howManyBlocksWritten shouldBe 2
+    }
+  }
+
+  describe("retrying a failed Put Block operation") {
+    class AzureFlakyBlockTransfer(maxFailures: Int) extends AzurePutBlockTransfer(blockSize = 5L) {
+      var failures = 0
+
+      override def writeBlockToAzure(
+        src: S3ObjectLocation,
+        dst: AzureBlobLocation,
+        range: BlobRange,
+        blockId: String,
+        s3Length: Long,
+        context: Unit
+      ): Unit = {
+        failures += 1
+        if (failures > maxFailures) {
+          super.writeBlockToAzure(src, dst, range, blockId, s3Length, context)
+        } else {
+          throw new Throwable("BOOM! This is a flaky failure")
+        }
+      }
+    }
+
+    it("retries a single flaky error") {
+      withNamespacePair {
+        case (srcBucket, dstContainer) =>
+          val src = createSrcLocation(srcBucket)
+          val dst = createDstLocation(dstContainer)
+
+          S3TypedStore[String].put(src)("Hello world") shouldBe a[Right[_, _]]
+
+          val transfer = new AzureFlakyBlockTransfer(maxFailures = 1)
+
+          val result = transfer.transfer(src, dst)
+          result.right.value shouldBe TransferPerformed(src, dst)
+
+          AzureTypedStore[String].get(dst).right.value.identifiedT shouldBe "Hello world"
+      }
+    }
+
+    it("does not retry errors forever") {
+      withNamespacePair {
+        case (srcBucket, dstContainer) =>
+          val src = createSrcLocation(srcBucket)
+          val dst = createDstLocation(dstContainer)
+
+          S3TypedStore[String].put(src)("Hello world") shouldBe a[Right[_, _]]
+
+          val transfer = new AzureFlakyBlockTransfer(maxFailures = Int.MaxValue)
+
+          val result = transfer.transfer(src, dst)
+          result.left.value shouldBe a[TransferDestinationFailure[_, _]]
+      }
     }
   }
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
@@ -1,5 +1,8 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage.azure
 
+import java.io.ByteArrayInputStream
+
+import com.azure.storage.blob.models.BlobRange
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
@@ -144,6 +147,49 @@ class AzurePutBlockTransferTest
             }
           }
       }
+    }
+  }
+
+  it("skips blocks that have already been written") {
+    withNamespacePair {
+      case (srcBucket, dstContainer) =>
+        val src = createSrcLocation(srcBucket)
+        val dst = createDstLocation(dstContainer)
+
+        s3Client.putObject(src.bucket, src.key, "Hello world")
+
+        // Write the first block to the destination blob
+        val blockClient = azureClient
+          .getBlobContainerClient(dst.container)
+          .getBlobClient(dst.name)
+          .getBlockBlobClient
+
+        val blockId = BlobRangeUtil.getBlockIdentifiers(count = 3).head
+
+        blockClient.stageBlock(blockId, new ByteArrayInputStream("Hello".getBytes()), 5)
+
+        var howManyBlocksWritten = 0
+
+        val transfer = new AzurePutBlockTransfer(blockSize = 5L) {
+          override def writeBlockToAzure(
+            src: S3ObjectLocation,
+            dst: AzureBlobLocation,
+            range: BlobRange,
+            blockId: String,
+            s3Length: Long,
+            context: Unit
+          ): Unit = {
+            howManyBlocksWritten += 1
+            super.writeBlockToAzure(src, dst, range, blockId, s3Length, context)
+          }
+        }
+
+        val result = transfer.transfer(src, dst)
+        result.right.value shouldBe TransferPerformed(src, dst)
+
+        // "Hello world" is 11 bytes long.  Bytes 1-5 were already written, which means
+        // the transfer should have written 6-10 and 11-.
+        howManyBlocksWritten shouldBe 2
     }
   }
 }


### PR DESCRIPTION
Addresses some issues discovered in https://github.com/wellcomecollection/platform/issues/4743

To write large blobs to Azure, we write a series of smaller, individual blocks and stitch them together at the end. The replicator should be the only service that's writing these blocks, so with this in mind we can cut a few corners to save time and money:

* The Azure API lets you look up all the blocks that have been written but not stitched together (“uncommitted blocks”). Because each instance of the replicator should pick the same blocks + block identifiers, **skip writing a block that already exists in Azure.** This means that if a replicator is interrupted midway through, it won't have to re-send all those blocks.

   (If a bad block somehow makes it in, the verifier will catch it.)

* We need to make (size of object / 100 MiB) individual Put Block calls for a replication to succeed. In S3, I think the TransferManager class might be doing some retrying logic for us; do the same here. **Retry each individual Put Block call up to three times before failing the replication.**

* If a blob already exists in the destination, the usual Transfer behaviour is to read out the whole stream, and compare it to the source – so we pay to read that information out of Azure. Again, since the verifier will do the proper checking of this blob, we can reduce unnecessary data transfer here. **If the destination blob in Azure exists and is the same size as the source object in S3, skip an exhaustive check of the contents.**

We can do these exhaustive checks inside S3 because the data transfer is "free" – we're only paying for the GetObject API call. In Azure, these exhaustive checks cost real money and add little value, given the verifier will be running immediately afterwards.

I realise this adds even more complexity to an already thorny area of the codebase; unfortunately I think we have to do this in the absence of an Azure equivalent of TransferManager.

The proof is in the pudding – we'll see if this allows us to replicate the 133 GiB MXF video, and how it does when we backfill the prod bags. I have managed to test all the changes, so we have some degree of confidence that it works.