### PR TITLE
Keep the full UpdateError in the ingests tracker

### DIFF
--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
 import uk.ac.wellcome.storage.{
   NotFoundError,
+  StorageError,
   UpdateNoSourceError,
   VersionAlreadyExistsError
 }
@@ -37,9 +38,8 @@ case class MismatchedVersionUpdateError(
 
 case class NoCallbackOnIngestError() extends IngestStoreError
 
-case class IngestStoreUnexpectedError(e: Throwable) extends IngestStoreError {
-
+case class IngestStoreUnexpectedError(storageError: StorageError) extends IngestStoreError {
   override def toString: String = {
-    s"IngestStoreUnexpectedError: ${e.toString}"
+    s"IngestStoreUnexpectedError: $storageError"
   }
 }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
@@ -38,7 +38,8 @@ case class MismatchedVersionUpdateError(
 
 case class NoCallbackOnIngestError() extends IngestStoreError
 
-case class IngestStoreUnexpectedError(storageError: StorageError) extends IngestStoreError {
+case class IngestStoreUnexpectedError(storageError: StorageError)
+    extends IngestStoreError {
   override def toString: String = {
     s"IngestStoreUnexpectedError: $storageError"
   }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTracker.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTracker.scala
@@ -18,7 +18,7 @@ trait IngestTracker extends Logging {
       case Left(err: VersionAlreadyExistsError) =>
         Left(IngestAlreadyExistsError(err))
       case Left(err: StorageError) =>
-        Left(IngestStoreUnexpectedError(err.e))
+        Left(IngestStoreUnexpectedError(err))
     }
 
   def get(id: IngestID): Result =
@@ -28,7 +28,7 @@ trait IngestTracker extends Logging {
       case Left(err: NotFoundError) =>
         Left(IngestDoesNotExistError(err))
       case Left(err: StorageError) =>
-        Left(IngestStoreUnexpectedError(err.e))
+        Left(IngestStoreUnexpectedError(err))
     }
 
   def update(update: IngestUpdate): Result = {
@@ -44,7 +44,7 @@ trait IngestTracker extends Logging {
               case err: UpdateNoSourceError =>
                 UpdateNonExistentIngestError(err)
               case err =>
-                IngestStoreUnexpectedError(err.e)
+                IngestStoreUnexpectedError(err)
             }
         }
     }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -16,7 +16,12 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, UpdateWriteError, Version}
+import uk.ac.wellcome.storage.{
+  StoreReadError,
+  StoreWriteError,
+  UpdateWriteError,
+  Version
+}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
@@ -71,10 +76,16 @@ trait IngestsTrackerApiFixture
         Left(IngestStoreUnexpectedError(StoreReadError(new Throwable("BOOM!"))))
 
       override def init(ingest: Ingest): Result =
-        Left(IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!"))))
+        Left(
+          IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!")))
+        )
 
       override def update(update: IngestUpdate): Result =
-        Left(IngestStoreUnexpectedError(UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))))
+        Left(
+          IngestStoreUnexpectedError(
+            UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))
+          )
+        )
     }
 
     val callbackSender = new MemoryMessageSender()

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, UpdateWriteError, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
@@ -68,13 +68,13 @@ trait IngestsTrackerApiFixture
       )
     ) {
       override def get(id: IngestID): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(StoreReadError(new Throwable("BOOM!"))))
 
       override def init(ingest: Ingest): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!"))))
 
       override def update(update: IngestUpdate): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))))
     }
 
     val callbackSender = new MemoryMessageSender()


### PR DESCRIPTION
Currently we swallow it, which means we don't get a meaningful log from DynamoDB.

To help with https://github.com/wellcomecollection/platform/issues/4781, and to generally make future debugging easier.