### PR TITLE
If the bag tracker is unavailable, the bag register will retry the registration

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -38,6 +38,12 @@ class BagRegisterWorker[IngestDestination, NotificationDestination](
 ) extends IngestStepWorker[KnownReplicasPayload, RegistrationSummary] {
   implicit val ec: ExecutionContext = as.dispatcher
 
+  // The bag register can fail if the bag tracker isn't available.  Rather than
+  // retrying immediately, allow a short delay before retrying a registration.
+  //
+  // Registration isn't a time-critical process, so a delay is acceptable.
+  override val visibilityTimeout: Int = 120
+
   override def process(
     payload: KnownReplicasPayload
   ): Future[Result[RegistrationSummary]] =

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -71,7 +71,8 @@ class Register(
       result = completedRegistration match {
         case Right(()) => IngestCompleted(registration.complete)
 
-        case Left(createError: BagTrackerCreateError) if createError.isInstanceOf[RetryableError] =>
+        case Left(createError: BagTrackerCreateError)
+            if createError.isInstanceOf[RetryableError] =>
           warn(s"Retryable error updating storage manifest: ${createError.err}")
           IngestShouldRetry(registration, e = createError.err)
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -111,7 +111,9 @@ class RegisterTest
       val ingestId = createIngestID
 
       withActorSystem { implicit actorSystem =>
-        val bagTrackerClient = new AkkaBagTrackerClient(trackerHost = Uri("http://localhost:9000/doesnotexist"))
+        val bagTrackerClient = new AkkaBagTrackerClient(
+          trackerHost = Uri("http://localhost:9000/doesnotexist")
+        )
 
         val register = new Register(
           bagReader = new S3BagReader(),

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -1,10 +1,12 @@
 package uk.ac.wellcome.platform.archive.bag_register.services
 
+import akka.http.scaladsl.model.Uri
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
+import uk.ac.wellcome.platform.archive.bag_tracker.client.AkkaBagTrackerClient
 import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
@@ -91,6 +93,45 @@ class RegisterTest
               .copy(keyPrefix = prefix.keyPrefix.stripSuffix(s"/$version"))
           )
         }
+    }
+  }
+
+  it("allows retrying a bag if the bag tracker is temporarily unavailable") {
+    val space = createStorageSpace
+    val version = createBagVersion
+
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, bagInfo) = storeS3BagWith(
+        space = space,
+        version = version
+      )
+
+      val primaryLocation = PrimaryS3ReplicaLocation(bagRoot)
+
+      val ingestId = createIngestID
+
+      withActorSystem { implicit actorSystem =>
+        val bagTrackerClient = new AkkaBagTrackerClient(trackerHost = Uri("http://localhost:9000/doesnotexist"))
+
+        val register = new Register(
+          bagReader = new S3BagReader(),
+          bagTrackerClient = bagTrackerClient,
+          storageManifestService = new S3StorageManifestService()
+        )
+
+        val future = register.update(
+          ingestId = ingestId,
+          location = primaryLocation,
+          replicas = Seq.empty,
+          version = version,
+          space = space,
+          externalIdentifier = bagInfo.externalIdentifier
+        )
+
+        whenReady(future) {
+          _ shouldBe a[IngestShouldRetry[_]]
+        }
+      }
     }
   }
 }

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/AkkaTrackerClientBase.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/AkkaTrackerClientBase.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.platform.archive.bag_tracker.client
+
+import akka.stream.StreamTcpException
+
+trait AkkaTrackerClientBase {
+  def isRetryable(err: Throwable): Boolean =
+    err match {
+      // This error can occur if the tracker API is unavailable.  Tasks should wait
+      // and then retry the request, if possible.
+      // See https://github.com/wellcomecollection/platform/issues/4834
+      case _: StreamTcpException => true
+
+      case _ => false
+    }
+}

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClient.scala
@@ -80,11 +80,17 @@ class AkkaBagTrackerClient(trackerHost: Uri)(implicit actorSystem: ActorSystem)
     httpResult
       .recover {
         case err: Throwable if isRetryable(err) =>
-          error(s"Retryable error from POST to $requestUri with ${storageManifest.idWithVersion}", err)
+          error(
+            s"Retryable error from POST to $requestUri with ${storageManifest.idWithVersion}",
+            err
+          )
           Left(new BagTrackerCreateError(err) with RetryableError)
 
         case err: Throwable =>
-          error(s"Unknown error from POST to $requestUri with ${storageManifest.idWithVersion}", err)
+          error(
+            s"Unknown error from POST to $requestUri with ${storageManifest.idWithVersion}",
+            err
+          )
           Left(BagTrackerCreateError(err))
       }
   }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/AkkaBagTrackerClientTest.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/AkkaBagTrackerClientTest.scala
@@ -1,13 +1,8 @@
-package uk.ac.wellcome.platform.archive.bag_tracker
+package uk.ac.wellcome.platform.archive.bag_tracker.client
 
 import akka.http.scaladsl.model.Uri
 import org.scalatest.concurrent.IntegrationPatience
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.bag_tracker.client.{
-  AkkaBagTrackerClient,
-  BagTrackerClient,
-  BagTrackerClientTestCases
-}
 
 class AkkaBagTrackerClientTest
     extends BagTrackerClientTestCases


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4834

The default is still to fail bags with unrecognised errors, so they're visible and we know to investigate and fix them – but we've knocked over the bags API recently, and having the pipeline handle it gracefully is better than pretending it won't happen again.