### PR TITLE
Don't reindex C&D with the regular bag indexer

### DIFF
--- a/indexer/reindex_bags_backlog.py
+++ b/indexer/reindex_bags_backlog.py
@@ -95,6 +95,15 @@ def get_latest_bags(dynamodb_client, table_name):
     ):
         dynamo_id = item["id"]["S"]
         version = int(item["version"]["N"])
+
+        # Don't index Chemist & Druggist with this script.  It's too big to index
+        # normally, and we have a separate script that breaks it into smaller,
+        # indexable-sized pieces.
+        #
+        # Trying to index C&D like other bags causes an outage in the bags API.
+        if dynamo_id == "digitised/b19974760":
+            continue
+
         stored_version = bags.get(dynamo_id, -1)
 
         seen_bags = seen_bags + 1


### PR DESCRIPTION
It's too big, and trying to index it causes the bags API to completely fall over when it tries to retrieve the bag.  Don't let somebody send it for indexing by accident.

Part of https://github.com/wellcomecollection/platform/issues/4796