### PR TITLE
Add the bag tracker to BuildKite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,8 @@ steps:
     label: "bag root finder"
   - command: .buildkite/scripts/run_job.py bag_tagger
     label: "bag tagger"
+  - command: .buildkite/scripts/run_job.py bag_tracker
+    label: "bag tracker"
   - command: .buildkite/scripts/run_job.py bag_verifier
     label: "bag verifier"
   - command: .buildkite/scripts/run_job.py bag_unpacker


### PR DESCRIPTION
🙈 

I was wondering why the bag tracker wasn't being deployed. Oops.

```
image ID            summary of changes
------------------  ------------------------------------
bag_indexer         ECR tag updated, 1 service deployed
bag_register        ECR tag updated, 2 services deployed
bag_replicator      ECR tag updated, 3 services deployed
bag_root_finder     ECR tag updated, 1 service deployed
bag_tagger          ECR tag updated, 1 service deployed
bag_tracker         -
bag_unpacker        ECR tag updated, 1 service deployed
bag_verifier        ECR tag updated, 4 services deployed
bag_versioner       ECR tag updated, 1 service deployed
bags_api            ECR tag updated, 2 services deployed
ingests_api         ECR tag updated, 1 service deployed
ingests_indexer     ECR tag updated, 1 service deployed
ingests_tracker     ECR tag updated, 1 service deployed
ingests_worker      ECR tag updated, 1 service deployed
notifier            ECR tag updated, 1 service deployed
replica_aggregator  ECR tag updated, 1 service deployed
```