### PR TITLE
Don't allow storing new files with filenames that end with a trailing `.`

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -133,7 +133,9 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
         )
       )
 
-      filenames = (bag.manifest.entries ++ bag.tagManifest.entries).map { case (path, _) => path.value }
+      filenames = (bag.manifest.entries ++ bag.tagManifest.entries).map {
+        case (path, _) => path.value
+      }
       _ <- verifyLegalFilenames(filenames.toSeq)
 
       verificationResult <- verifyChecksumAndSize(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -133,9 +133,8 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
         )
       )
 
-      _ <- verifyLegalFilenames(
-        bag.manifest.entries.map { case (path, _) => path.value }.toSeq
-      )
+      filenames = (bag.manifest.entries ++ bag.tagManifest.entries).map { case (path, _) => path.value }
+      _ <- verifyLegalFilenames(filenames.toSeq)
 
       verificationResult <- verifyChecksumAndSize(
         root = root,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -52,6 +52,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
+    with VerifyLegalFilenames
     with VerifyNoUnreferencedFiles[BagLocation, BagPrefix] {
 
   val bagReader: BagReader[BagLocation, BagPrefix]
@@ -130,6 +131,10 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
           bucket = primaryBucket,
           keyPrefix = s"$space/$externalIdentifier"
         )
+      )
+
+      _ <- verifyLegalFilenames(
+        bag.manifest.entries.map { case (path, _) => path.value }.toSeq
       )
 
       verificationResult <- verifyChecksumAndSize(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
@@ -3,23 +3,26 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 
 trait VerifyLegalFilenames {
-  def verifyLegalFilenames(filenames: Seq[String]): Either[BagVerifierError, Unit] = {
+  def verifyLegalFilenames(
+    filenames: Seq[String]
+  ): Either[BagVerifierError, Unit] = {
     // Azure blob storage does not support blob names that end with a `.`
     // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-names
     val endsWithADot = filenames.filter { _.endsWith(".") }
 
     // Combine the results into a single message that can be logged.
     val results = Map(
-      "Filenames cannot end with a ." -> endsWithADot,
+      "Filenames cannot end with a ." -> endsWithADot
     )
 
     val logMessage = results
-      .map { case (reason, badFilenames) =>
-        if (badFilenames.isEmpty) {
-          ""
-        } else {
-          s"$reason: ${badFilenames.mkString(", ")}"
-        }
+      .map {
+        case (reason, badFilenames) =>
+          if (badFilenames.isEmpty) {
+            ""
+          } else {
+            s"$reason: ${badFilenames.mkString(", ")}"
+          }
       }
       .filterNot { _.isEmpty }
       .mkString("; ")

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
@@ -2,10 +2,8 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 
-trait VerifyLegalFilenames[BagLocation] {
-  def verifyLegalFilenames(locations: Seq[BagLocation]): Either[BagVerifierError, Unit] = {
-    val filenames = locations.map { filename }
-
+trait VerifyLegalFilenames {
+  def verifyLegalFilenames(filenames: Seq[String]): Either[BagVerifierError, Unit] = {
     // Azure blob storage does not support blob names that end with a `.`
     // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-names
     val endsWithADot = filenames.filter { _.endsWith(".") }
@@ -31,6 +29,4 @@ trait VerifyLegalFilenames[BagLocation] {
       case message => Left(BagVerifierError(message))
     }
   }
-
-  def filename(location: BagLocation): String
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenames.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
+
+import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
+
+trait VerifyLegalFilenames[BagLocation] {
+  def verifyLegalFilenames(locations: Seq[BagLocation]): Either[BagVerifierError, Unit] = {
+    val filenames = locations.map { filename }
+
+    // Azure blob storage does not support blob names that end with a `.`
+    // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-names
+    val endsWithADot = filenames.filter { _.endsWith(".") }
+
+    // Combine the results into a single message that can be logged.
+    val results = Map(
+      "Filenames cannot end with a ." -> endsWithADot,
+    )
+
+    val logMessage = results
+      .map { case (reason, badFilenames) =>
+        if (badFilenames.isEmpty) {
+          ""
+        } else {
+          s"$reason: ${badFilenames.mkString(", ")}"
+        }
+      }
+      .filterNot { _.isEmpty }
+      .mkString("; ")
+
+    logMessage match {
+      case ""      => Right(())
+      case message => Left(BagVerifierError(message))
+    }
+  }
+
+  def filename(location: BagLocation): String
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -631,9 +631,13 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
     it("fails if the tag manifest has illegal filenames") {
       val badBuilder = new BagBuilderImpl {
-        override protected def createTagManifest(entries: Seq[ManifestFile]): Option[String] =
+        override protected def createTagManifest(
+          entries: Seq[ManifestFile]
+        ): Option[String] =
           super.createTagManifest(
-            entries.map { file => file.copy(name = file.name + ".") }
+            entries.map { file =>
+              file.copy(name = file.name + ".")
+            }
           )
       }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -613,9 +613,22 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     }
   }
 
-  it(
-    "doesn't match locations in a namespace with same prefix but different directory"
-  ) {
+  it("fails if the bag has illegal filenames") {
+    val badBuilder = new BagBuilderImpl {
+      override protected def randomPath: _root_.scala.Predef.String =
+        super.randomPath + "."
+    }
+
+    assertBagResultFails(badBuilder) { result =>
+      result.summary shouldBe a[VerificationIncompleteSummary]
+
+      val summary = result.summary.asInstanceOf[VerificationIncompleteSummary]
+
+      summary.e.getMessage should startWith("Filenames cannot end with a .:")
+    }
+  }
+
+  it("skips locations in a namespace with same prefix but different directory") {
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -613,18 +613,37 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     }
   }
 
-  it("fails if the bag has illegal filenames") {
-    val badBuilder = new BagBuilderImpl {
-      override protected def randomPath: _root_.scala.Predef.String =
-        super.randomPath + "."
+  describe("checks for illegal filenames") {
+    it("fails if the manifest has illegal filenames") {
+      val badBuilder = new BagBuilderImpl {
+        override protected def randomPath: _root_.scala.Predef.String =
+          super.randomPath + "."
+      }
+
+      assertBagResultFails(badBuilder) { result =>
+        result.summary shouldBe a[VerificationIncompleteSummary]
+
+        val summary = result.summary.asInstanceOf[VerificationIncompleteSummary]
+
+        summary.e.getMessage should startWith("Filenames cannot end with a .:")
+      }
     }
 
-    assertBagResultFails(badBuilder) { result =>
-      result.summary shouldBe a[VerificationIncompleteSummary]
+    it("fails if the tag manifest has illegal filenames") {
+      val badBuilder = new BagBuilderImpl {
+        override protected def createTagManifest(entries: Seq[ManifestFile]): Option[String] =
+          super.createTagManifest(
+            entries.map { file => file.copy(name = file.name + ".") }
+          )
+      }
 
-      val summary = result.summary.asInstanceOf[VerificationIncompleteSummary]
+      assertBagResultFails(badBuilder) { result =>
+        result.summary shouldBe a[VerificationIncompleteSummary]
 
-      summary.e.getMessage should startWith("Filenames cannot end with a .:")
+        val summary = result.summary.asInstanceOf[VerificationIncompleteSummary]
+
+        summary.e.getMessage should startWith("Filenames cannot end with a .:")
+      }
     }
   }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
@@ -4,12 +4,17 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class VerifyLegalFilenamesTest extends AnyFunSpec with Matchers with EitherValues {
+class VerifyLegalFilenamesTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues {
   val verifier: VerifyLegalFilenames =
     new VerifyLegalFilenames {}
 
   it("allows legal filenames") {
-    verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(())
+    verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(
+      ()
+    )
   }
 
   it("flags a file with a trailing dot") {
@@ -19,8 +24,13 @@ class VerifyLegalFilenamesTest extends AnyFunSpec with Matchers with EitherValue
   }
 
   it("flags multiple files with a trailing dot") {
-    val err = verifier.verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif")).left.value
+    val err = verifier
+      .verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif"))
+      .left
+      .value
     err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."
-    err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg., alsobad.png.")
+    err.userMessage shouldBe Some(
+      "Filenames cannot end with a .: bad.jpg., alsobad.png."
+    )
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class VerifyLegalFilenamesTest extends AnyFunSpec with Matchers with EitherValues {
-  val verifier: VerifyLegalFilenames[String] =
-    (location: String) => location
+  val verifier: VerifyLegalFilenames =
+    new VerifyLegalFilenames {}
 
   it("allows legal filenames") {
     verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(())

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class VerifyLegalFilenamesTest extends AnyFunSpec with Matchers with EitherValues {
+  val verifier: VerifyLegalFilenames[String] =
+    (location: String) => location
+
+  it("allows legal filenames") {
+    verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(())
+  }
+
+  it("flags a file with a trailing dot") {
+    val err = verifier.verifyLegalFilenames(Seq("bad.jpg.")).left.value
+    err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg."
+    err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg.")
+  }
+
+  it("flags multiple files with a trailing dot") {
+    val err = verifier.verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif")).left.value
+    err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."
+    err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg., alsobad.png.")
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -42,6 +42,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
   )(namespace: Namespace): BagPrefix
 
   def createBagLocation(bagRoot: BagPrefix, path: String): BagLocation
+
   def storeBagWith(
     space: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
@@ -292,7 +293,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     }
   }
 
-  private def randomPath: String =
+  protected def randomPath: String =
     (1 to randomInt(from = 1, to = 5))
       .map { _ =>
         randomAlphanumeric


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4790

These files will be caught at the pre-replicator verifier, so although we have one bag that's slipped through, it won't happen again.

This may cause a slight issue for Archivematica bags; we'll cross that bridge if/when we come to it.