### PR TITLE
Don't write tags to blobs in Azure after all…

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -281,7 +281,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
       .getOrElse(Right(()))
 
   // e.g. Content-MD5, Content-SHA256
-  protected def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =
+  private def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =
     s"Content-${expectedFileFixity.checksum.algorithm.pathRepr.toUpperCase}"
 
   private def fixityTagValue(expectedFileFixity: ExpectedFileFixity): String =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -266,16 +266,16 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
 
         Right(existingTags ++ fixityTags)
       } match {
-      case Right(_) => Right(())
-      case Left(writeError) =>
-        Left(
-          FileFixityCouldNotWriteTag(
-            expectedFileFixity = expectedFileFixity,
-            objectLocation = location,
-            e = writeError.e
+        case Right(_) => Right(())
+        case Left(writeError) =>
+          Left(
+            FileFixityCouldNotWriteTag(
+              expectedFileFixity = expectedFileFixity,
+              objectLocation = location,
+              e = writeError.e
+            )
           )
-        )
-    }
+      }
 
   // e.g. Content-MD5, Content-SHA256
   protected def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -1,10 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
 
 import com.azure.storage.blob.BlobServiceClient
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
-  ExpectedFileFixity,
-  FixityChecker
-}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.{ExpectedFileFixity, FixityChecker}
 import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureLocatable
 import uk.ac.wellcome.platform.archive.common.storage.services.azure.{
   AzureLargeStreamReader,
@@ -46,9 +43,7 @@ class AzureFixityChecker(implicit blobClient: BlobServiceClient)
   // We can't include a hyphen in the name because Azure metadata names have to be
   // valid C# identifiers.
   // See https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources#Subheading1
-  override protected def fixityTagName(
-    expectedFileFixity: ExpectedFileFixity
-  ): String =
+  override protected def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =
     s"Content${expectedFileFixity.checksum.algorithm.pathRepr.toUpperCase}"
 
   override implicit val locator: AzureLocatable = new AzureLocatable

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.platform.archive.common.storage.services.azure.{
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.tags.azure.AzureBlobMetadata
 
 class AzureFixityChecker(implicit blobClient: BlobServiceClient)
     extends FixityChecker[AzureBlobLocation, AzureBlobLocationPrefix] {
@@ -37,7 +36,13 @@ class AzureFixityChecker(implicit blobClient: BlobServiceClient)
   override protected val sizeFinder =
     new AzureSizeFinder()
 
-  override val tags = Some(new AzureBlobMetadata())
+  /**
+    * The FixityChecker tags objects with their checksum so that,
+    * if they are lifecycled to cold storage, we don't need to read them to know the checksum.
+    * This is useful for files referenced in the fetch file. However, references in the fetch file
+    * will always point to the primary bucket in S3, never Azure, so there's no need to tag in the AzureFixityChecker
+    */
+  override val tags = None
 
   // e.g. ContentMD5, ContentSHA256
   // We can't include a hyphen in the name because Azure metadata names have to be

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -37,7 +37,7 @@ class AzureFixityChecker(implicit blobClient: BlobServiceClient)
   override protected val sizeFinder =
     new AzureSizeFinder()
 
-  override val tags = new AzureBlobMetadata()
+  override val tags = Some(new AzureBlobMetadata())
 
   // e.g. ContentMD5, ContentSHA256
   // We can't include a hyphen in the name because Azure metadata names have to be

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
 
 import com.azure.storage.blob.BlobServiceClient
-import uk.ac.wellcome.platform.archive.bagverifier.fixity.{ExpectedFileFixity, FixityChecker}
+import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureLocatable
 import uk.ac.wellcome.platform.archive.common.storage.services.azure.{
   AzureLargeStreamReader,
@@ -43,13 +43,6 @@ class AzureFixityChecker(implicit blobClient: BlobServiceClient)
     * will always point to the primary bucket in S3, never Azure, so there's no need to tag in the AzureFixityChecker
     */
   override val tags = None
-
-  // e.g. ContentMD5, ContentSHA256
-  // We can't include a hyphen in the name because Azure metadata names have to be
-  // valid C# identifiers.
-  // See https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources#Subheading1
-  override protected def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =
-    s"Content${expectedFileFixity.checksum.algorithm.pathRepr.toUpperCase}"
 
   override implicit val locator: AzureLocatable = new AzureLocatable
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityChecker.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.storage.tags.memory.MemoryTags
 
 class MemoryFixityChecker(
   val streamReader: MemoryStreamStore[MemoryLocation],
-  val tags: MemoryTags[MemoryLocation]
+  val tags: Option[MemoryTags[MemoryLocation]]
 ) extends FixityChecker[MemoryLocation, MemoryLocationPrefix] {
 
   override protected val sizeFinder: SizeFinder[MemoryLocation] =

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.s3.S3SizeFinder
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
+import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.s3.S3Tags
 
 class S3FixityChecker(implicit s3Client: AmazonS3)
@@ -23,8 +24,7 @@ class S3FixityChecker(implicit s3Client: AmazonS3)
   override protected val sizeFinder: S3SizeFinder =
     new S3SizeFinder()
 
-  override val tags = new S3Tags()
-
+  override val tags: Option[Tags[S3ObjectLocation]] = Some(new S3Tags())
   override implicit val locator
     : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
     S3Locatable.s3UriLocatable

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTagsTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTagsTestCases.scala
@@ -47,7 +47,8 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
           fixityChecker.check(expectedFileFixity) shouldBe a[
             FileFixityCorrect[_]
           ]
-          fixityChecker.tags.get(location).right.value shouldBe Identified(
+          fixityChecker.tags shouldBe defined
+          fixityChecker.tags.get.get(location).right.value shouldBe Identified(
             location,
             Map(
               tagName(checksum.algorithm) -> checksumString
@@ -196,7 +197,8 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
             FileFixityMismatch[_]
           ]
 
-          fixityChecker.tags.get(location).right.value shouldBe Identified(
+          fixityChecker.tags shouldBe defined
+          fixityChecker.tags.get.get(location).right.value shouldBe Identified(
             location,
             Map.empty
           )
@@ -239,7 +241,8 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
             ]
           }
 
-          fixityChecker.tags.get(location).right.value shouldBe Identified(
+          fixityChecker.tags shouldBe defined
+          fixityChecker.tags.get.get(location).right.value shouldBe Identified(
             location,
             Map(
               tagName(MD5) -> "68e109f0f40ca72a15e05cc22786f8e6",

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -108,7 +108,7 @@ class FixityCheckerTests
     it("if it can't write the fixity tags") {
       val streamStore = MemoryStreamStore[MemoryLocation]()
 
-      val tags = new MemoryTags[MemoryLocation](initialTags = Map.empty) {
+      val tags = Some(new MemoryTags[MemoryLocation](initialTags = Map.empty) {
         override def get(
           location: MemoryLocation
         ): Either[ReadError, Identified[MemoryLocation, Map[String, String]]] =
@@ -127,7 +127,7 @@ class FixityCheckerTests
             StoreWriteError(new Throwable("BOOM!"))
           )
         }
-      }
+      })
 
       val contentString = "HelloWorld"
       val checksum =
@@ -248,8 +248,8 @@ class FixityCheckerTests
     }
   }
 
-  def createMemoryTags: MemoryTags[MemoryLocation] =
-    new MemoryTags[MemoryLocation](initialTags = Map.empty) {
+  def createMemoryTags: Option[MemoryTags[MemoryLocation]] =
+    Some(new MemoryTags[MemoryLocation](initialTags = Map.empty) {
       override def get(
         location: MemoryLocation
       ): Either[ReadError, Identified[MemoryLocation, Map[String, String]]] =
@@ -259,5 +259,5 @@ class FixityCheckerTests
             Right(Identified(location, Map[String, String]()))
           case Left(err) => Left(err)
         }
-    }
+    })
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -5,17 +5,16 @@ import java.net.URI
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityChecker,
-  FixityCheckerTagsTestCases
+  FixityCheckerTestCases
 }
 import uk.ac.wellcome.platform.archive.bagverifier.storage.azure.AzureResolvable
-import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
 import uk.ac.wellcome.storage.store.azure.{AzureStreamStore, AzureTypedStore}
 
 class AzureFixityCheckerTest
-    extends FixityCheckerTagsTestCases[
+    extends FixityCheckerTestCases[
       AzureBlobLocation,
       AzureBlobLocationPrefix,
       Container,
@@ -60,12 +59,4 @@ class AzureFixityCheckerTest
 
   override def createId(implicit container: Container): AzureBlobLocation =
     createAzureBlobLocationWith(container)
-
-  override def tagName(algorithm: HashingAlgorithm): String =
-    algorithm match {
-      case MD5 => "ContentMD5"
-      case SHA1 => "ContentSHA1"
-      case SHA256 => "ContentSHA256"
-      case SHA512 => "ContentSHA512"
-    }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityCheckerTest.scala
@@ -63,8 +63,8 @@ class AzureFixityCheckerTest
 
   override def tagName(algorithm: HashingAlgorithm): String =
     algorithm match {
-      case MD5    => "ContentMD5"
-      case SHA1   => "ContentSHA1"
+      case MD5 => "ContentMD5"
+      case SHA1 => "ContentSHA1"
       case SHA256 => "ContentSHA256"
       case SHA512 => "ContentSHA512"
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -22,15 +22,15 @@ class MemoryFixityCheckerTest
       MemoryLocation,
       MemoryLocationPrefix,
       String,
-      (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation]),
+      (MemoryStreamStore[MemoryLocation], Option[MemoryTags[MemoryLocation]]),
       MemoryStreamStore[MemoryLocation]
     ]
     with EitherValues {
   type MemoryContext =
-    (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation])
+    (MemoryStreamStore[MemoryLocation], Option[MemoryTags[MemoryLocation]])
 
-  def createMemoryTags: MemoryTags[MemoryLocation] =
-    new MemoryTags[MemoryLocation](initialTags = Map.empty) {
+  def createMemoryTags: Option[MemoryTags[MemoryLocation]] =
+    Some(new MemoryTags[MemoryLocation](initialTags = Map.empty) {
       override def get(
         location: MemoryLocation
       ): Either[ReadError, Identified[MemoryLocation, Map[String, String]]] =
@@ -40,7 +40,7 @@ class MemoryFixityCheckerTest
             Right(Identified(location, Map[String, String]()))
           case Left(err) => Left(err)
         }
-    }
+    })
 
   override def withContext[R](
     testWith: TestWith[MemoryContext, R]

--- a/ingests/ingests_api/src/test/resources/logback-test.xml
+++ b/ingests/ingests_api/src/test/resources/logback-test.xml
@@ -8,4 +8,10 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/ingests/ingests_tracker/src/test/resources/logback-test.xml
+++ b/ingests/ingests_tracker/src/test/resources/logback-test.xml
@@ -8,4 +8,10 @@
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/ingests/ingests_worker/src/test/resources/logback-test.xml
+++ b/ingests/ingests_worker/src/test/resources/logback-test.xml
@@ -9,6 +9,9 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-      <logger name="com.amazonaws" level="WARN"/>
-    <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
 </configuration>

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -514,7 +514,7 @@ module "replicator_verifier_azure" {
   ]
 
   verifier_secrets = {
-    azure_endpoint = "${var.azure_ssm_parameter_base}/read_write_sas_url"
+    azure_endpoint = "${var.azure_ssm_parameter_base}/read_only_sas_url"
   }
 
   replicator_secrets = {

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -44,8 +44,6 @@ module "bag_replicator" {
 
   deployment_service_name = var.deployment_service_name_replicator
   deployment_service_env  = var.deployment_service_env
-
-  use_fargate_spot = true
 }
 
 # bag_verifier
@@ -86,7 +84,5 @@ module "bag_verifier" {
 
   deployment_service_name = var.deployment_service_name_verifier
   deployment_service_env  = var.deployment_service_env
-
-  use_fargate_spot = true
 }
 


### PR DESCRIPTION
…because legal holds mean you can't modify the metadata after a blob has been written.