### PR TITLE
Clean up the construction of bags in tests

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -29,13 +29,13 @@ class BagRegisterFeatureTest
     val createdAfterDate = Instant.now()
     val space = createStorageSpace
     val version = createBagVersion
-    val dataFileCount = randomInt(1, 15)
+    val payloadFileCount = randomInt(1, 15)
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot, bagInfo) = createRegisterBagWith(
+      val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
         version = version,
-        dataFileCount = dataFileCount
+        payloadFileCount = payloadFileCount
       )
 
       val bagId = BagId(
@@ -74,7 +74,7 @@ class BagRegisterFeatureTest
 
             storageManifest.space shouldBe bagId.space
             storageManifest.info shouldBe bagInfo
-            storageManifest.manifest.files should have size dataFileCount
+            storageManifest.manifest.files should have size payloadFileCount
 
             storageManifest.location shouldBe PrimaryS3StorageLocation(
               prefix = bagRoot

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -39,7 +39,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -140,20 +139,11 @@ trait BagRegisterFixtures
     dataFileCount: Int = randomInt(1, 15)
   )(
     implicit bucket: Bucket
-  ): (S3ObjectLocationPrefix, BagInfo) = {
-    implicit val typedStore: S3TypedStore[String] =
-      S3TypedStore[String]
-
-    val bagContents =
-      createBagContentsWith(
-        space = space,
-        externalIdentifier = externalIdentifier,
-        version = version,
-        payloadFileCount = dataFileCount
-      )(namespace = bucket, primaryBucket = bucket)
-
-    storeBagContents(bagContents)
-
-    (bagContents.bagRoot, bagContents.bagInfo)
-  }
+  ): (S3ObjectLocationPrefix, BagInfo) =
+    storeBagWith(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version,
+      payloadFileCount = dataFileCount
+    )(namespace = bucket, primaryBucket = bucket)
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -1,14 +1,12 @@
 package uk.ac.wellcome.platform.archive.bag_register.fixtures
 
 import org.scalatest.Assertion
-import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.messaging.sqs.SQSClientFactory
 import uk.ac.wellcome.platform.archive.bag_register.services.{
   BagRegisterWorker,
   Register,
@@ -57,14 +55,6 @@ trait BagRegisterFixtures
     with StringNamespaceFixtures
     with StorageSpaceGenerators
     with S3BagBuilder {
-
-  override implicit val asyncSqsClient: SqsAsyncClient =
-    SQSClientFactory.createAsyncClient(
-      region = "localhost",
-      endpoint = "http://localhost:9324",
-      accessKey = "access",
-      secretKey = "secret"
-    )
 
   type Fixtures = (
     BagRegisterWorker[String, String],

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -17,27 +17,15 @@ import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.{
   StorageManifestDaoFixture
 }
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  BagVersion,
-  ExternalIdentifier
-}
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.fixtures.s3.S3BagBuilder
-import uk.ac.wellcome.platform.archive.common.generators.{
-  ExternalIdentifierGenerators,
-  StorageSpaceGenerators
-}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Ingest,
   IngestID,
   IngestStatusUpdate
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -49,10 +37,8 @@ trait BagRegisterFixtures
     with OperationFixtures
     with StorageManifestDaoFixture
     with IngestUpdateAssertions
-    with ExternalIdentifierGenerators
     with BagTrackerFixtures
     with StringNamespaceFixtures
-    with StorageSpaceGenerators
     with S3BagBuilder {
 
   type Fixtures = (
@@ -131,19 +117,4 @@ trait BagRegisterFixtures
       ingestFailed.status shouldBe Ingest.Failed
       ingestFailed.events.head.description shouldBe "Register failed"
     }
-
-  def createRegisterBagWith(
-    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
-    space: StorageSpace,
-    version: BagVersion,
-    dataFileCount: Int = randomInt(1, 15)
-  )(
-    implicit bucket: Bucket
-  ): (S3ObjectLocationPrefix, BagInfo) =
-    storeBagWith(
-      space = space,
-      externalIdentifier = externalIdentifier,
-      version = version,
-      payloadFileCount = dataFileCount
-    )(namespace = bucket, primaryBucket = bucket)
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -29,17 +29,17 @@ class BagRegisterWorkerTest
     val createdAfterDate = Instant.now()
     val space = createStorageSpace
     val version = createBagVersion
-    val dataFileCount = randomInt(1, 15)
+    val payloadFileCount = randomInt(1, 15)
 
     val ingests = new MemoryMessageSender()
 
     val storageManifestDao = createStorageManifestDao()
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot, bagInfo) = createRegisterBagWith(
+      val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
-        dataFileCount = dataFileCount,
-        version = version
+        version = version,
+        payloadFileCount = payloadFileCount
       )
 
       val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
@@ -78,7 +78,7 @@ class BagRegisterWorkerTest
 
       storageManifest.space shouldBe bagId.space
       storageManifest.info shouldBe bagInfo
-      storageManifest.manifest.files should have size dataFileCount
+      storageManifest.manifest.files should have size payloadFileCount
 
       storageManifest.location shouldBe PrimaryS3StorageLocation(
         prefix = bagRoot
@@ -105,9 +105,9 @@ class BagRegisterWorkerTest
     val registrationNotifications = new MemoryMessageSender()
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot, bagInfo) = createRegisterBagWith(
+      val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
-        version = version
+        version = version,
       )
 
       val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)
@@ -157,15 +157,15 @@ class BagRegisterWorkerTest
     val externalIdentifier = createExternalIdentifier
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot1, bagInfo1) = createRegisterBagWith(
-        externalIdentifier = externalIdentifier,
+      val (bagRoot1, bagInfo1) = storeS3BagWith(
         space = space,
+        externalIdentifier = externalIdentifier,
         version = version1
       )
 
-      val (bagRoot2, _) = createRegisterBagWith(
-        externalIdentifier = externalIdentifier,
+      val (bagRoot2, _) = storeS3BagWith(
         space = space,
+        externalIdentifier = externalIdentifier,
         version = version2
       )
 
@@ -236,7 +236,7 @@ class BagRegisterWorkerTest
     val storageManifestDao = createStorageManifestDao()
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot, bagInfo) = createRegisterBagWith(
+      val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
         version = version
       )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -107,7 +107,7 @@ class BagRegisterWorkerTest
     withLocalS3Bucket { implicit bucket =>
       val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
-        version = version,
+        version = version
       )
 
       val primaryLocation = PrimaryS3ReplicaLocation(prefix = bagRoot)

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -31,7 +31,7 @@ class RegisterTest
     val version = createBagVersion
 
     withLocalS3Bucket { implicit bucket =>
-      val (bagRoot, bagInfo) = createRegisterBagWith(
+      val (bagRoot, bagInfo) = storeS3BagWith(
         space = space,
         version = version
       )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -21,7 +21,6 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.services.s3.S3SizeFinder
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
 import scala.util.Random
 
@@ -485,20 +484,14 @@ class StorageManifestServiceTest
   )(
     implicit bucket: Bucket
   ): (S3ObjectLocationPrefix, Bag) = {
-    implicit val typedStore: S3TypedStore[String] =
-      S3TypedStore[String]
-
-    val bagContents =
-      bagBuilder.createBagContentsWith(
-        space = space,
-        version = version
-      )(namespace = bucket, primaryBucket = bucket)
-
-    bagBuilder.storeBagContents(bagContents)
+    val (bagRoot, _) = bagBuilder.storeBagWith(
+      space = space,
+      version = version
+    )(namespace = bucket, primaryBucket = bucket)
 
     (
-      bagContents.bagRoot,
-      new S3BagReader().get(bagContents.bagRoot).right.value
+      bagRoot,
+      new S3BagReader().get(bagRoot).right.value
     )
   }
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -484,10 +484,10 @@ class StorageManifestServiceTest
   )(
     implicit bucket: Bucket
   ): (S3ObjectLocationPrefix, Bag) = {
-    val (bagRoot, _) = bagBuilder.storeBagWith(
+    val (bagRoot, _) = bagBuilder.storeS3BagWith(
       space = space,
       version = version
-    )(namespace = bucket, primaryBucket = bucket)
+    )
 
     (
       bagRoot,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -80,7 +80,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     externalIdentifier: ExternalIdentifier,
     bagBuilder: BagBuilder[BagLocation, BagPrefix, Namespace] = bagBuilder,
     version: BagVersion = BagVersion(randomInt(from = 2, to = 10))
-  )(testWith: TestWith[(Bucket, BagPrefix), R])(implicit namespace: Namespace): R =
+  )(
+    testWith: TestWith[(Bucket, BagPrefix), R]
+  )(implicit namespace: Namespace): R =
     withTypedStore { implicit typedStore =>
       withLocalS3Bucket { implicit primaryBucket =>
         val (bagRoot, _) = bagBuilder.storeBagWith(

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -51,9 +51,9 @@ trait ReplicatedBagVerifierTestCases[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    withNamespace { namespace =>
+    withNamespace { implicit namespace =>
       withLocalS3Bucket { srcBucket =>
-        withBag(space, externalIdentifier)(namespace) {
+        withBag(space, externalIdentifier) {
           case (primaryBucket, replicaBagRoot) =>
             val srcBagRoot =
               S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
@@ -88,9 +88,9 @@ trait ReplicatedBagVerifierTestCases[
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 
-    withNamespace { namespace =>
+    withNamespace { implicit namespace =>
       withLocalS3Bucket { srcBucket =>
-        withBag(space, externalIdentifier)(namespace) {
+        withBag(space, externalIdentifier) {
           case (primaryBucket, replicaBagRoot) =>
             val srcBagRoot =
               S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -200,7 +200,7 @@ trait BagReaderTestCases[
 
   protected def toString(ns: Namespace): String = ns.toString
 
-  protected def createBag()(namespace: Namespace, bucket: Bucket)(
+  private def createBag()(namespace: Namespace, bucket: Bucket)(
     implicit typedStore: TypedStore[BagLocation, String]
   ): (BagPrefix, BagInfo) = {
     val bagContents = createBagContentsWith()(namespace, bucket)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -46,12 +46,14 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
   def storeBagWith(
     space: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
     payloadFileCount: Int = randomInt(from = 5, to = 50)
   )(namespace: Namespace, primaryBucket: Bucket): (BagPrefix, BagInfo) = {
 
     val bagContents = createBagContentsWith(
       space = space,
       externalIdentifier = externalIdentifier,
+      version = version,
       payloadFileCount = payloadFileCount
     )(namespace, primaryBucket)
 
@@ -59,6 +61,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }
+
   def storeBagContents(bagContents: BagContents)(
     implicit typedStore: TypedStore[BagLocation, String]
   ): Unit = {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -48,7 +48,10 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
     payloadFileCount: Int = randomInt(from = 5, to = 50)
-  )(implicit namespace: Namespace, primaryBucket: Bucket): (BagPrefix, BagInfo) = {
+  )(
+    implicit namespace: Namespace,
+    primaryBucket: Bucket
+  ): (BagPrefix, BagInfo) = {
 
     val bagContents = createBagContentsWith(
       space = space,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -48,7 +48,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
     payloadFileCount: Int = randomInt(from = 5, to = 50)
-  )(namespace: Namespace, primaryBucket: Bucket): (BagPrefix, BagInfo) = {
+  )(implicit namespace: Namespace, primaryBucket: Bucket): (BagPrefix, BagInfo) = {
 
     val bagContents = createBagContentsWith(
       space = space,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/s3/S3BagBuilder.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.fixtures.s3
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
   BagVersion,
   ExternalIdentifier
 }
@@ -38,4 +39,17 @@ trait S3BagBuilder
       bucket = bagRoot.bucket,
       key = path
     )
+
+  def storeS3BagWith(
+    space: StorageSpace = createStorageSpace,
+    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    version: BagVersion = BagVersion(randomInt(from = 2, to = 10)),
+    payloadFileCount: Int = randomInt(from = 5, to = 50)
+  )(implicit bucket: Bucket): (S3ObjectLocationPrefix, BagInfo) =
+    storeBagWith(
+      space = space,
+      externalIdentifier = externalIdentifier,
+      version = version,
+      payloadFileCount = payloadFileCount
+    )(namespace = bucket, primaryBucket = bucket)
 }


### PR DESCRIPTION
Some tidy ups I spotted while reading bag register code. Nothing earth-shattering, but does reduce the line code and make things easier to follow.