### PR TITLE
Use the new location of the VPC terraform state

### DIFF
--- a/terraform/infra/endpoints.tf
+++ b/terraform/infra/endpoints.tf
@@ -2,7 +2,7 @@ resource "aws_route53_zone" "internal" {
   name = "storage.internal."
 
   vpc {
-    vpc_id = local.vpc_id
+    vpc_id = local.storage_vpcs["storage_vpc_id"]
   }
 
   tags = local.default_tags

--- a/terraform/infra/locals.tf
+++ b/terraform/infra/locals.tf
@@ -1,4 +1,0 @@
-locals {
-  vpc_id = data.terraform_remote_state.infra_shared.outputs.storage_vpc_id
-}
-

--- a/terraform/infra/terraform.tf
+++ b/terraform/infra/terraform.tf
@@ -9,14 +9,17 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "infra_shared" {
+data "terraform_remote_state" "accounts_storage" {
   backend = "s3"
 
   config = {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/storage.tfstate"
     region   = "eu-west-1"
   }
 }
 
+locals {
+  storage_vpcs = data.terraform_remote_state.accounts_storage.outputs
+}

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -4,8 +4,8 @@ locals {
   api_url     = "https://api.wellcomecollection.org"
   domain_name = "storage.api.wellcomecollection.org"
 
-  vpc_id          = data.terraform_remote_state.infra_shared.outputs.storage_vpc_id
-  private_subnets = data.terraform_remote_state.infra_shared.outputs.storage_vpc_private_subnets
+  vpc_id          = local.storage_vpcs["storage_vpc_id"]
+  private_subnets = local.storage_vpcs["storage_vpc_private_subnets"]
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 

--- a/terraform/stack_prod/terraform.tf
+++ b/terraform/stack_prod/terraform.tf
@@ -9,6 +9,21 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "accounts_storage" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/platform-infrastructure/accounts/storage.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+locals {
+  storage_vpcs = data.terraform_remote_state.accounts_storage.outputs
+}
+
 data "terraform_remote_state" "infra_shared" {
   backend = "s3"
 

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -4,8 +4,8 @@ locals {
   staging_api_url     = "https://api-stage.wellcomecollection.org"
   staging_domain_name = "storage.api-stage.wellcomecollection.org"
 
-  vpc_id          = data.terraform_remote_state.infra_shared.outputs.storage_vpc_id
-  private_subnets = data.terraform_remote_state.infra_shared.outputs.storage_vpc_private_subnets
+  vpc_id          = local.storage_vpcs["storage_vpc_id"]
+  private_subnets = local.storage_vpcs["storage_vpc_private_subnets"]
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 

--- a/terraform/stack_staging/terraform.tf
+++ b/terraform/stack_staging/terraform.tf
@@ -9,6 +9,21 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "accounts_storage" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/platform-infrastructure/accounts/storage.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+locals {
+  storage_vpcs = data.terraform_remote_state.accounts_storage.outputs
+}
+
 data "terraform_remote_state" "infra_shared" {
   backend = "s3"
 


### PR DESCRIPTION
Part of wellcomecollection/platform#4802

We've rearranged some of our Terraform configs to reduce the amount of cross-account coupling. Changing the storage VPC shouldn't affect the storage VPC, etc.

This should be a no-op, but Alice is doing other stuff in Terraform so it may conflict in ways I haven't spotted.