### PR TITLE
Propagate deployment tags correctly

### DIFF
--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -41,14 +41,14 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.2.2"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
   name   = "app"
 
   image = var.api_container_image
@@ -59,7 +59,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,16 +1,16 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.2.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.2.2"
   namespace = var.service_name
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.2.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.2.2"
 
   cpu    = var.cpu
   memory = var.memory
@@ -23,7 +23,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.2.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.2.2"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
@@ -40,9 +40,10 @@ module "service" {
 
   target_group_arn = var.target_group_arn
 
+  propagate_tags = "SERVICE"
+
   deployment_service = var.deployment_service_name
   deployment_env     = var.deployment_service_env
-  deployment_label   = "initial"
 
   container_name = var.container_name
   container_port = var.container_port

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -69,7 +69,7 @@ module "external_api_container_secrets_permissions" {
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
   name   = "worker"
 
   image = var.worker_container_image
@@ -81,13 +81,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -99,7 +99,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }

--- a/terraform/stack_prod/provider.tf
+++ b/terraform/stack_prod/provider.tf
@@ -4,6 +4,11 @@ provider "aws" {
   }
 
   region  = var.aws_region
-  version = "2.51.0"
+  version = "2.60.0"
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -1,9 +1,13 @@
 provider "aws" {
   assume_role {
-    # TODO: Does this need to be the -admin role?  Could it be -developer?
-    role_arn = "arn:aws:iam::975596993436:role/storage-admin"
+    role_arn = "arn:aws:iam::975596993436:role/storage-developer"
   }
 
   region  = var.aws_region
-  version = "~> 2.0"
+  version = "2.60.0"
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }


### PR DESCRIPTION
This fixes an issue where not all services/tasks had tags as expected. This also prepares for https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/29 by ignoring the deployment label at the provider level.