### PR TITLE
Transfer objects to Azure whose keys end with a dot

### DIFF
--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
@@ -1,19 +1,18 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage.azure
 
-import com.amazonaws.services.s3.iterable.S3Objects
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
 import uk.ac.wellcome.storage.store.azure.AzureTypedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.transfer.{TransferNoOp, TransferOverwriteFailure}
-import scala.collection.convert.ImplicitConversions._
 
 class AzurePutBlockFromURLTransferTest
     extends AnyFunSpec
     with Matchers
     with S3Fixtures
-    with AzureFixtures {
+    with AzureFixtures
+    with AzureTransferFixtures {
   val srcStore: S3TypedStore[String] = S3TypedStore[String]
   val dstStore: AzureTypedStore[String] = AzureTypedStore[String]
 
@@ -27,8 +26,9 @@ class AzurePutBlockFromURLTransferTest
           val dst = createAzureBlobLocationWith(dstContainer)
 
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
-          val srcSummary =
-            S3Objects.withPrefix(s3Client, src.bucket, src.key).head
+          val srcSummary = createS3ObjectSummaryFrom(
+            src, size = "Hello world".getBytes().length
+          )
 
           dstStore.put(dst)("Hello world") shouldBe a[Right[_, _]]
 
@@ -47,8 +47,9 @@ class AzurePutBlockFromURLTransferTest
           val dst = createAzureBlobLocationWith(dstContainer)
 
           srcStore.put(src)("hello world") shouldBe a[Right[_, _]]
-          val srcSummary =
-            S3Objects.withPrefix(s3Client, src.bucket, src.key).head
+          val srcSummary = createS3ObjectSummaryFrom(
+            src, size = "hello world".getBytes().length
+          )
           dstStore.put(dst)("HELLO WORLD") shouldBe a[Right[_, _]]
 
           transfer
@@ -66,8 +67,9 @@ class AzurePutBlockFromURLTransferTest
           val dst = createAzureBlobLocationWith(dstContainer)
 
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
-          val srcSummary =
-            S3Objects.withPrefix(s3Client, src.bucket, src.key).head
+          val srcSummary = createS3ObjectSummaryFrom(
+            src, size = "Hello world".getBytes().length
+          )
           dstStore.put(dst)("Greetings, humans") shouldBe a[Right[_, _]]
 
           transfer

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator.storage.azure
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import uk.ac.wellcome.storage.azure.AzureBlobLocation
 import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.azure.AzureTypedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.transfer.{TransferNoOp, TransferOverwriteFailure}
@@ -12,7 +15,8 @@ class AzurePutBlockFromURLTransferTest
     with Matchers
     with S3Fixtures
     with AzureFixtures
-    with AzureTransferFixtures {
+    with AzureTransferFixtures
+    with TableDrivenPropertyChecks {
   val srcStore: S3TypedStore[String] = S3TypedStore[String]
   val dstStore: AzureTypedStore[String] = AzureTypedStore[String]
 
@@ -76,6 +80,32 @@ class AzurePutBlockFromURLTransferTest
             .transfer(srcSummary, dst, checkForExisting = true)
             .left
             .value shouldBe a[TransferOverwriteFailure[_, _]]
+        }
+      }
+    }
+  }
+
+  it("handles weird keys") {
+    val weirdKeys = Table(
+      "key",
+      "born-digital/SATSY/1821/4/v1/data/objects/Disc_4/Outreach_-_misc/PFFD_enquiry_-Dawn_G.",
+    )
+
+    withLocalS3Bucket { bucket =>
+      withAzureContainer { container =>
+        forAll(weirdKeys) { key =>
+          val src = S3ObjectLocation(bucket.name, key)
+          val dst = AzureBlobLocation(container.name, key)
+
+          srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
+
+          transfer.transfer(
+            src = createS3ObjectSummaryFrom(src),
+            dst = dst,
+            checkForExisting = true
+          ) shouldBe a[Right[_, _]]
+
+          dstStore.get(dst).right.value.identifiedT shouldBe "Hello world"
         }
       }
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockFromURLTransferTest.scala
@@ -31,7 +31,8 @@ class AzurePutBlockFromURLTransferTest
 
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
           val srcSummary = createS3ObjectSummaryFrom(
-            src, size = "Hello world".getBytes().length
+            src,
+            size = "Hello world".getBytes().length
           )
 
           dstStore.put(dst)("Hello world") shouldBe a[Right[_, _]]
@@ -52,7 +53,8 @@ class AzurePutBlockFromURLTransferTest
 
           srcStore.put(src)("hello world") shouldBe a[Right[_, _]]
           val srcSummary = createS3ObjectSummaryFrom(
-            src, size = "hello world".getBytes().length
+            src,
+            size = "hello world".getBytes().length
           )
           dstStore.put(dst)("HELLO WORLD") shouldBe a[Right[_, _]]
 
@@ -72,7 +74,8 @@ class AzurePutBlockFromURLTransferTest
 
           srcStore.put(src)("Hello world") shouldBe a[Right[_, _]]
           val srcSummary = createS3ObjectSummaryFrom(
-            src, size = "Hello world".getBytes().length
+            src,
+            size = "Hello world".getBytes().length
           )
           dstStore.put(dst)("Greetings, humans") shouldBe a[Right[_, _]]
 
@@ -88,7 +91,7 @@ class AzurePutBlockFromURLTransferTest
   it("handles weird keys") {
     val weirdKeys = Table(
       "key",
-      "born-digital/SATSY/1821/4/v1/data/objects/Disc_4/Outreach_-_misc/PFFD_enquiry_-Dawn_G.",
+      "born-digital/SATSY/1821/4/v1/data/objects/Disc_4/Outreach_-_misc/PFFD_enquiry_-Dawn_G."
     )
 
     withLocalS3Bucket { bucket =>

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzurePutBlockTransferTest.scala
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.azure.storage.blob.models.BlobRange
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.azure.AzureBlobLocation
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
@@ -38,7 +37,7 @@ class AzurePutBlockTransferTest
     ]
     with S3Fixtures
     with AzureFixtures
-    with StorageRandomThings {
+    with AzureTransferFixtures {
 
   val blockSize: Int = 10000
 
@@ -61,16 +60,7 @@ class AzurePutBlockTransferTest
 
   override def createSrcLocation(bucket: Bucket): S3ObjectSummary = {
     val src = createS3ObjectLocationWith(bucket)
-    val summary = new S3ObjectSummary()
-    summary.setBucketName(src.bucket)
-    summary.setKey(src.key)
-
-    // By default, the size of an S3ObjectSummary() is zero.  We don't want it to
-    // be zero, because then the underlying S3 SDK will skip trying to read it;
-    // the correct size will be set in the StreamStore[S3ObjectSummary].
-    summary.setSize(randomInt(from = 1, to = 50))
-
-    summary
+    createS3ObjectSummaryFrom(src)
   }
 
   override def createDstLocation(container: Container): AzureBlobLocation =

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzureTransferFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/azure/AzureTransferFixtures.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage.azure
+
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+
+trait AzureTransferFixtures extends StorageRandomThings {
+  def createS3ObjectSummaryFrom(
+    location: S3ObjectLocation,
+    size: Long = randomInt(from = 1, to = 50)
+  ): S3ObjectSummary = {
+    val summary = new S3ObjectSummary()
+    summary.setBucketName(location.bucket)
+    summary.setKey(location.key)
+
+    // By default, the size of an S3ObjectSummary() is zero.  We don't want it to
+    // be zero, because then the underlying S3 SDK will skip trying to read it;
+    // the correct size will be set in the StreamStore[S3ObjectSummary].
+    summary.setSize(size)
+
+    summary
+  }
+}


### PR DESCRIPTION
Turns out a key that ends with a `.` has issues with Azure; I'm assuming because "Put Block from URL" can't actually get any data from the URL. This patch modifies the URLTransfer to fallback to transferring the bytes directly in this case. We don't want to do this all the time, but we can make one-off exceptions.