### PR TITLE
If the ingest worker tries to update a non-existent ingest, retry

### DIFF
--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApi.scala
@@ -17,7 +17,8 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.services.MessagingService
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.{
   IngestDoesNotExistError,
   IngestTracker,
-  StateConflictError
+  StateConflictError,
+  UpdateNonExistentIngestError
 }
 import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.typesafe.Runnable
@@ -70,6 +71,9 @@ class IngestsTrackerApi[CallbackDestination, IngestsDestination](
                     info(s"Updated ingest: $ingest")
                     messagingService.send(ingest)
                     complete(StatusCodes.OK -> ingest)
+                  case Left(UpdateNonExistentIngestError(e)) =>
+                    error(s"Could not find ingest $id to update: $e")
+                    complete(StatusCodes.NotFound)
                   case Left(e: StateConflictError) =>
                     error(s"Ingest $id can not be updated", e)
                     complete(StatusCodes.Conflict)

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClient.scala
@@ -90,6 +90,9 @@ class AkkaIngestTrackerClient(trackerHost: Uri)(implicit as: ActorSystem)
         case StatusCodes.OK =>
           info(f"OK for PATCH to $requestUri with $ingestUpdate")
           Unmarshal(response.entity).to[Ingest].map(Right(_))
+        case StatusCodes.NotFound =>
+          warn(f"Not Found for PATCH to $requestUri with $ingestUpdate")
+          Future(Left(IngestTrackerUpdateNonExistentIngestError(ingestUpdate)))
         case StatusCodes.Conflict =>
           warn(f"Conflict for PATCH to $requestUri with $ingestUpdate")
           Future(Left(IngestTrackerUpdateConflictError(ingestUpdate)))

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -22,6 +22,9 @@ sealed trait IngestTrackerUpdateError extends IngestTrackerError {
   val ingestUpdate: IngestUpdate
 }
 
+case class IngestTrackerUpdateNonExistentIngestError(ingestUpdate: IngestUpdate)
+  extends IngestTrackerUpdateError
+
 case class IngestTrackerUpdateConflictError(ingestUpdate: IngestUpdate)
     extends IngestTrackerUpdateError
 

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerError.scala
@@ -23,7 +23,7 @@ sealed trait IngestTrackerUpdateError extends IngestTrackerError {
 }
 
 case class IngestTrackerUpdateNonExistentIngestError(ingestUpdate: IngestUpdate)
-  extends IngestTrackerUpdateError
+    extends IngestTrackerUpdateError
 
 case class IngestTrackerUpdateConflictError(ingestUpdate: IngestUpdate)
     extends IngestTrackerUpdateError

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
 import uk.ac.wellcome.storage.{
   NotFoundError,
+  StorageError,
   UpdateNoSourceError,
   VersionAlreadyExistsError
 }
@@ -37,9 +38,8 @@ case class MismatchedVersionUpdateError(
 
 case class NoCallbackOnIngestError() extends IngestStoreError
 
-case class IngestStoreUnexpectedError(e: Throwable) extends IngestStoreError {
-
+case class IngestStoreUnexpectedError(storageError: StorageError) extends IngestStoreError {
   override def toString: String = {
-    s"IngestStoreUnexpectedError: ${e.toString}"
+    s"IngestStoreUnexpectedError: $storageError"
   }
 }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestError.scala
@@ -38,7 +38,8 @@ case class MismatchedVersionUpdateError(
 
 case class NoCallbackOnIngestError() extends IngestStoreError
 
-case class IngestStoreUnexpectedError(storageError: StorageError) extends IngestStoreError {
+case class IngestStoreUnexpectedError(storageError: StorageError)
+    extends IngestStoreError {
   override def toString: String = {
     s"IngestStoreUnexpectedError: $storageError"
   }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTracker.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/IngestTracker.scala
@@ -18,7 +18,7 @@ trait IngestTracker extends Logging {
       case Left(err: VersionAlreadyExistsError) =>
         Left(IngestAlreadyExistsError(err))
       case Left(err: StorageError) =>
-        Left(IngestStoreUnexpectedError(err.e))
+        Left(IngestStoreUnexpectedError(err))
     }
 
   def get(id: IngestID): Result =
@@ -28,7 +28,7 @@ trait IngestTracker extends Logging {
       case Left(err: NotFoundError) =>
         Left(IngestDoesNotExistError(err))
       case Left(err: StorageError) =>
-        Left(IngestStoreUnexpectedError(err.e))
+        Left(IngestStoreUnexpectedError(err))
     }
 
   def update(update: IngestUpdate): Result = {
@@ -44,7 +44,7 @@ trait IngestTracker extends Logging {
               case err: UpdateNoSourceError =>
                 UpdateNonExistentIngestError(err)
               case err =>
-                IngestStoreUnexpectedError(err.e)
+                IngestStoreUnexpectedError(err)
             }
         }
     }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTracker.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTracker.scala
@@ -4,9 +4,16 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import grizzled.slf4j.Logging
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID._
-import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.{IngestTracker, UpdateNonExistentIngestError}
+import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.{
+  IngestTracker,
+  UpdateNonExistentIngestError
+}
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTracker.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTracker.scala
@@ -4,9 +4,9 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import grizzled.slf4j.Logging
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestUpdate}
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID._
-import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestTracker
+import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.{IngestTracker, UpdateNonExistentIngestError}
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore
@@ -18,4 +18,15 @@ class DynamoIngestTracker(config: DynamoConfig)(
 
   override val underlying: VersionedStore[IngestID, Int, Ingest] =
     new DynamoSingleVersionStore[IngestID, Ingest](config)
+
+  override def update(update: IngestUpdate): Result =
+    super.update(update) match {
+      case Left(UpdateNonExistentIngestError(err)) =>
+        warn(
+          s"DynamoDB could not find ingest ${update.id} to update. " +
+            "DynamoDB reads are eventually consistent and this may be fixed on retrying."
+        )
+        Left(UpdateNonExistentIngestError(err))
+      case result => result
+    }
 }

--- a/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/memory/MemoryIngestTracker.scala
+++ b/ingests/ingests_tracker/src/main/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/memory/MemoryIngestTracker.scala
@@ -7,12 +7,3 @@ import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 class MemoryIngestTracker(
   val underlying: MemoryVersionedStore[IngestID, Ingest]
 ) extends IngestTracker
-
-object MemoryIngestTracker {
-  def apply(): MemoryIngestTracker =
-    new MemoryIngestTracker(
-      underlying = MemoryVersionedStore[IngestID, Ingest](
-        initialEntries = Map.empty
-      )
-    )
-}

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApiFeatureTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/IngestsTrackerApiFeatureTest.scala
@@ -374,8 +374,8 @@ class IngestsTrackerApiFeatureTest
       withIngestsTrackerApi() {
         case (callbackSender, ingestsSender, ingestTracker) =>
           whenPatchRequestReady(path, ingestEventEntity) { response =>
-            it("responds with Conflict") {
-              response.status shouldBe StatusCodes.Conflict
+            it("responds with NotFound") {
+              response.status shouldBe StatusCodes.NotFound
             }
 
             it("does not create the Ingest") {
@@ -392,7 +392,6 @@ class IngestsTrackerApiFeatureTest
             it("does not send a CallbackNotification message") {
               callbackSender.getMessages[CallbackNotification] shouldBe empty
             }
-
           }
       }
     }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -164,7 +164,9 @@ trait IngestTrackerClientTestCases
         withIngestsTracker(ingest) { _ =>
           withIngestTrackerClient(trackerUri) { client =>
             whenReady(client.updateIngest(update)) {
-              _.left.value shouldBe IngestTrackerUpdateNonExistentIngestError(update)
+              _.left.value shouldBe IngestTrackerUpdateNonExistentIngestError(
+                update
+              )
             }
           }
         }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -157,6 +157,19 @@ trait IngestTrackerClientTestCases
         }
       }
 
+      it("errors if you apply an update to a non-existent ingest") {
+        val ingest = createIngest
+        val update = createIngestEventUpdate
+
+        withIngestsTracker(ingest) { _ =>
+          withIngestTrackerClient(trackerUri) { client =>
+            whenReady(client.updateIngest(update)) {
+              _.left.value shouldBe IngestTrackerUpdateNonExistentIngestError(update)
+            }
+          }
+        }
+      }
+
       it("errors if the tracker API returns a 500 error") {
         withBrokenIngestsTrackerApi { _ =>
           withIngestTrackerClient(trackerUri) { client =>

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/client/IngestTrackerClientTest.scala
@@ -135,7 +135,7 @@ trait IngestTrackerClientTestCases
       it("fails to apply a conflicting update") {
         val initialIngest = createIngestWith(status = Succeeded)
         val failedUpdate = createIngestStatusUpdateWith(
-          id = ingest.id,
+          id = initialIngest.id,
           status = Ingest.Failed
         )
 

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestTrackerFixtures.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestTrackerFixtures.scala
@@ -64,7 +64,7 @@ trait IngestTrackerFixtures extends EitherValues with TimeTestFixture {
   ): MemoryIngestTracker = {
     initialIngests
       .map { ingest =>
-        store.init(ingest.id)(ingest)
+        store.init(ingest.id)(ingest) shouldBe a[Right[_, _]]
       }
 
     new MemoryIngestTracker(store)

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -16,7 +16,12 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, UpdateWriteError, Version}
+import uk.ac.wellcome.storage.{
+  StoreReadError,
+  StoreWriteError,
+  UpdateWriteError,
+  Version
+}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
@@ -71,10 +76,16 @@ trait IngestsTrackerApiFixture
         Left(IngestStoreUnexpectedError(StoreReadError(new Throwable("BOOM!"))))
 
       override def init(ingest: Ingest): Result =
-        Left(IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!"))))
+        Left(
+          IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!")))
+        )
 
       override def update(update: IngestUpdate): Result =
-        Left(IngestStoreUnexpectedError(UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))))
+        Left(
+          IngestStoreUnexpectedError(
+            UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))
+          )
+        )
     }
 
     val callbackSender = new MemoryMessageSender()

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/fixtures/IngestsTrackerApiFixture.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.storage.ingests_tracker.services.{
 }
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.IngestStoreUnexpectedError
 import uk.ac.wellcome.platform.storage.ingests_tracker.tracker.memory.MemoryIngestTracker
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, UpdateWriteError, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
@@ -68,13 +68,13 @@ trait IngestsTrackerApiFixture
       )
     ) {
       override def get(id: IngestID): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(StoreReadError(new Throwable("BOOM!"))))
 
       override def init(ingest: Ingest): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(StoreWriteError(new Throwable("BOOM!"))))
 
       override def update(update: IngestUpdate): Result =
-        Left(IngestStoreUnexpectedError(new Throwable("BOOM!")))
+        Left(IngestStoreUnexpectedError(UpdateWriteError(StoreWriteError(new Throwable("BOOM!")))))
     }
 
     val callbackSender = new MemoryMessageSender()

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -4,6 +4,7 @@ import java.time.temporal.ChronoUnit
 
 import com.amazonaws.services.dynamodbv2.model._
 import org.scalatest.Assertion
+import org.scalatest.concurrent.ScalaFutures
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
 import uk.ac.wellcome.fixtures.TestWith
@@ -30,10 +31,14 @@ import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
 class DynamoIngestTrackerTest
     extends IngestTrackerTestCases[DynamoTable]
     with DynamoFixtures
-    with RandomThings {
+    with RandomThings
+    with ScalaFutures {
   override def withContext[R](
     testWith: TestWith[DynamoTable, R]
   ): R =
@@ -156,5 +161,27 @@ class DynamoIngestTrackerTest
     )
 
     adjusted1 shouldBe adjusted2
+  }
+
+  // This test is added temporarily to reproduce https://github.com/wellcomecollection/platform/issues/4781
+  // What does the Dynamo ingest tracker do if you fire in lots of updates
+  // for the same ingest in quick succession?
+  it("reproduces the error") {
+    val ingest = createIngest
+
+    val updates = (1 to 10)
+      .map { _ => createIngestEventUpdateWith(id = ingest.id) }
+
+    withContext { implicit context =>
+      withIngestTracker(initialIngests = Seq(ingest)) { tracker =>
+        val futures = Future.sequence(
+          updates.map { u => Future(tracker.update(u)) }
+        )
+
+        whenReady(futures) { r =>
+          r.foreach { println(_) }
+        }
+      }
+    }
   }
 }

--- a/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -37,7 +37,7 @@ class DynamoIngestTrackerTest
   override def withContext[R](
     testWith: TestWith[DynamoTable, R]
   ): R =
-    withSpecifiedTable(createIngestTrackerTable) { ingestTrackerTable =>
+    withLocalDynamoDbTable { ingestTrackerTable =>
       testWith(ingestTrackerTable)
     }
 

--- a/ingests/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerServiceTest.scala
+++ b/ingests/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerServiceTest.scala
@@ -92,7 +92,9 @@ class IngestsWorkerServiceTest
     }
   }
 
-  def withIngestTrackerClient[R](trackerUri: String)(testWith: TestWith[IngestTrackerClient, R]): R =
+  def withIngestTrackerClient[R](
+    trackerUri: String
+  )(testWith: TestWith[IngestTrackerClient, R]): R =
     withActorSystem { implicit actorSystem =>
       val client = new AkkaIngestTrackerClient(trackerHost = Uri(trackerUri))
 

--- a/ingests/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerServiceTest.scala
+++ b/ingests/ingests_worker/src/test/scala/uk/ac/wellcome/platform/storage/ingests_worker/services/IngestsWorkerServiceTest.scala
@@ -1,8 +1,10 @@
 package uk.ac.wellcome.platform.storage.ingests_worker.services
 
+import akka.http.scaladsl.model.Uri
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.worker.models.{
   DeterministicFailure,
   NonDeterministicFailure,
@@ -11,6 +13,11 @@ import uk.ac.wellcome.messaging.worker.models.{
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.HttpFixtures
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.storage.ingests_tracker.client.{
+  AkkaIngestTrackerClient,
+  IngestTrackerClient
+}
+import uk.ac.wellcome.platform.storage.ingests_tracker.fixtures.IngestsTrackerApiFixture
 import uk.ac.wellcome.platform.storage.ingests_worker.fixtures.IngestsWorkerFixtures
 
 class IngestsWorkerServiceTest
@@ -20,6 +27,7 @@ class IngestsWorkerServiceTest
     with HttpFixtures
     with ScalaFutures
     with IngestsWorkerFixtures
+    with IngestsTrackerApiFixture
     with IntegrationPatience {
 
   val visibilityTimeout = 5
@@ -71,4 +79,24 @@ class IngestsWorkerServiceTest
       }
     }
   }
+
+  it("updating a non-existent ingest is a non-deterministic failure") {
+    withIngestsTrackerApi(initialIngests = Seq.empty) { _ =>
+      withIngestTrackerClient(trackerUri) { client =>
+        withIngestWorker(ingestTrackerClient = client) { worker =>
+          whenReady(worker.processMessage(createIngestEventUpdate)) {
+            _ shouldBe a[NonDeterministicFailure[_]]
+          }
+        }
+      }
+    }
+  }
+
+  def withIngestTrackerClient[R](trackerUri: String)(testWith: TestWith[IngestTrackerClient, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val client = new AkkaIngestTrackerClient(trackerHost = Uri(trackerUri))
+
+      testWith(client)
+    }
+
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4781

This introduces a new status code in the ingest tracker API. If you do a `PATCH /ingest/{id}` and that ingest doesn't exist yet, you get an HTTP 404 Not Found instead of HTTP 409 Conflict. This can occur if there's a DynamoDB consistency issue that means the DynamoTracker can't find the ingest.

The tracker client turns this status code into a new error type, and the ingest worker treats this error as non-deterministic.

Plus a couple of other changes to make this code easier to debug if we have other issues in future.