### PR TITLE
Rewrite the daily reporter to be more useful

### DIFF
--- a/monitoring/daily_reporter/requirements.in
+++ b/monitoring/daily_reporter/requirements.in
@@ -1,2 +1,3 @@
 boto3
 httpx
+jinja2

--- a/monitoring/daily_reporter/requirements.txt
+++ b/monitoring/daily_reporter/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-boto3==1.13.12
+boto3==1.13.12            # via -r requirements.in
 botocore==1.16.12         # via boto3, s3transfer
 certifi==2020.4.5.1       # via httpx
 chardet==3.0.4            # via httpx
@@ -13,10 +13,12 @@ h11==0.9.0                # via httpx
 h2==3.2.0                 # via httpx
 hpack==3.0.0              # via h2
 hstspreload==2020.5.19    # via httpx
-httpx==0.12.1
+httpx==0.12.1             # via -r requirements.in
 hyperframe==5.2.0         # via h2
 idna==2.9                 # via httpx
+jinja2==2.11.2            # via -r requirements.in
 jmespath==0.10.0          # via boto3, botocore
+markupsafe==1.1.1         # via jinja2
 python-dateutil==2.8.1    # via botocore
 rfc3986==1.4.0            # via httpx
 s3transfer==0.3.3         # via boto3

--- a/monitoring/daily_reporter/src/aws.py
+++ b/monitoring/daily_reporter/src/aws.py
@@ -1,0 +1,11 @@
+import boto3
+
+
+secrets_client = boto3.client("secretsmanager")
+
+
+def get_secret(secret_id):
+    """
+    Get a Secret from Secrets Manager.
+    """
+    return secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -10,90 +10,8 @@ import httpx
 from aws import get_secret
 from elasticsearch import get_es_client, get_interesting_ingests
 from html_report import store_s3_report
-from ingests import classify_ingest
-
-
-def _get_slack_message(label, ingests):
-    result = f"*{label}:* "
-
-    if not ingests:
-        result += "no activity."
-        return result
-
-    # Produce a message of the form
-    #
-    #     Prod: succeeded (14), failed (user error) (2), stalled (1)
-    #
-    # Highlight unusual statuses.
-    status_descriptions = []
-    for status, individual_ingests in ingests.items():
-        if status in ("stalled", "failed (unknown reason)"):
-            status_descriptions.append(f"*{status} ({len(individual_ingests)})*")
-        else:
-            status_descriptions.append(f"{status} ({len(individual_ingests)})")
-
-    result += ", ".join(status_descriptions)
-
-    for status in ("failed (unknown reason)", "stalled"):
-        if ingests.get(status, []):
-            result += "\n" + status.title() + ":"
-            for i in ingests[status][:15]:
-                result += f"\n- <https://wellcome-ingest-inspector.glitch.me/ingests/{i['id']}|`{i['id']}`> – {i['space']}/{i['externalIdentifier']}"
-                if i["version"]:
-                    result += "/" + i["version"]
-
-            if len(ingests[status]) >= 15:
-                result += "\n- ..."
-
-    return result
-
-
-def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s3_url):
-    heading = (
-        f"What happened in the storage service "
-        f"in the last {days_to_fetch} day{'s' if days_to_fetch > 1 else ''}?"
-    )
-
-    result = {
-        "blocks": [
-            {"type": "header", "text": {"type": "plain_text", "text": heading}},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": _get_slack_message(
-                        "Prod", ingests=classified_ingests["prod"]
-                    ),
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": _get_slack_message(
-                        "Staging", ingests=classified_ingests["staging"]
-                    ),
-                },
-            },
-
-        ]
-    }
-
-    if not found_everything:
-        result['blocks'].append({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "Elasticsearch can only return the first 10,000 results. There may be ingests missing from this report."
-            }
-        })
-
-    result['blocks'].append({
-        "type": "section",
-        "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
-    })
-
-    return result
+from ingests import get_dev_status
+from slack import prepare_slack_payload
 
 
 def main(*args):
@@ -109,25 +27,25 @@ def main(*args):
         es_client, index_name="storage_stage_ingests", days_to_fetch=days_to_fetch
     )
 
-    classified_ingests = {
+    ingests_by_status = {
         "prod": collections.defaultdict(list),
         "staging": collections.defaultdict(list),
     }
 
     for ingest in prod_ingests["ingests"]:
-        status = classify_ingest(ingest)
-        classified_ingests["prod"][status].append(ingest)
+        status = get_dev_status(ingest)
+        ingests_by_status["prod"][status].append(ingest)
 
     for ingest in staging_ingests["ingests"]:
-        status = classify_ingest(ingest)
-        classified_ingests["staging"][status].append(ingest)
+        status = get_dev_status(ingest)
+        ingests_by_status["staging"][status].append(ingest)
 
     found_everything = (
         prod_ingests["found_everything"] and staging_ingests["found_everything"]
     )
 
     s3_url = store_s3_report(
-        classified_ingests=classified_ingests,
+        ingests_by_status=ingests_by_status,
         found_everything=found_everything,
         days_to_fetch=days_to_fetch,
     )

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -6,42 +6,102 @@ import json
 import boto3
 import httpx
 
-
-secrets_client = boto3.client("secretsmanager")
-
-
-def get_secret(secret_id):
-    return secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]
+from elasticsearch import get_es_client
 
 
-def get_recent_ingests(es_client, *, index_name, days_to_fetch):
+def get_interesting_ingests(es_client, *, index_name, days_to_fetch):
     """
-    Get ingests that were modified in the last N days.
+    Get ingests that are "interesting".
     """
     today = datetime.datetime.now()
 
     start = today - datetime.timedelta(days=days_to_fetch)
 
-    resp = es_client.request(
-        method="GET",
-        url=f"/{index_name}/_search",
-        json={
-            "query": {
-                "bool": {
-                    "filter": [
-                        {
-                            "range": {
-                                "lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}
-                            }
-                        }
-                    ]
-                }
-            },
-            "size": 1000,
-        },
-    )
+    # Did we find everything we were looking for?  It's possible we might
+    found_everything = True
 
-    return [hit["_source"] for hit in resp.json()["hits"]["hits"]]
+    # Ingests we want to return
+    ingests = {}
+
+    # We make three requests to Elasticsearch, to maximise the chance of finding
+    # ingests that might need more attention:
+    #
+    #   * everything modified in the last N days
+    #   * everything modified in the last N days which hasn't succeeded
+    #   * everything which hasn't completed
+    #
+    # A single ES request returns up to 10000 documents; if more than that have
+    # been updated (e.g. we've just done a big migration), we want to flag that
+    # fact and try to find the most interesting stuff.
+    filters = [
+        [{"range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}}],
+        [{
+            "range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}},{
+            "terms": {"status.id": ["processing", "accepted", "failed"]},
+        }],
+        [{"terms": {"status.id": ["processing", "accepted"]}}],
+    ]
+
+    for filter_clause in filters:
+        resp = es_client.request(
+            method="GET",
+            url=f"/{index_name}/_search",
+            json={
+                "query": {"bool": {"filter": filter_clause}},
+                "_source": [
+                    "id",
+                    "lastModifiedDate",
+                    "space.id",
+                    "status.id",
+                    "bag.info.externalIdentifier",
+                    "bag.info.version",
+                    "createdDate",
+                    "events.description",
+                ],
+                # We can retrieve up to 10000 documents in one request.
+                "size": 10000,
+                "sort": [{"id": "desc"}],
+            },
+        )
+
+        # We use a dict to de-duplicate result.  The same ingest may appear
+        # multiple times in this response -- that's not an issue.
+        for hit in resp.json()["hits"]["hits"]:
+            ingests[hit["_id"]] = _parse_ingest_from_hit(hit)
+
+        # If there are more than 10000 results, that suggests there are more
+        # that we didn't get.  Flag this to the caller.
+        if resp.json()["hits"]["total"]["value"] >= 10000:
+            found_everything = False
+
+    return {"ingests": ingests, "found_everything": found_everything}
+
+
+def _parse_date(d):
+    try:
+        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_ingest_from_hit(hit):
+    source = hit["_source"]
+    ingest = {
+        "id": source["id"],
+        "space": source["space"]["id"],
+        "status": source["status"]["id"],
+        "externalIdentifier": source["bag"]["info"]["externalIdentifier"],
+        "version": source["bag"].get("version"),
+        "createdDate": _parse_date(source["lastModifiedDate"]),
+        "events": [ev["description"] for ev in source["events"]]
+    }
+
+    try:
+        ingest["lastModifiedDate"] = _parse_date(source["lastModifiedDate"])
+    except KeyError:
+        ingest["lastModifiedDate"] = ingest["createdDate"]
+
+    return ingest
 
 
 def get_ingests_by_status(recent_ingests):
@@ -168,51 +228,52 @@ def prepare_slack_payload(recent_ingests, name, time_period):
 
 
 def main(*args):
-    es_host = get_secret("storage_service_reporter/es_host")
-    es_port = get_secret("storage_service_reporter/es_port")
-    es_user = get_secret("storage_service_reporter/es_user")
-    es_pass = get_secret("storage_service_reporter/es_pass")
+    es_client = get_es_client()
 
-    elasticsearch_url = f"https://{es_host}:{es_port}"
-    with httpx.Client(base_url=elasticsearch_url, auth=(es_user, es_pass)) as es_client:
-        prod_ingests = get_recent_ingests(
-            es_client, index_name="storage_ingests", days_to_fetch=2
-        )
-        stage_ingests = get_recent_ingests(
-            es_client, index_name="storage_stage_ingests", days_to_fetch=2
-        )
-
-    prod_payload = prepare_slack_payload(
-        prod_ingests, name="the storage service", time_period="48 hours"
+    prod_ingests = get_interesting_ingests(
+        es_client, index_name="storage_ingests", days_to_fetch=2
     )
-    stage_payload = prepare_slack_payload(
-        stage_ingests, name="the staging service", time_period="48 hours"
-    )
+    # stage_ingests = get_recent_ingests(
+    #     es_client, index_name="storage_stage_ingests", days_to_fetch=2
+    # )
 
-    complete_payload = {
-        "blocks": prod_payload["blocks"]
-        + [{"type": "divider"}]
-        + stage_payload["blocks"]
-    }
+    from pprint import pprint
 
-    resp = httpx.post(
-        get_secret("storage_service_reporter/slack_webhook"), json=complete_payload
-    )
+    pprint(prod_ingests["ingests"])
 
-    print(f"Sent payload to Slack: {resp}")
-
-    if resp.status_code != 200:
-        print("Non-200 response from Slack:")
-
-        print("")
-
-        print("== request ==")
-        print(json.dumps(complete_payload, indent=2, sort_keys=True))
-
-        print("")
-
-        print("== response ==")
-        print(resp.text)
+    #
+    #
+    # prod_payload = prepare_slack_payload(
+    #     prod_ingests, name="the storage service", time_period="48 hours"
+    # )
+    # stage_payload = prepare_slack_payload(
+    #     stage_ingests, name="the staging service", time_period="48 hours"
+    # )
+    #
+    # complete_payload = {
+    #     "blocks": prod_payload["blocks"]
+    #     + [{"type": "divider"}]
+    #     + stage_payload["blocks"]
+    # }
+    #
+    # resp = httpx.post(
+    #     get_secret("storage_service_reporter/slack_webhook"), json=complete_payload
+    # )
+    #
+    # print(f"Sent payload to Slack: {resp}")
+    #
+    # if resp.status_code != 200:
+    #     print("Non-200 response from Slack:")
+    #
+    #     print("")
+    #
+    #     print("== request ==")
+    #     print(json.dumps(complete_payload, indent=2, sort_keys=True))
+    #
+    #     print("")
+    #
+    #     print("== response ==")
+    #     print(resp.text)
 
 
 if __name__ == "__main__":

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -154,9 +154,13 @@ def main(*args):
         status = classify_ingest(ingest)
         classified_ingests['staging'][status].append(ingest)
 
+    found_everything = (
+        prod_ingests["found_everything"] and staging_ingests["found_everything"]
+    )
+
     from pprint import pprint
 
-    html = create_html_report(classified_ingests)
+    html = create_html_report(classified_ingests=classified_ingests, found_everything=found_everything)
 
     with open('rendered_report.html', 'w') as outfile:
         outfile.write(html)

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -2,6 +2,8 @@
 
 import collections
 import json
+import sys
+import webbrowser
 
 import httpx
 
@@ -130,31 +132,35 @@ def main(*args):
         days_to_fetch=days_to_fetch,
     )
 
-    payload = prepare_slack_payload(
-        classified_ingests=classified_ingests,
-        found_everything=found_everything,
-        days_to_fetch=days_to_fetch,
-        s3_url=s3_url,
-    )
+    if "--browser" in sys.argv:
+        webbrowser.open(s3_url)
 
-    resp = httpx.post(
-        get_secret("storage_service_reporter/slack_webhook"), json=payload
-    )
+    if "--skip-slack" not in sys.argv:
+        payload = prepare_slack_payload(
+            classified_ingests=classified_ingests,
+            found_everything=found_everything,
+            days_to_fetch=days_to_fetch,
+            s3_url=s3_url,
+        )
 
-    print(f"Sent payload to Slack: {resp}")
+        resp = httpx.post(
+            get_secret("storage_service_reporter/slack_webhook"), json=payload
+        )
 
-    if resp.status_code != 200:
-        print("Non-200 response from Slack:")
+        print(f"Sent payload to Slack: {resp}")
 
-        print("")
+        if resp.status_code != 200:
+            print("Non-200 response from Slack:")
 
-        print("== request ==")
-        print(json.dumps(payload, indent=2, sort_keys=True))
+            print("")
 
-        print("")
+            print("== request ==")
+            print(json.dumps(payload, indent=2, sort_keys=True))
 
-        print("== response ==")
-        print(resp.text)
+            print("")
+
+            print("== response ==")
+            print(resp.text)
 
 
 if __name__ == "__main__":

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -52,7 +52,7 @@ def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s
         f"in the last {days_to_fetch} day{'s' if days_to_fetch > 1 else ''}?"
     )
 
-    return {
+    result = {
         "blocks": [
             {"type": "header", "text": {"type": "plain_text", "text": heading}},
             {
@@ -73,12 +73,25 @@ def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s
                     ),
                 },
             },
-            {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
-            },
+
         ]
     }
+
+    if not found_everything:
+        result['blocks'].append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Elasticsearch can only return the first 10,000 results. There may be ingests missing from this report."
+            }
+        })
+
+    result['blocks'].append({
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
+    })
+
+    return result
 
 
 def main(*args):

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -55,7 +55,7 @@ def main(*args):
 
     if "--skip-slack" not in sys.argv:
         payload = prepare_slack_payload(
-            classified_ingests=classified_ingests,
+            ingests_by_status=ingests_by_status,
             found_everything=found_everything,
             days_to_fetch=days_to_fetch,
             s3_url=s3_url,

--- a/monitoring/daily_reporter/src/daily_reporter.py
+++ b/monitoring/daily_reporter/src/daily_reporter.py
@@ -1,107 +1,9 @@
 #!/usr/bin/env python
 
-import datetime
-import json
+import collections
 
-import boto3
-import httpx
-
-from elasticsearch import get_es_client
-
-
-def get_interesting_ingests(es_client, *, index_name, days_to_fetch):
-    """
-    Get ingests that are "interesting".
-    """
-    today = datetime.datetime.now()
-
-    start = today - datetime.timedelta(days=days_to_fetch)
-
-    # Did we find everything we were looking for?  It's possible we might
-    found_everything = True
-
-    # Ingests we want to return
-    ingests = {}
-
-    # We make three requests to Elasticsearch, to maximise the chance of finding
-    # ingests that might need more attention:
-    #
-    #   * everything modified in the last N days
-    #   * everything modified in the last N days which hasn't succeeded
-    #   * everything which hasn't completed
-    #
-    # A single ES request returns up to 10000 documents; if more than that have
-    # been updated (e.g. we've just done a big migration), we want to flag that
-    # fact and try to find the most interesting stuff.
-    filters = [
-        [{"range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}}],
-        [{
-            "range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}},{
-            "terms": {"status.id": ["processing", "accepted", "failed"]},
-        }],
-        [{"terms": {"status.id": ["processing", "accepted"]}}],
-    ]
-
-    for filter_clause in filters:
-        resp = es_client.request(
-            method="GET",
-            url=f"/{index_name}/_search",
-            json={
-                "query": {"bool": {"filter": filter_clause}},
-                "_source": [
-                    "id",
-                    "lastModifiedDate",
-                    "space.id",
-                    "status.id",
-                    "bag.info.externalIdentifier",
-                    "bag.info.version",
-                    "createdDate",
-                    "events.description",
-                ],
-                # We can retrieve up to 10000 documents in one request.
-                "size": 10000,
-                "sort": [{"id": "desc"}],
-            },
-        )
-
-        # We use a dict to de-duplicate result.  The same ingest may appear
-        # multiple times in this response -- that's not an issue.
-        for hit in resp.json()["hits"]["hits"]:
-            ingests[hit["_id"]] = _parse_ingest_from_hit(hit)
-
-        # If there are more than 10000 results, that suggests there are more
-        # that we didn't get.  Flag this to the caller.
-        if resp.json()["hits"]["total"]["value"] >= 10000:
-            found_everything = False
-
-    return {"ingests": ingests, "found_everything": found_everything}
-
-
-def _parse_date(d):
-    try:
-        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
-    except ValueError:
-        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%SZ")
-
-
-def _parse_ingest_from_hit(hit):
-    source = hit["_source"]
-    ingest = {
-        "id": source["id"],
-        "space": source["space"]["id"],
-        "status": source["status"]["id"],
-        "externalIdentifier": source["bag"]["info"]["externalIdentifier"],
-        "version": source["bag"].get("version"),
-        "createdDate": _parse_date(source["lastModifiedDate"]),
-        "events": [ev["description"] for ev in source["events"]]
-    }
-
-    try:
-        ingest["lastModifiedDate"] = _parse_date(source["lastModifiedDate"])
-    except KeyError:
-        ingest["lastModifiedDate"] = ingest["createdDate"]
-
-    return ingest
+from elasticsearch import get_es_client, get_interesting_ingests
+from ingests import classify_ingest
 
 
 def get_ingests_by_status(recent_ingests):
@@ -233,13 +135,18 @@ def main(*args):
     prod_ingests = get_interesting_ingests(
         es_client, index_name="storage_ingests", days_to_fetch=2
     )
-    # stage_ingests = get_recent_ingests(
-    #     es_client, index_name="storage_stage_ingests", days_to_fetch=2
-    # )
+
+    classified_ingests = {
+        'prod': collections.defaultdict(list),
+        'stage': collections.defaultdict(list),
+    }
+    for ingest in prod_ingests["ingests"]:
+        status = classify_ingest(ingest)
+        classified_ingests['prod'][status].append(ingest)
 
     from pprint import pprint
 
-    pprint(prod_ingests["ingests"])
+    pprint(classified_ingests['prod'].keys())
 
     #
     #

--- a/monitoring/daily_reporter/src/elasticsearch.py
+++ b/monitoring/daily_reporter/src/elasticsearch.py
@@ -1,3 +1,5 @@
+import datetime
+
 import boto3
 import httpx
 
@@ -25,3 +27,111 @@ def get_es_client():
         base_url=f"https://{es_host}:{es_port}",
         auth=(es_user, es_pass)
     )
+
+
+def _parse_date(d):
+    try:
+        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_ingest_from_hit(hit):
+    source = hit["_source"]
+    ingest = {
+        "id": source["id"],
+        "space": source["space"]["id"],
+        "status": source["status"]["id"],
+        "externalIdentifier": source["bag"]["info"]["externalIdentifier"],
+        "version": source["bag"].get("version"),
+        "createdDate": _parse_date(source["lastModifiedDate"]),
+        "events": [
+            {
+                "description": ev["description"],
+                "createdDate": _parse_date(ev["createdDate"])
+            } for ev in source["events"]
+        ],
+    }
+
+    try:
+        ingest["lastModifiedDate"] = _parse_date(source["lastModifiedDate"])
+    except KeyError:
+        ingest["lastModifiedDate"] = ingest["createdDate"]
+
+    return ingest
+
+
+def get_interesting_ingests(es_client, *, index_name, days_to_fetch):
+    """
+    Get ingests that are "interesting".  This could mean:
+
+    *   it was updated recently
+    *   it's still processing
+
+    It tries to highlight ingests that might need attention, e.g. failures or
+    stalled ingests.
+
+    """
+    today = datetime.datetime.now()
+
+    start = today - datetime.timedelta(days=days_to_fetch)
+
+    # Did we find everything we were looking for?  It's possible we might
+    found_everything = True
+
+    # Ingests we want to return
+    ingests = {}
+
+    # We make three requests to Elasticsearch, to maximise the chance of finding
+    # ingests that might need more attention:
+    #
+    #   * everything modified in the last N days
+    #   * everything modified in the last N days which hasn't succeeded
+    #   * everything which hasn't completed
+    #
+    # A single ES request returns up to 10000 documents; if more than that have
+    # been updated (e.g. we've just done a big migration), we want to flag that
+    # fact and try to find the most interesting stuff.
+    filters = [
+        [{"range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}}],
+        [{
+            "range": {"lastModifiedDate": {"gte": start.strftime("%Y-%m-%d")}}},{
+            "terms": {"status.id": ["processing", "accepted", "failed"]},
+        }],
+        [{"terms": {"status.id": ["processing", "accepted"]}}],
+    ]
+
+    for filter_clause in filters:
+        resp = es_client.request(
+            method="GET",
+            url=f"/{index_name}/_search",
+            json={
+                "query": {"bool": {"filter": filter_clause}},
+                "_source": [
+                    "id",
+                    "lastModifiedDate",
+                    "space.id",
+                    "status.id",
+                    "bag.info.externalIdentifier",
+                    "bag.info.version",
+                    "createdDate",
+                    "events.createdDate",
+                    "events.description",
+                ],
+                # We can retrieve up to 10000 documents in one request.
+                "size": 10000,
+                "sort": [{"id": "desc"}],
+            },
+        )
+
+        # We use a dict to de-duplicate result.  The same ingest may appear
+        # multiple times in this response -- that's not an issue.
+        for hit in resp.json()["hits"]["hits"]:
+            ingests[hit["_id"]] = _parse_ingest_from_hit(hit)
+
+        # If there are more than 10000 results, that suggests there are more
+        # that we didn't get.  Flag this to the caller.
+        if resp.json()["hits"]["total"]["value"] >= 10000:
+            found_everything = False
+
+    return {"ingests": ingests.values(), "found_everything": found_everything}

--- a/monitoring/daily_reporter/src/elasticsearch.py
+++ b/monitoring/daily_reporter/src/elasticsearch.py
@@ -1,0 +1,27 @@
+import boto3
+import httpx
+
+
+secrets_client = boto3.client("secretsmanager")
+
+
+def get_secret(secret_id):
+    """
+    Get a Secret from Secrets Manager.
+    """
+    return secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]
+
+
+def get_es_client():
+    """
+    Get an instance of httpx.Client authenticated to the reporting cluster.
+    """
+    es_host = get_secret("storage_service_reporter/es_host")
+    es_port = get_secret("storage_service_reporter/es_port")
+    es_user = get_secret("storage_service_reporter/es_user")
+    es_pass = get_secret("storage_service_reporter/es_pass")
+
+    return httpx.Client(
+        base_url=f"https://{es_host}:{es_port}",
+        auth=(es_user, es_pass)
+    )

--- a/monitoring/daily_reporter/src/html_report.py
+++ b/monitoring/daily_reporter/src/html_report.py
@@ -37,7 +37,7 @@ def add_s3_uri(description):
         )
 
 
-def create_html_report(classified_ingests, found_everything, days_to_fetch):
+def create_html_report(ingests_by_status, found_everything, days_to_fetch):
     template_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "templates")
     env = Environment(
         loader=FileSystemLoader(template_dir), autoescape=select_autoescape(["html"])
@@ -49,7 +49,7 @@ def create_html_report(classified_ingests, found_everything, days_to_fetch):
     template = env.get_template("report.html")
 
     return template.render(
-        classified_ingests=classified_ingests,
+        ingests_by_status=ingests_by_status,
         found_everything=found_everything,
         days_to_fetch=days_to_fetch,
         today=datetime.date.today(),
@@ -58,6 +58,10 @@ def create_html_report(classified_ingests, found_everything, days_to_fetch):
 
 
 def store_s3_report(**kwargs):
+    """
+    Create an HTML report, upload it to the daily-reporting S3 bucket, and
+    return a URL where the report can be found.
+    """
     html = create_html_report(**kwargs)
 
     s3 = boto3.client("s3")

--- a/monitoring/daily_reporter/src/html_report.py
+++ b/monitoring/daily_reporter/src/html_report.py
@@ -7,18 +7,18 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
 def last_event(ingest):
-    failures = [ev for ev in ingest['events'] if 'failed' in ev['description']]
+    failures = [ev for ev in ingest["events"] if "failed" in ev["description"]]
     if failures:
-        return max(failures, key=lambda ev: ev['createdDate'])
+        return max(failures, key=lambda ev: ev["createdDate"])
     else:
         try:
-            return max(ingest['events'], key=lambda ev: ev['createdDate'])
+            return max(ingest["events"], key=lambda ev: ev["createdDate"])
         except ValueError:
             return None
 
 
 def add_s3_uri(description):
-    s3_uri = re.search(r's3://(?P<bucket>[^/]+)/(?P<key>[^\s:]+)', description)
+    s3_uri = re.search(r"s3://(?P<bucket>[^/]+)/(?P<key>[^\s:]+)", description)
 
     if s3_uri is None:
         return description
@@ -32,22 +32,21 @@ def add_s3_uri(description):
             f"&region=eu-west-1"
         )
 
-        return description.replace(s3_uri.group(0), f'<a href="{s3_console_link}">{s3_uri.group(0)}</a>')
+        return description.replace(
+            s3_uri.group(0), f'<a href="{s3_console_link}">{s3_uri.group(0)}</a>'
+        )
 
 
 def create_html_report(classified_ingests, found_everything, days_to_fetch):
-    template_dir = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), 'templates'
-    )
+    template_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "templates")
     env = Environment(
-        loader=FileSystemLoader(template_dir),
-        autoescape=select_autoescape(['html'])
+        loader=FileSystemLoader(template_dir), autoescape=select_autoescape(["html"])
     )
 
     env.filters["last_event"] = last_event
     env.filters["add_s3_uri"] = add_s3_uri
 
-    template = env.get_template('report.html')
+    template = env.get_template("report.html")
 
     return template.render(
         classified_ingests=classified_ingests,
@@ -72,7 +71,7 @@ def store_s3_report(**kwargs):
         Key=f"{today}.html",
         Body=html.encode("utf8"),
         ContentType="text/html",
-        ACL="public-read"
+        ACL="public-read",
     )
 
     return f"https://{daily_reporting_bucket}.s3-eu-west-1.amazonaws.com/{today}.html"

--- a/monitoring/daily_reporter/src/html_report.py
+++ b/monitoring/daily_reporter/src/html_report.py
@@ -1,0 +1,54 @@
+import datetime
+import os
+import re
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def last_event(ingest):
+    failures = [ev for ev in ingest['events'] if 'failed' in ev['description']]
+    if failures:
+        return max(failures, key=lambda ev: ev['createdDate'])
+    else:
+        try:
+            return max(ingest['events'], key=lambda ev: ev['createdDate'])
+        except ValueError:
+            return None
+
+
+def add_s3_uri(description):
+    s3_uri = re.search(r's3://(?P<bucket>[^/]+)/(?P<key>[^\s:]+)', description)
+
+    if s3_uri is None:
+        return description
+    else:
+        bucket = s3_uri.group("bucket")
+        key = s3_uri.group("key")
+
+        s3_console_link = (
+            f"https://s3.console.aws.amazon.com/s3/buckets/{bucket}"
+            f"/{os.path.dirname(key)}/?tab=overview&prefixSearch={os.path.basename(key)}"
+            f"&region=eu-west-1"
+        )
+
+        return description.replace(s3_uri.group(0), f'<a href="{s3_console_link}">{s3_uri.group(0)}</a>')
+
+
+def create_html_report(classified_ingests):
+    template_dir = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), 'templates'
+    )
+    env = Environment(
+        loader=FileSystemLoader(template_dir),
+        autoescape=select_autoescape(['html'])
+    )
+
+    env.filters["last_event"] = last_event
+    env.filters["add_s3_uri"] = add_s3_uri
+
+    template = env.get_template('report.html')
+
+    return template.render(
+        classified_ingests=classified_ingests,
+        today=datetime.date.today()
+    )

--- a/monitoring/daily_reporter/src/html_report.py
+++ b/monitoring/daily_reporter/src/html_report.py
@@ -34,7 +34,7 @@ def add_s3_uri(description):
         return description.replace(s3_uri.group(0), f'<a href="{s3_console_link}">{s3_uri.group(0)}</a>')
 
 
-def create_html_report(classified_ingests):
+def create_html_report(classified_ingests, found_everything):
     template_dir = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), 'templates'
     )
@@ -50,5 +50,6 @@ def create_html_report(classified_ingests):
 
     return template.render(
         classified_ingests=classified_ingests,
+        found_everything=found_everything,
         today=datetime.date.today()
     )

--- a/monitoring/daily_reporter/src/ingests.py
+++ b/monitoring/daily_reporter/src/ingests.py
@@ -1,0 +1,72 @@
+import datetime
+
+
+def classify_ingest(ingest):
+    """
+    Get an ingest status that reflects whether we need to pay attention to it.
+    For example:
+
+    *   If the ingest has failed, was it a user error (failed verification) or
+        a storage service error (failed replication)?
+    *   If the ingest is processing or accepted, has it been updated recently,
+        or is it stalled?
+
+    """
+    # Success never needs our attention.
+    if ingest["status"] == "succeeded":
+        return "succeeded"
+
+    elif ingest["status"] == "failed":
+        # We sort failures into two groups:
+        #
+        #   -   a user error is one that means there was something wrong with the
+        #       bag, e.g. it couldn't be unpacked correctly, it failed verification
+        #   -   an unknown error is one that we can't categorise, and might indicate
+        #       a storage service error, e.g. a replication failure
+        #
+        failure_reasons = [
+            ev["description"]
+            for ev in ingest["events"]
+            if "failed" in ev["description"]
+        ]
+
+        if failure_reasons and all(
+            reason.startswith(
+                (
+                    "Verification (pre-replicating to archive storage) failed",
+                    "Unpacking failed",
+                    "Assigning bag version failed",
+                )
+            )
+            for reason in failure_reasons
+        ):
+            return "failed (user error)"
+        else:
+            return "failed (unknown reason)"
+
+    elif ingest["status"] == "accepted":
+        # An ingest is in the 'accepted' state until it goes to the bag unpacker.
+        # There may be a short delay while the bag unpacker starts up; a delay of
+        # more than an hour suggests something is wrong.
+        #
+        # To allow for timezone slop, look for a delay of two hours.
+        delay = datetime.datetime.now() - ingest["createdDate"]
+
+        if abs(delay.total_seconds()) > 60 * 60 * 2:
+            return "stalled"
+        else:
+            return "accepted"
+
+    elif ingest["status"] == "processing":
+        # Ingests should wait up to 5 hours before being retried due to SQS.
+        # If an ingest hasn't been updated in more than 5 hours, something is
+        # probably wrong.
+        #
+        # To allow for timezone slop, look for a delay of seven hours.  It will
+        # be flagged the following day if it's still stalled.
+        delay = datetime.datetime.now() - ingest["createdDate"]
+
+        if abs(delay.total_seconds()) > 60 * 60 * 7:
+            return "stalled"
+        else:
+            return "processing"

--- a/monitoring/daily_reporter/src/ingests.py
+++ b/monitoring/daily_reporter/src/ingests.py
@@ -1,7 +1,7 @@
 import datetime
 
 
-def classify_ingest(ingest):
+def get_dev_status(ingest):
     """
     Get an ingest status that reflects whether we need to pay attention to it.
     For example:

--- a/monitoring/daily_reporter/src/slack.py
+++ b/monitoring/daily_reporter/src/slack.py
@@ -39,7 +39,7 @@ def _get_slack_message(label, ingests):
     return result
 
 
-def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s3_url):
+def prepare_slack_payload(ingests_by_status, found_everything, days_to_fetch, s3_url):
     heading = (
         f"What happened in the storage service "
         f"in the last {days_to_fetch} day{'s' if days_to_fetch > 1 else ''}?"
@@ -53,7 +53,7 @@ def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s
                 "text": {
                     "type": "mrkdwn",
                     "text": _get_slack_message(
-                        "Prod", ingests=classified_ingests["prod"]
+                        "Prod", ingests=ingests_by_status["prod"]
                     ),
                 },
             },
@@ -62,7 +62,7 @@ def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s
                 "text": {
                     "type": "mrkdwn",
                     "text": _get_slack_message(
-                        "Staging", ingests=classified_ingests["staging"]
+                        "Staging", ingests=ingests_by_status["staging"]
                     ),
                 },
             },

--- a/monitoring/daily_reporter/src/slack.py
+++ b/monitoring/daily_reporter/src/slack.py
@@ -66,22 +66,25 @@ def prepare_slack_payload(ingests_by_status, found_everything, days_to_fetch, s3
                     ),
                 },
             },
-
         ]
     }
 
     if not found_everything:
-        result['blocks'].append({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "Elasticsearch can only return the first 10,000 results. There may be ingests missing from this report."
+        result["blocks"].append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Elasticsearch can only return the first 10,000 results. There may be ingests missing from this report.",
+                },
             }
-        })
+        )
 
-    result['blocks'].append({
-        "type": "section",
-        "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
-    })
+    result["blocks"].append(
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
+        }
+    )
 
     return result

--- a/monitoring/daily_reporter/src/slack.py
+++ b/monitoring/daily_reporter/src/slack.py
@@ -1,0 +1,87 @@
+def _get_slack_message(label, ingests):
+    result = f"*{label}:* "
+
+    if not ingests:
+        result += "no activity."
+        return result
+
+    # Produce a message of the form
+    #
+    #     Prod: succeeded (14), failed (user error) (2), stalled (1)
+    #
+    # Highlight unusual statuses.
+    status_descriptions = []
+    for status, individual_ingests in ingests.items():
+        if status in ("stalled", "failed (unknown reason)"):
+            status_descriptions.append(f"*{status} ({len(individual_ingests)})*")
+        else:
+            status_descriptions.append(f"{status} ({len(individual_ingests)})")
+
+    result += ", ".join(status_descriptions)
+
+    # Create a list of any ingests that are likely to need special attention.
+    # The list is of the form
+    #
+    #       - a123-a123-a123 – digitised/b1234/v1
+    #
+    # and the ingest UUID links to the ingest inspector.
+    for status in ("failed (unknown reason)", "stalled"):
+        if ingests.get(status, []):
+            result += "\n" + status.title() + ":"
+            for i in ingests[status][:15]:
+                result += f"\n- <https://wellcome-ingest-inspector.glitch.me/ingests/{i['id']}|`{i['id']}`> – {i['space']}/{i['externalIdentifier']}"
+                if i["version"]:
+                    result += "/" + i["version"]
+
+            if len(ingests[status]) >= 15:
+                result += "\n- ..."
+
+    return result
+
+
+def prepare_slack_payload(classified_ingests, found_everything, days_to_fetch, s3_url):
+    heading = (
+        f"What happened in the storage service "
+        f"in the last {days_to_fetch} day{'s' if days_to_fetch > 1 else ''}?"
+    )
+
+    result = {
+        "blocks": [
+            {"type": "header", "text": {"type": "plain_text", "text": heading}},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": _get_slack_message(
+                        "Prod", ingests=classified_ingests["prod"]
+                    ),
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": _get_slack_message(
+                        "Staging", ingests=classified_ingests["staging"]
+                    ),
+                },
+            },
+
+        ]
+    }
+
+    if not found_everything:
+        result['blocks'].append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Elasticsearch can only return the first 10,000 results. There may be ingests missing from this report."
+            }
+        })
+
+    result['blocks'].append({
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": f"*Full report*: {s3_url}"},
+    })
+
+    return result

--- a/monitoring/daily_reporter/src/templates/report.html
+++ b/monitoring/daily_reporter/src/templates/report.html
@@ -142,7 +142,7 @@
           {% endif %}
         </p>
 
-        {% if not classified_ingests %}
+        {% if not ingests_by_status %}
           <p>No activity!</p>
         {% endif %}
 
@@ -151,7 +151,7 @@
             <tr>
               <th colspan="3"><h1>{{ label }}</h1></th>
             </tr>
-            {% if classified_ingests.get(label, {}) %}
+            {% if ingests_by_status.get(label, {}) %}
               {% for classification in [
                 "failed (unknown reason)",
                 "stalled",
@@ -160,9 +160,9 @@
                 "processing",
                 "succeeded"
               ] %}
-                {% if classified_ingests[label].get(classification) %}
+                {% if ingests_by_status[label].get(classification) %}
                   <tr><td colspan="3"><h3>{{ classification }}</h3></td></tr>
-                  {% for ingest in classified_ingests[label].get(classification) | sort(attribute="lastModifiedDate", reverse=True) %}
+                  {% for ingest in ingests_by_status[label].get(classification) | sort(attribute="lastModifiedDate", reverse=True) %}
                   <tr class="status-{{ ingest.status }}">
                     <td class="ingest_id">
                       <a href="https://wellcome-ingest-inspector.glitch.me/ingests/{{ ingest.id }}">{{ ingest.id }}</a></td>

--- a/monitoring/daily_reporter/src/templates/report.html
+++ b/monitoring/daily_reporter/src/templates/report.html
@@ -15,6 +15,14 @@
         margin-bottom: 3em;
       }
 
+      footer {
+        margin-top: 4em;
+        border-top: 1px solid #ccc;
+        font-size: small;
+        color: #999;
+        padding-top: 10px;
+      }
+
       div.content {
         max-width: 1000px;
         margin-left:  auto;
@@ -126,10 +134,13 @@
     </aside>
     <main>
       <div class="content">
-        {% if not found_everything %}
-          Elasticsearch can only return the first 10,000 results.
-          There may be ingests missing from this report.
-        {% endif %}
+        <p>
+          Here's everything that happened in the last <strong>{{ days_to_fetch }} days</strong> in the storage service.
+          {% if not found_everything %}
+            Elasticsearch can only return the first 10,000 results.
+            There may be ingests missing from this report.
+          {% endif %}
+        </p>
 
         {% if not classified_ingests %}
           <p>No activity!</p>
@@ -180,5 +191,10 @@
         </table>
       </div>
     </main>
+    <footer>
+      <div class="content">
+        Report generated at {{ now.isoformat() }}
+      </div>
+    </footer>
   </body>
 </html>

--- a/monitoring/daily_reporter/src/templates/report.html
+++ b/monitoring/daily_reporter/src/templates/report.html
@@ -162,19 +162,20 @@
               ] %}
                 {% if classified_ingests[label].get(classification) %}
                   <tr><td colspan="3"><h3>{{ classification }}</h3></td></tr>
-                  {% for ingest in classified_ingests[label].get(classification) %}
+                  {% for ingest in classified_ingests[label].get(classification) | sort(attribute="lastModifiedDate", reverse=True) %}
                   <tr class="status-{{ ingest.status }}">
                     <td class="ingest_id">
                       <a href="https://wellcome-ingest-inspector.glitch.me/ingests/{{ ingest.id }}">{{ ingest.id }}</a></td>
                     <td>{{ ingest.space }}</td>
                     <td>{{ ingest.externalIdentifier }}</td>
                     <td>{{ ingest.version or "(no version)" }}</td>
+                    <td>{{ ingest.lastModifiedDate.strftime("%Y-%m-%d @ %H:%M") }}</td>
                   </tr>
 
                   {% set last_event = ingest|last_event %}
                   {% if last_event and ingest.status != 'succeeded' %}
                   <tr class="status-{{ ingest.status }} last_event">
-                    <td colspan="4" {% if loop.last %}style="padding-bottom: 3px"{% endif %}>
+                    <td colspan="5" {% if loop.last %}style="padding-bottom: 3px"{% endif %}>
                       Last event: {{ last_event.description|add_s3_uri|safe }}<br/>
                       {{ last_event.createdDate.strftime("%d %B %Y @ %H:%M") }}
                     </td>

--- a/monitoring/daily_reporter/src/templates/report.html
+++ b/monitoring/daily_reporter/src/templates/report.html
@@ -88,7 +88,7 @@
       }
 
       .status-accepted a {
-        color: #FEC200;  /* runny yolk */
+        color: #cc9c00;  /* runny yolk */
       }
 
       h1, h3 {
@@ -126,8 +126,13 @@
     </aside>
     <main>
       <div class="content">
+        {% if not found_everything %}
+          Elasticsearch can only return the first 10,000 results.
+          There may be ingests missing from this report.
+        {% endif %}
+
         {% if not classified_ingests %}
-          No activity!
+          <p>No activity!</p>
         {% endif %}
 
         <table>

--- a/monitoring/daily_reporter/src/templates/report.html
+++ b/monitoring/daily_reporter/src/templates/report.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title>Storage service report for {{ today.strftime("%d %B %Y") }}</title>
+
+    <style>
+      body {
+        font: 12pt 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        color: #121212;
+        line-height: 1.5;
+        margin: 0;
+        margin-bottom: 3em;
+      }
+
+      div.content {
+        max-width: 1000px;
+        margin-left:  auto;
+        margin-right: auto;
+        padding-left:  1em;
+        padding-right: 1em;
+      }
+
+      @font-face {
+        font-family: Wellcome;
+        src: url(https://wellcome.ac.uk/sites/all/themes/corp_base/assets/fonts/wellcome-bold-webfont.woff2);
+      }
+
+      aside {
+        background-color: #FEC200;  /* runny yolk */
+        font: 18pt Wellcome, sans-serif;
+        padding-top:    0.5em;
+        padding-bottom: 0.5em;
+        border-bottom: 5px solid black;
+        margin-bottom: 1em;
+      }
+
+      a:hover {
+        text-decoration: none;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-left: -14px;
+      }
+
+      h1, h3, .no_activity {
+        margin-left: 14px;
+      }
+
+      .no_activity {
+        padding-left: 14px;
+      }
+
+      tr.status-succeeded td:first-child {
+        border-left: 6px solid #4C8026;  /* sherwood 2 */
+        padding-left: 14px;
+      }
+
+      tr.status-processing td:first-child {
+        border-left: 6px solid #009BB2;  /* bora bora */
+        padding-left: 14px;
+      }
+
+      tr.status-failed td:first-child {
+        border-left: 6px solid #E10F2D;  /* brogues 3 */
+        padding-left: 14px;
+      }
+
+      tr.status-accepted td:first-child {
+        border-left: 6px solid #FEC200;  /* runny yolk */
+        padding-left: 14px;
+      }
+
+      .status-succeeded a {
+        color: #4C8026;  /* sherwood 2 */
+      }
+
+      .status-processing a {
+        color: #009BB2;  /* bora bora */
+      }
+
+      .status-failed a {
+        color: #E10F2D;  /* brogues 3 */
+      }
+
+      .status-accepted a {
+        color: #FEC200;  /* runny yolk */
+      }
+
+      h1, h3 {
+        margin-bottom: 5px;
+      }
+
+      th {
+        text-align: left;
+      }
+
+      td {
+        padding: 3px;
+        vertical-align: top;
+      }
+
+      td.ingest_id {
+        font-family: monospace;
+
+      }
+
+      .last_event td {
+        padding-left: 2.5em !important;
+        font-size: 90%;
+        padding-bottom: 1em;
+        line-height: 1.5em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <aside>
+      <div class="content">
+        Storage service report for {{ today.strftime("%d %B %Y") }}
+      </div>
+    </aside>
+    <main>
+      <div class="content">
+        {% if not classified_ingests %}
+          No activity!
+        {% endif %}
+
+        <table>
+          {% for label in ["prod", "staging"] %}
+            <tr>
+              <th colspan="3"><h1>{{ label }}</h1></th>
+            </tr>
+            {% if classified_ingests.get(label, {}) %}
+              {% for classification in [
+                "failed (unknown reason)",
+                "stalled",
+                "failed (user error)",
+                "accepted",
+                "processing",
+                "succeeded"
+              ] %}
+                {% if classified_ingests[label].get(classification) %}
+                  <tr><td colspan="3"><h3>{{ classification }}</h3></td></tr>
+                  {% for ingest in classified_ingests[label].get(classification) %}
+                  <tr class="status-{{ ingest.status }}">
+                    <td class="ingest_id">
+                      <a href="https://wellcome-ingest-inspector.glitch.me/ingests/{{ ingest.id }}">{{ ingest.id }}</a></td>
+                    <td>{{ ingest.space }}</td>
+                    <td>{{ ingest.externalIdentifier }}</td>
+                    <td>{{ ingest.version or "(no version)" }}</td>
+                  </tr>
+
+                  {% set last_event = ingest|last_event %}
+                  {% if last_event and ingest.status != 'succeeded' %}
+                  <tr class="status-{{ ingest.status }} last_event">
+                    <td colspan="4" {% if loop.last %}style="padding-bottom: 3px"{% endif %}>
+                      Last event: {{ last_event.description|add_s3_uri|safe }}<br/>
+                      {{ last_event.createdDate.strftime("%d %B %Y @ %H:%M") }}
+                    </td>
+                  </tr>
+                  {% endif %}
+
+                  {% endfor %}
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              <tr><td class="no_activity">No activity!</td></tr>
+            {% endif %}
+          {% endfor %}
+        </table>
+      </div>
+    </main>
+  </body>
+</html>

--- a/terraform/monitoring/lambda_daily_reporter.tf
+++ b/terraform/monitoring/lambda_daily_reporter.tf
@@ -7,7 +7,7 @@ module "daily_reporter_lambda" {
   s3_bucket = "wellcomecollection-storage-infra"
   s3_key    = "lambdas/monitoring/daily_reporter.zip"
 
-  timeout = 30
+  timeout = 300
 
   tags = local.default_tags
 }
@@ -51,6 +51,23 @@ data "aws_iam_policy_document" "read_es_secrets" {
 resource "aws_iam_role_policy" "allow_reporter_to_read_es_secrets" {
   role   = module.daily_reporter_lambda.role_name
   policy = data.aws_iam_policy_document.read_es_secrets.json
+}
+
+data "aws_iam_policy_document" "upload_to_s3" {
+  statement {
+    actions = [
+      "s3:Put*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.daily_reporter.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_reporter_to_upload_to_s3" {
+  role   = module.daily_reporter_lambda.role_name
+  policy = data.aws_iam_policy_document.upload_to_s3.json
 }
 
 # Schedule the reporter to run at 6am every day

--- a/terraform/monitoring/provider.tf
+++ b/terraform/monitoring/provider.tf
@@ -12,3 +12,14 @@ provider "aws" {
   region  = "eu-west-1"
   version = "~> 2.7"
 }
+
+provider "aws" {
+  region  = "eu-west-1"
+  version = "2.35.0"
+
+  alias = "platform"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+}

--- a/terraform/monitoring/s3_daily_reporter.tf
+++ b/terraform/monitoring/s3_daily_reporter.tf
@@ -1,0 +1,58 @@
+# Create a bucket with static website hosting to host the storage service
+# daily reports.  This has to live in the platform account because we block
+# creating buckets with public access in the storage account.
+
+resource "aws_s3_bucket" "daily_reporter" {
+  bucket = "wellcomecollection-storage-daily-reporting"
+  acl    = "public-read"
+
+  provider = aws.platform
+
+  website {
+    index_document = "index.html"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  lifecycle_rule {
+    id      = "expire_old_reports"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "daily_reporter_storage_access" {
+  bucket = aws_s3_bucket.daily_reporter.id
+  policy = data.aws_iam_policy_document.daily_reporter_storage_access.json
+
+  provider = aws.platform
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "daily_reporter_storage_access" {
+  statement {
+    actions = [
+      "s3:PutObject*",
+      "s3:GetObject*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.daily_reporter.arn}",
+      "${aws_s3_bucket.daily_reporter.arn}/*",
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        data.aws_caller_identity.current.account_id,
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4769

New features:

* Previously the daily reporter would only report on ingests that were updated in the last 2 days. It now additionally looks for ingests from any time which are in the "processing" or "accepted" states, which might indicate a stalled ingest.

* Stalled ingests are now flagged in the daily Slack message.

* It writes a colourful HTML report of the last two days of storage service activity, which is written to a public S3 bucket configured to do static website hosting: https://wellcomecollection-storage-daily-reporting.s3-eu-west-1.amazonaws.com/2020-09-30.html