### PR TITLE
Use latest ECS terraform module

### DIFF
--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -41,14 +41,14 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.3.0"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.3.0"
   name   = "app"
 
   image = var.api_container_image
@@ -59,7 +59,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.3.0"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,16 +1,16 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.2.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.3.0"
   namespace = var.service_name
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.3.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.3.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -23,7 +23,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.3.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
@@ -39,9 +39,7 @@ module "service" {
   use_fargate_spot   = var.use_fargate_spot
 
   target_group_arn = var.target_group_arn
-
-  propagate_tags = "SERVICE"
-
+  
   deployment_service = var.deployment_service_name
   deployment_env     = var.deployment_service_env
 

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -39,7 +39,7 @@ module "service" {
   use_fargate_spot   = var.use_fargate_spot
 
   target_group_arn = var.target_group_arn
-  
+
   deployment_service = var.deployment_service_name
   deployment_env     = var.deployment_service_env
 

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -69,7 +69,7 @@ module "external_api_container_secrets_permissions" {
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.3.0"
   name   = "worker"
 
   image = var.worker_container_image
@@ -81,13 +81,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.3.0"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.3.0"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -99,7 +99,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.3.0"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }


### PR DESCRIPTION
Keep in sync with latest - removes need to specify propagate tags.

Note: this terraform is applied.