### PR TITLE
If we can't read a range, expose the underlying error

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/LargeStreamReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/LargeStreamReader.scala
@@ -82,7 +82,9 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
     inner.retry(maxAttempts = retries)((ident, range)) match {
       case Right(bytes) => bytes
       case Left(err) =>
-        throw new RuntimeException(s"Unable to read range $range from $ident: $err")
+        throw new RuntimeException(
+          s"Unable to read range $range from $ident: $err"
+        )
     }
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/LargeStreamReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/LargeStreamReader.scala
@@ -82,7 +82,7 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
     inner.retry(maxAttempts = retries)((ident, range)) match {
       case Right(bytes) => bytes
       case Left(err) =>
-        throw new RuntimeException(s"Unable to read range $range from $ident")
+        throw new RuntimeException(s"Unable to read range $range from $ident: $err")
     }
   }
 }


### PR DESCRIPTION
We had an Azure verification fail to read an OpenByteRange(0), but it doesn't include the underlying error message.

Expose it for easier debugging (e.g. is this a timeout? the object isn't there?).

Discovered while debugging https://wellcome-ingest-inspector.glitch.me/ingests/17495c0c-6d84-47db-b43b-4f30630b3ede