### PR TITLE
General tidy-ups in the storage-service tests before using the new RandomGenerators

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -265,7 +265,7 @@ class StorageManifestServiceTest
   describe("fails if the fetch.txt is wrong") {
     it("refers to files that aren't in the manifest") {
       val fetchEntries = Map(
-        BagPath(randomAlphanumeric) -> createFetchMetadata
+        createBagPath -> createFetchMetadata
       )
 
       val bag = createBagWith(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/StorageManifestServiceTest.scala
@@ -16,7 +16,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.azure.AzureBlobLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
@@ -550,7 +549,7 @@ class StorageManifestServiceTest
             .asPrefix
         ),
         SecondaryAzureReplicaLocation(
-          AzureBlobLocationPrefix(randomAlphanumeric, randomAlphanumeric)
+          createAzureBlobLocationPrefix
             .asLocation(version.toString)
             .asPrefix
         )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -69,7 +69,7 @@ trait BagReplicatorFixtures
     ingests: MemoryMessageSender = new MemoryMessageSender(),
     outgoing: MemoryMessageSender = new MemoryMessageSender(),
     lockServiceDao: LockDao[String, UUID] = new MemoryLockDao[String, UUID] {},
-    stepName: String = randomAlphanumericWithLength(),
+    stepName: String = createStepName,
     replicaType: ReplicaType = chooseFrom(Seq(PrimaryReplica, SecondaryReplica))
   )(
     testWith: TestWith[

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.storage.generators.{
 }
 
 class ReplicationRequestTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with S3ObjectLocationGenerators
     with AzureBlobLocationGenerators {

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
@@ -11,16 +11,19 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   SecondaryAzureReplicaLocation,
   SecondaryS3ReplicaLocation
 }
-import uk.ac.wellcome.storage.azure.AzureBlobLocationPrefix
-import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.generators.{
+  AzureBlobLocationGenerators,
+  S3ObjectLocationGenerators
+}
 
-class ReplicationRequestTest extends AnyFunSpec with Matchers with S3ObjectLocationGenerators {
+class ReplicationRequestTest
+  extends AnyFunSpec
+    with Matchers
+    with S3ObjectLocationGenerators
+    with AzureBlobLocationGenerators {
   describe("toReplicaLocation") {
     val s3Prefix = createS3ObjectLocationPrefix
-    val azurePrefix = AzureBlobLocationPrefix(
-      container = randomAlphanumeric,
-      namePrefix = randomAlphanumeric
-    )
+    val azurePrefix = createAzureBlobLocationPrefix
 
     val s3Request = ReplicationRequest(
       srcPrefix = createS3ObjectLocationPrefix,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/models/ReplicationRequestTest.scala
@@ -12,9 +12,9 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   SecondaryS3ReplicaLocation
 }
 import uk.ac.wellcome.storage.azure.AzureBlobLocationPrefix
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
 
-class ReplicationRequestTest extends AnyFunSpec with Matchers with S3Fixtures {
+class ReplicationRequestTest extends AnyFunSpec with Matchers with S3ObjectLocationGenerators {
   describe("toReplicaLocation") {
     val s3Prefix = createS3ObjectLocationPrefix
     val azurePrefix = AzureBlobLocationPrefix(

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/fixtures/BagRootFinderFixtures.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/fixtures/BagRootFinderFixtures.scala
@@ -25,7 +25,7 @@ trait BagRootFinderFixtures
     queue: Queue,
     ingests: MemoryMessageSender,
     outgoing: MemoryMessageSender,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(testWith: TestWith[BagRootFinderWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
       val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/ApplyTagsTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/ApplyTagsTest.scala
@@ -38,11 +38,7 @@ class ApplyTagsTest
         )
 
         val s3Location = s3Prefix.asLocation(file.path)
-        s3Client.putObject(
-          s3Location.bucket,
-          s3Location.key,
-          randomAlphanumeric
-        )
+        putStream(s3Location)
 
         s3Tags.update(s3Location) { _ =>
           Right(Map("Content-SHA256" -> "4a5a41ebcf5e2c24c"))

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -31,7 +31,7 @@ trait BagUnpackerFixtures
     ingests: MemoryMessageSender,
     outgoing: MemoryMessageSender,
     dstBucket: Bucket,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(testWith: TestWith[BagUnpackerWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
       val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
@@ -92,7 +92,7 @@ class BagUnpackerWorkerTest
     withLocalS3Bucket { srcBucket =>
       val location = createS3ObjectLocationWith(srcBucket)
 
-      s3Client.putObject(location.bucket, location.key, "hello world")
+      putStream(location)
 
       val payload = createSourceLocationPayloadWith(location)
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerMessageTest.scala
@@ -6,16 +6,14 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.storage.providers.memory.{
-  MemoryLocation,
-  MemoryLocationPrefix
-}
+import uk.ac.wellcome.storage.generators.MemoryLocationGenerators
 
 import scala.util.Random
 
 class UnpackerMessageTest
     extends AnyFunSpec
     with Matchers
+    with MemoryLocationGenerators
     with StorageRandomThings {
   it("handles a single file correctly") {
     val summary = createSummaryWith(fileCount = 1)
@@ -47,14 +45,8 @@ class UnpackerMessageTest
   ): UnpackSummary[_, _] =
     UnpackSummary(
       ingestId = createIngestID,
-      srcLocation = MemoryLocation(
-        namespace = randomAlphanumeric,
-        path = randomAlphanumeric
-      ),
-      dstPrefix = MemoryLocationPrefix(
-        namespace = randomAlphanumeric,
-        path = randomAlphanumeric
-      ),
+      srcLocation = createMemoryLocation,
+      dstPrefix = createMemoryLocationPrefix,
       fileCount = fileCount,
       bytesUnpacked = bytesUnpacked,
       startTime = Instant.now()

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityCheckerTests.scala
@@ -19,6 +19,7 @@ import uk.ac.wellcome.platform.archive.common.verify.{
   MD5
 }
 import uk.ac.wellcome.storage._
+import uk.ac.wellcome.storage.generators.MemoryLocationGenerators
 import uk.ac.wellcome.storage.providers.memory.{
   MemoryLocation,
   MemoryLocationPrefix
@@ -33,15 +34,13 @@ class FixityCheckerTests
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with FixityGenerators[MemoryLocation] {
+    with FixityGenerators[MemoryLocation]
+    with MemoryLocationGenerators {
   override def resolve(location: MemoryLocation): URI =
     new URI(s"mem://$location")
 
   override def createLocation: MemoryLocation =
-    MemoryLocation(
-      namespace = randomAlphanumeric,
-      path = randomAlphanumeric
-    )
+    createMemoryLocation
 
   describe("handles errors correctly") {
     it("turns an error in locate() into a FileFixityCouldNotRead") {
@@ -133,10 +132,7 @@ class FixityCheckerTests
       val checksum =
         Checksum(MD5, ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6"))
 
-      val location = MemoryLocation(
-        namespace = randomAlphanumeric,
-        path = randomAlphanumeric
-      )
+      val location = createMemoryLocation
 
       val inputStream = stringCodec.toStream(contentString).right.value
       streamStore.put(location)(inputStream) shouldBe a[Right[_, _]]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/memory/MemoryFixityCheckerTest.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   FixityCheckerTagsTestCases
 }
 import uk.ac.wellcome.storage._
+import uk.ac.wellcome.storage.generators.MemoryLocationGenerators
 import uk.ac.wellcome.storage.providers.memory.{
   MemoryLocation,
   MemoryLocationPrefix
@@ -25,7 +26,8 @@ class MemoryFixityCheckerTest
       (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation]),
       MemoryStreamStore[MemoryLocation]
     ]
-    with EitherValues {
+    with EitherValues
+    with MemoryLocationGenerators {
   type MemoryContext =
     (MemoryStreamStore[MemoryLocation], MemoryTags[MemoryLocation])
 
@@ -82,10 +84,7 @@ class MemoryFixityCheckerTest
     testWith(randomAlphanumeric)
 
   override def createId(implicit namespace: String): MemoryLocation =
-    MemoryLocation(
-      namespace = namespace,
-      path = randomAlphanumeric
-    )
+    createMemoryLocation
 
   override def resolve(location: MemoryLocation): URI =
     new URI(s"mem://$location")

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -47,7 +47,7 @@ trait BagVerifierFixtures
     outgoing: MemoryMessageSender,
     queue: Queue = dummyQueue,
     bucket: Bucket,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(
     testWith: TestWith[BagVerifierWorker[
       S3ObjectLocation,
@@ -85,7 +85,7 @@ trait BagVerifierFixtures
     outgoing: MemoryMessageSender,
     queue: Queue = dummyQueue,
     bucket: Bucket,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(
     testWith: TestWith[BagVerifierWorker[
       S3ObjectLocation,
@@ -124,7 +124,7 @@ trait BagVerifierFixtures
     outgoing: MemoryMessageSender = new MemoryMessageSender(),
     queue: Queue = dummyQueue,
     bucket: Bucket,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(
     testWith: TestWith[BagVerifierWorker[
       AzureBlobLocation,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -221,7 +221,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
       ): Option[String] =
         super.createPayloadManifest(
           entries.tail :+ PayloadEntry(
-            bagPath = BagPath(randomAlphanumeric),
+            bagPath = createBagPath,
             path = randomAlphanumeric,
             contents = randomAlphanumeric
           )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -290,7 +290,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
   it("fails if the external identifier in the bag-info.txt is incorrect") {
     val space = createStorageSpace
-    val externalIdentifier = randomAlphanumeric
+    val externalIdentifier = createExternalIdentifier.underlying
     val bagInfoExternalIdentifier =
       ExternalIdentifier(externalIdentifier + "_bag-info")
     val payloadExternalIdentifier =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -328,7 +328,7 @@ class BagVerifierWorkerTest
     val ingests = new MemoryMessageSender()
     val outgoing = new MemoryMessageSender()
 
-    val externalIdentifier = randomAlphanumeric
+    val externalIdentifier = createExternalIdentifier.underlying
     val bagInfoExternalIdentifier =
       ExternalIdentifier(externalIdentifier + "_bag-info")
     val payloadExternalIdentifier =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/ReplicatedBagVerifierTestCases.scala
@@ -57,9 +57,9 @@ trait ReplicatedBagVerifierTestCases[
           case (primaryBucket, replicaBagRoot) =>
             val srcBagRoot =
               S3ObjectLocationPrefix(srcBucket.name, replicaBagRoot.pathPrefix)
-            S3TypedStore[String].put(
-              srcBagRoot.asLocation("tagmanifest-sha256.txt")
-            )(randomAlphanumeric)
+
+            putStream(srcBagRoot.asLocation("tagmanifest-sha256.txt"))
+
             val ingestStep =
               withVerifier(primaryBucket) {
                 _.verify(

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
@@ -29,7 +29,7 @@ trait BagVersionerFixtures
     queue: Queue = dummyQueue,
     ingests: MemoryMessageSender,
     outgoing: MemoryMessageSender,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   )(testWith: TestWith[BagVersionerWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
       val ingestUpdater = createIngestUpdaterWith(ingests, stepName = stepName)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagPath,
   MatchedLocation,
   PayloadManifest
 }
@@ -96,7 +95,7 @@ class BagMatcherTest
       )
 
       val fetchMetadata = createFetchMetadata
-      val fetchPath = BagPath(randomAlphanumeric)
+      val fetchPath = createBagPath
       val fetchChecksumValue = randomChecksumValue
 
       val checksumAlgorithm = randomHashingAlgorithm
@@ -134,7 +133,7 @@ class BagMatcherTest
 
   describe("error cases") {
     it("there's a fetch entry for a file that isn't in the bag") {
-      val fetchPath = BagPath(randomAlphanumeric)
+      val fetchPath = createBagPath
       val fetchEntries = Map(fetchPath -> createFetchMetadata)
 
       val result = BagMatcher.correlateFetchEntryToBagFile(
@@ -151,7 +150,7 @@ class BagMatcherTest
 
     it("there are multiple fetch entries for files that aren't in the bag") {
       val fetchEntries = (1 to 3).map { _ =>
-        BagPath(randomAlphanumeric) -> createFetchMetadata
+        createBagPath -> createFetchMetadata
       }.toMap
 
       val result = BagMatcher.correlateFetchEntryToBagFile(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublish
 trait OperationFixtures extends StorageRandomThings {
   def createIngestUpdaterWith(
     messageSender: MemoryMessageSender,
-    stepName: String = randomAlphanumericWithLength()
+    stepName: String = createStepName
   ) =
     new IngestUpdater[String](
       stepName = stepName,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -199,4 +199,7 @@ trait StorageRandomThings extends RandomThings {
     StorageProvider(
       id = chooseFrom(StorageProvider.allowedValues)
     )
+
+  def createStepName: String =
+    s"step-$randomAlphanumeric"
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -9,14 +9,12 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
-    with ReplicaLocationGenerators
-    with S3Fixtures {
+    with ReplicaLocationGenerators {
 
   def randomIngestType: IngestType =
     chooseFrom(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -2,9 +2,12 @@ package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.generators.{
+  AzureBlobLocationGenerators,
+  S3ObjectLocationGenerators
+}
 
-trait ReplicaLocationGenerators extends StorageRandomThings with S3ObjectLocationGenerators {
+trait ReplicaLocationGenerators extends StorageRandomThings with S3ObjectLocationGenerators with AzureBlobLocationGenerators {
   def createPrimaryLocation: PrimaryReplicaLocation =
     chooseFrom(
       Seq(
@@ -15,7 +18,8 @@ trait ReplicaLocationGenerators extends StorageRandomThings with S3ObjectLocatio
   def createSecondaryLocation: SecondaryReplicaLocation =
     chooseFrom(
       Seq(
-        SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix)
+        SecondaryS3ReplicaLocation(prefix = createS3ObjectLocationPrefix),
+        SecondaryAzureReplicaLocation(prefix = createAzureBlobLocationPrefix)
       )
     )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.storage.generators.{
   S3ObjectLocationGenerators
 }
 
-trait ReplicaLocationGenerators extends StorageRandomThings with S3ObjectLocationGenerators with AzureBlobLocationGenerators {
+trait ReplicaLocationGenerators
+    extends StorageRandomThings
+    with S3ObjectLocationGenerators
+    with AzureBlobLocationGenerators {
   def createPrimaryLocation: PrimaryReplicaLocation =
     chooseFrom(
       Seq(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/ReplicaLocationGenerators.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
 
-trait ReplicaLocationGenerators extends StorageRandomThings with S3Fixtures {
+trait ReplicaLocationGenerators extends StorageRandomThings with S3ObjectLocationGenerators {
   def createPrimaryLocation: PrimaryReplicaLocation =
     chooseFrom(
       Seq(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.storage.services.DestinationBuilder
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
-import uk.ac.wellcome.storage.azure.AzureBlobLocationPrefix
 
 import scala.util.Random
 
@@ -59,12 +58,7 @@ trait StorageManifestGenerators
         chooseFrom(
           Seq(
             SecondaryS3StorageLocation(createS3ObjectLocationPrefix),
-            SecondaryAzureStorageLocation(
-              AzureBlobLocationPrefix(
-                randomAlphanumeric,
-                randomAlphanumeric
-              )
-            )
+            SecondaryAzureStorageLocation(createAzureBlobLocationPrefix)
           )
         )
       },

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
@@ -20,7 +20,7 @@ class IngestUpdaterTest
     with IngestOperationGenerators
     with BagIdGenerators {
 
-  val stepName: String = randomAlphanumericWithLength()
+  val stepName: String = createStepName
 
   val ingestId: IngestID = createIngestID
   val summary: TestSummary = createTestSummary()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -27,10 +27,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class LargeResponsesTest
-    extends AnyFunSpec
-    with S3Fixtures
-    with Akka {
+class LargeResponsesTest extends AnyFunSpec with S3Fixtures with Akka {
 
   private val converter = StreamConverters.asInputStream()
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -20,7 +20,6 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.s3.S3ObjectLocationPrefix
 import uk.ac.wellcome.storage.services.s3.S3Uploader
 
@@ -31,7 +30,6 @@ import scala.concurrent.{Await, Future}
 class LargeResponsesTest
     extends AnyFunSpec
     with S3Fixtures
-    with RandomThings
     with Akka {
 
   private val converter = StreamConverters.asInputStream()

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -176,7 +176,9 @@ class DisplayIngestTest
     ),
     callback: Option[DisplayCallback] = None,
     ingestType: DisplayIngestType = CreateDisplayIngestType,
-    space: DisplayStorageSpace = DisplayStorageSpace(createStorageSpace.underlying)
+    space: DisplayStorageSpace = DisplayStorageSpace(
+      createStorageSpace.underlying
+    )
   ): RequestDisplayIngest =
     RequestDisplayIngest(
       sourceLocation = sourceLocation,

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/ingests/DisplayIngestTest.scala
@@ -171,12 +171,12 @@ class DisplayIngestTest
   def createRequestDisplayIngestWith(
     sourceLocation: DisplayLocation = DisplayLocation(
       provider = DisplayProvider(id = "aws-s3-ia"),
-      bucket = randomAlphanumeric,
+      bucket = createBucketName,
       path = randomAlphanumeric
     ),
     callback: Option[DisplayCallback] = None,
     ingestType: DisplayIngestType = CreateDisplayIngestType,
-    space: DisplayStorageSpace = DisplayStorageSpace(randomAlphanumeric)
+    space: DisplayStorageSpace = DisplayStorageSpace(createStorageSpace.underlying)
   ): RequestDisplayIngest =
     RequestDisplayIngest(
       sourceLocation = sourceLocation,

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
@@ -34,7 +34,7 @@ trait ReplicaAggregatorFixtures
       ),
     ingests: MemoryMessageSender = new MemoryMessageSender(),
     outgoing: MemoryMessageSender = new MemoryMessageSender(),
-    stepName: String = randomAlphanumericWithLength(),
+    stepName: String = createStepName,
     expectedReplicaCount: Int = 1
   )(testWith: TestWith[ReplicaAggregatorWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4827. This is PR 1 of 2 – this is a bunch of cleanups that aren't random-related, but make it easier to apply in the next PR.