### PR TITLE
Implement a multi-size finder for S3

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/S3StorageManifestService.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/S3StorageManifestService.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
-import uk.ac.wellcome.platform.archive.common.storage.services.s3.{S3MultiSizeFinder, S3SizeFinder}
+import uk.ac.wellcome.platform.archive.common.storage.services.s3.{
+  S3MultiSizeFinder,
+  S3SizeFinder
+}
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.azure.AzureBlobLocation
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -363,15 +363,14 @@ class StorageManifestServiceTest
         )
 
         val storageManifestSizes =
-          (storageManifest.manifest.files ++ storageManifest.tagManifest.files)
-            .map { file =>
+          (storageManifest.manifest.files ++ storageManifest.tagManifest.files).map {
+            file =>
               storageManifest.location.prefix.asLocation(file.path) -> file.size
-            }
-            .toMap
+          }.toMap
 
         val expectedSizes =
           (bagContents.bagObjects ++ bagContents.fetchObjects)
-            .map { case (loc, contents) => loc -> contents.getBytes.length}
+            .map { case (loc, contents) => loc -> contents.getBytes.length }
 
         storageManifestSizes shouldBe expectedSizes
       }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinder.scala
@@ -29,17 +29,19 @@ import scala.collection.JavaConverters._
 // class for every new prefix/collection of objects.
 //
 class S3MultiSizeFinder(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
-  extends SizeFinder[S3ObjectLocation]
+    extends SizeFinder[S3ObjectLocation]
     with RetryableReadable[S3ObjectLocation, Long] {
 
   private var sizeCache: Map[S3ObjectLocation, Long] = Map.empty
 
   private val fallback = new S3SizeFinder(maxRetries = maxRetries)
 
-  override protected def retryableGetFunction(location: S3ObjectLocation): Long =
+  override protected def retryableGetFunction(
+    location: S3ObjectLocation
+  ): Long =
     sizeCache.get(location) match {
       case Some(size) => size
-      case None       =>
+      case None =>
         freshenCache(location)
 
         // It's possible that a ListObjectsV2 result might miss this key --
@@ -69,9 +71,10 @@ class S3MultiSizeFinder(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
     )
 
     sizeCache = sizeCache ++ resp.getObjectSummaries.asScala
-      .map { summary => S3ObjectLocation(location.bucket, summary.getKey) -> summary.getSize }
+      .map { summary =>
+        S3ObjectLocation(location.bucket, summary.getKey) -> summary.getSize
+      }
   }
-
 
   override protected def buildGetError(throwable: Throwable): ReadError =
     S3Errors.readErrors(throwable)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinder.scala
@@ -1,0 +1,53 @@
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{AmazonS3Exception, ListObjectsV2Request}
+import uk.ac.wellcome.platform.archive.common.storage.services.SizeFinder
+import uk.ac.wellcome.storage.ReadError
+import uk.ac.wellcome.storage.s3.{S3Errors, S3ObjectLocation}
+import uk.ac.wellcome.storage.store.RetryableReadable
+
+import scala.collection.JavaConverters._
+
+// A variant of S3SizeFinder suitable for looking up the size of lots
+// of objects that are adjacent in an S3 bucket.
+//
+// It gets up to 1000 objects at once with a single ListObjectsV2 call
+// and caches the result, rather than individual HeadObject requests.
+//
+// Note: there is no cache eviction logic; create a new instance of this
+// class for every new prefix/collection of objects.
+class S3MultiSizeFinder(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
+  extends SizeFinder[S3ObjectLocation]
+    with RetryableReadable[S3ObjectLocation, Long] {
+
+  // (bucket) -> Map(key -> size)
+  private var cache: Map[S3ObjectLocation, Long] = Map.empty
+
+  override protected def retryableGetFunction(location: S3ObjectLocation): Long =
+    cache.get(location) match {
+      case Some(size) => size
+      case None       =>
+        freshenCache(location)
+
+        val exc = new AmazonS3Exception(s"Unable to find size of object $location")
+        exc.setStatusCode(404)
+
+        cache.getOrElse(location, throw exc)
+    }
+
+  private def freshenCache(location: S3ObjectLocation): Unit = {
+    val resp = s3Client.listObjectsV2(
+      new ListObjectsV2Request()
+        .withBucketName(location.bucket)
+        .withStartAfter(location.key.dropRight(1))
+    )
+
+    cache = cache ++ resp.getObjectSummaries.asScala
+      .map { summary => S3ObjectLocation(location.bucket, summary.getKey) -> summary.getSize }
+  }
+
+
+  override protected def buildGetError(throwable: Throwable): ReadError =
+    S3Errors.readErrors(throwable)
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -58,6 +58,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }
+
   def storeBagContents(bagContents: BagContents)(
     implicit typedStore: TypedStore[BagLocation, String]
   ): Unit = {
@@ -171,10 +172,10 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     }.toMap
 
     BagContents(
-      fetchObjects,
-      manifestObjects ++ payloadObjects,
-      bagRoot,
-      bagInfo
+      fetchObjects = fetchObjects,
+      bagObjects = manifestObjects ++ payloadObjects,
+      bagRoot = bagRoot,
+      bagInfo = bagInfo
     )
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
@@ -68,13 +68,13 @@ class S3MultiSizeFinderTest extends SizeFinderTestCases[S3ObjectLocation, Bucket
       // This means our ListObjects request might miss the object we're interested
       // in if the key layout causes a lookup miss.
       (1 to 1000).foreach { i =>
-        s3Client.putObject(bucket.name, s"file-a$i", randomAlphanumeric)
+        s3Client.putObject(bucket.name, s"object-a$i", randomAlphanumeric)
       }
 
       val size = randomInt(from = 10, to = 100)
-      s3Client.putObject(bucket.name, "file-b", randomAlphanumericWithLength(size))
+      s3Client.putObject(bucket.name, "object-b", randomAlphanumericWithLength(size))
 
-      val location = S3ObjectLocation(bucket.name, key = "file-b")
+      val location = S3ObjectLocation(bucket.name, key = "object-b")
 
       finder.getSize(location).right.value shouldBe size
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
@@ -1,17 +1,26 @@
 package uk.ac.wellcome.platform.archive.common.storage.services.s3
 
-import com.amazonaws.services.s3.model.{GetObjectMetadataRequest, ListObjectsV2Request}
+import com.amazonaws.services.s3.model.{
+  GetObjectMetadataRequest,
+  ListObjectsV2Request
+}
 import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.platform.archive.common.storage.services.{SizeFinder, SizeFinderTestCases}
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  SizeFinder,
+  SizeFinderTestCases
+}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
-class S3MultiSizeFinderTest extends SizeFinderTestCases[S3ObjectLocation, Bucket] with S3Fixtures with StorageRandomThings {
+class S3MultiSizeFinderTest
+    extends SizeFinderTestCases[S3ObjectLocation, Bucket]
+    with S3Fixtures
+    with StorageRandomThings {
   override def withContext[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
       testWith(bucket)
@@ -46,15 +55,19 @@ class S3MultiSizeFinderTest extends SizeFinderTestCases[S3ObjectLocation, Bucket
         size -> S3ObjectLocation(bucket.name, key)
       }
 
-      locations.foreach { case (s, loc) =>
-        finder.getSize(loc).right.value shouldBe s
+      locations.foreach {
+        case (s, loc) =>
+          finder.getSize(loc).right.value shouldBe s
       }
 
       // We don't care about the exact number of calls; the important thing is
       // that we're not making 1100 of them!
-      verify(spyClient, Mockito.atMost(5)).listObjectsV2(any[ListObjectsV2Request])
-      verify(spyClient, Mockito.never()).getObjectMetadata(any[String], any[String])
-      verify(spyClient, Mockito.never()).getObjectMetadata(any[GetObjectMetadataRequest])
+      verify(spyClient, Mockito.atMost(5))
+        .listObjectsV2(any[ListObjectsV2Request])
+      verify(spyClient, Mockito.never())
+        .getObjectMetadata(any[String], any[String])
+      verify(spyClient, Mockito.never())
+        .getObjectMetadata(any[GetObjectMetadataRequest])
     }
   }
 
@@ -72,7 +85,11 @@ class S3MultiSizeFinderTest extends SizeFinderTestCases[S3ObjectLocation, Bucket
       }
 
       val size = randomInt(from = 10, to = 100)
-      s3Client.putObject(bucket.name, "object-b", randomAlphanumericWithLength(size))
+      s3Client.putObject(
+        bucket.name,
+        "object-b",
+        randomAlphanumericWithLength(size)
+      )
 
       val location = S3ObjectLocation(bucket.name, key = "object-b")
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/s3/S3MultiSizeFinderTest.scala
@@ -1,0 +1,60 @@
+package uk.ac.wellcome.platform.archive.common.storage.services.s3
+
+import com.amazonaws.services.s3.model.{GetObjectMetadataRequest, ListObjectsV2Request}
+import org.mockito.Matchers._
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.platform.archive.common.storage.services.{SizeFinder, SizeFinderTestCases}
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+
+class S3MultiSizeFinderTest extends SizeFinderTestCases[S3ObjectLocation, Bucket] with S3Fixtures with StorageRandomThings {
+  override def withContext[R](testWith: TestWith[Bucket, R]): R =
+    withLocalS3Bucket { bucket =>
+      testWith(bucket)
+    }
+
+  override def withSizeFinder[R](
+    testWith: TestWith[SizeFinder[S3ObjectLocation], R]
+  )(implicit context: Bucket): R =
+    testWith(new S3MultiSizeFinder())
+
+  override def createIdent(implicit bucket: Bucket): S3ObjectLocation =
+    createS3ObjectLocationWith(bucket)
+
+  override def createObject(location: S3ObjectLocation, contents: String)(
+    implicit context: Bucket
+  ): Unit =
+    s3Client.putObject(location.bucket, location.key, contents)
+
+  it("finds thousands of objects with only a handful of API calls") {
+    val spyClient = spy(s3Client)
+
+    val finder = new S3MultiSizeFinder()(spyClient)
+
+    withLocalS3Bucket { bucket =>
+      // More objects makes the test go longer; the key is to have more objects
+      // than get returned in a single ListObjectsV2 API call (1000).
+      val locations = (1 to 1100).map { size =>
+        val key = s"file-$size.txt"
+
+        s3Client.putObject(bucket.name, key, randomAlphanumericWithLength(size))
+
+        size -> S3ObjectLocation(bucket.name, key)
+      }
+
+      locations.foreach { case (s, loc) =>
+        finder.getSize(loc).right.value shouldBe s
+      }
+
+      // We don't care about the exact number of calls; the important thing is
+      // that we're not making 1100 of them!
+      verify(spyClient, Mockito.atMost(5)).listObjectsV2(any[ListObjectsV2Request])
+      verify(spyClient, Mockito.never()).getObjectMetadata(any[String], any[String])
+      verify(spyClient, Mockito.never()).getObjectMetadata(any[GetObjectMetadataRequest])
+    }
+  }
+}


### PR DESCRIPTION
Epistemic status: moderately experimental. I'm not sure if this is a worthwhile tradeoff of code complexity/register performance, and I'd be interested in other opinions.

In the bag register, we often need to find lots of sizes at once – if the objects in a bag are all new, and don't have sizes listed in fetch.txt. Currently we do this by making an individual HeadObject call for each object. This is slow – registering a bag with ~37k objects takes 10 minutes, because we're making ~37k individual API calls.

We can get the size of 1000 objects at once by calling ListObjectsV2, which should make registration faster and more reliable. Call it when you're asked for the size of the first object, then return cached results for the next object along.

The comments in the code should explain how it works, hopefully.