### PR TITLE
Retry on lock failure in bag_versioner

### DIFF
--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.storage.bag_versioner.services
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestID,
+  IngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.storage.bag_versioner.models._
 import uk.ac.wellcome.platform.storage.bag_versioner.versioning._
@@ -43,7 +46,7 @@ class BagVersioner(versionPicker: VersionPicker) {
             maybeUserFacingMessage = Some(s"Assigned bag version $version")
           )
 
-        case Left(error@UnableToAssignVersion(internalError)) =>
+        case Left(error @ UnableToAssignVersion(internalError)) =>
           IngestFailed(
             BagVersionerFailureSummary(
               ingestId = ingestId,
@@ -67,9 +70,11 @@ class BagVersioner(versionPicker: VersionPicker) {
       }
     }
 
-  private def getUnderlyingThrowable(error: IngestVersionManagerError): Throwable =
+  private def getUnderlyingThrowable(
+    error: IngestVersionManagerError
+  ): Throwable =
     error match {
       case err: IngestVersionManagerDaoError => err.e
-      case err => new Throwable(s"Unexpected error in the bag versioner: $err")
+      case err                               => new Throwable(s"Unexpected error in the bag versioner: $err")
     }
 }

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
@@ -3,23 +3,10 @@ package uk.ac.wellcome.platform.storage.bag_versioner.services
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  IngestID,
-  IngestType
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepResult,
-  IngestStepSucceeded,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.storage.bag_versioner.models._
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
-  IngestVersionManagerDaoError,
-  UnableToAssignVersion,
-  VersionPicker,
-  VersionPickerError
-}
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning._
 
 import scala.util.Try
 
@@ -56,24 +43,33 @@ class BagVersioner(versionPicker: VersionPicker) {
             maybeUserFacingMessage = Some(s"Assigned bag version $version")
           )
 
-        case Left(error) =>
+        case Left(error@UnableToAssignVersion(internalError)) =>
           IngestFailed(
             BagVersionerFailureSummary(
               ingestId = ingestId,
               startTime = startTime,
               endTime = Instant.now()
             ),
-            e = getUnderlyingThrowable(error),
+            e = getUnderlyingThrowable(internalError),
             maybeUserFacingMessage =
               UserFacingMessages.createMessage(ingestId, error)
+          )
+
+        case Left(error: FailedToGetLock) =>
+          IngestShouldRetry(
+            BagVersionerFailureSummary(
+              ingestId = ingestId,
+              startTime = startTime,
+              endTime = Instant.now()
+            ),
+            e = new Throwable(s"Failed to get lock: ${error.failedLock}")
           )
       }
     }
 
-  private def getUnderlyingThrowable(error: VersionPickerError): Throwable =
+  private def getUnderlyingThrowable(error: IngestVersionManagerError): Throwable =
     error match {
-      case UnableToAssignVersion(internalError: IngestVersionManagerDaoError) =>
-        internalError.e
+      case err: IngestVersionManagerDaoError => err.e
       case err => new Throwable(s"Unexpected error in the bag versioner: $err")
     }
 }

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
@@ -4,17 +4,10 @@ import java.time.Instant
 import java.util.UUID
 
 import cats.{Id, Monad, MonadError}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagId,
-  BagVersion,
-  ExternalIdentifier
-}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  IngestID,
-  IngestType
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, IngestType}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.locking.{FailedProcess, LockDao, LockingService}
+import uk.ac.wellcome.storage.locking.{FailedLockingServiceOp, LockDao, LockingService}
 
 class VersionPicker(
   lockingService: LockingService[
@@ -58,9 +51,8 @@ class VersionPicker(
       case Right(Left(ingestVersionManagerError)) =>
         Left(UnableToAssignVersion(ingestVersionManagerError))
 
-      case Left(FailedProcess(_, err)) => Left(InternalVersionPickerError(err))
-      case Left(err) =>
-        Left(InternalVersionPickerError(new Throwable(s"Locking error: $err")))
+      case Left(err: FailedLockingServiceOp) =>
+        Left(FailedToGetLock(err))
     }
   }
 

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
@@ -4,10 +4,21 @@ import java.time.Instant
 import java.util.UUID
 
 import cats.{Id, Monad, MonadError}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestID,
+  IngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.locking.{FailedLockingServiceOp, LockDao, LockingService}
+import uk.ac.wellcome.storage.locking.{
+  FailedLockingServiceOp,
+  LockDao,
+  LockingService
+}
 
 class VersionPicker(
   lockingService: LockingService[

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
+import uk.ac.wellcome.storage.locking.FailedLockingServiceOp
+
 sealed trait VersionPickerError
 
-case class InternalVersionPickerError(e: Throwable) extends VersionPickerError
+case class FailedToGetLock(failedLock: FailedLockingServiceOp)
+  extends VersionPickerError
 
-case class UnableToAssignVersion(e: IngestVersionManagerError)
-    extends VersionPickerError
+case class UnableToAssignVersion(ingestVersionManagerError: IngestVersionManagerError)
+  extends VersionPickerError

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
@@ -5,7 +5,8 @@ import uk.ac.wellcome.storage.locking.FailedLockingServiceOp
 sealed trait VersionPickerError
 
 case class FailedToGetLock(failedLock: FailedLockingServiceOp)
-  extends VersionPickerError
+    extends VersionPickerError
 
-case class UnableToAssignVersion(ingestVersionManagerError: IngestVersionManagerError)
-  extends VersionPickerError
+case class UnableToAssignVersion(
+  ingestVersionManagerError: IngestVersionManagerError
+) extends VersionPickerError

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.storage.bag_versioner.services.{BagVersioner, BagVersionerWorker}
+import uk.ac.wellcome.platform.storage.bag_versioner.services.{
+  BagVersioner,
+  BagVersionerWorker
+}
 import uk.ac.wellcome.storage.locking.LockDao
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -20,7 +23,9 @@ trait BagVersionerFixtures
     with AlpakkaSQSWorkerFixtures
     with VersionPickerFixtures {
 
-  def withBagVersioner[R](dao: LockDao[String, UUID])(testWith: TestWith[BagVersioner, R]): R =
+  def withBagVersioner[R](
+    dao: LockDao[String, UUID]
+  )(testWith: TestWith[BagVersioner, R]): R =
     withVersionPicker(dao) { versionPicker =>
       testWith(new BagVersioner(versionPicker))
     }

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/BagVersionerFixtures.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.storage.bag_versioner.fixtures
 
+import java.util.UUID
+
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
@@ -7,10 +9,8 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.storage.bag_versioner.services.{
-  BagVersioner,
-  BagVersionerWorker
-}
+import uk.ac.wellcome.platform.storage.bag_versioner.services.{BagVersioner, BagVersionerWorker}
+import uk.ac.wellcome.storage.locking.LockDao
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -19,6 +19,11 @@ trait BagVersionerFixtures
     with Akka
     with AlpakkaSQSWorkerFixtures
     with VersionPickerFixtures {
+
+  def withBagVersioner[R](dao: LockDao[String, UUID])(testWith: TestWith[BagVersioner, R]): R =
+    withVersionPicker(dao) { versionPicker =>
+      testWith(new BagVersioner(versionPicker))
+    }
 
   def withBagVersioner[R](testWith: TestWith[BagVersioner, R]): R =
     withVersionPicker { versionPicker =>

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
@@ -6,14 +6,22 @@ import cats.Id
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory.MemoryIngestVersionManager
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
-  IngestVersionManagerError,
-  VersionPicker
-}
-import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{IngestVersionManagerError, VersionPicker}
+import uk.ac.wellcome.storage.locking.{LockDao, LockFailure, LockingService, UnlockFailure}
 import uk.ac.wellcome.storage.locking.memory.MemoryLockDao
 
 trait VersionPickerFixtures {
+
+  def createBrokenLockDao: LockDao[String, UUID] = new LockDao[String, UUID] {
+      override def lock(id: String, contextId: UUID): LockResult = Left(
+        LockFailure(id, new Throwable("BOOM!"))
+      )
+
+      override def unlock(contextId: UUID): UnlockResult = Left(
+        UnlockFailure(contextId, new Throwable("BOOM!"))
+      )
+    }
+
   def createLockDao: MemoryLockDao[String, UUID] =
     new MemoryLockDao[String, UUID] {}
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
@@ -6,21 +6,29 @@ import cats.Id
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory.MemoryIngestVersionManager
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{IngestVersionManagerError, VersionPicker}
-import uk.ac.wellcome.storage.locking.{LockDao, LockFailure, LockingService, UnlockFailure}
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
+  IngestVersionManagerError,
+  VersionPicker
+}
+import uk.ac.wellcome.storage.locking.{
+  LockDao,
+  LockFailure,
+  LockingService,
+  UnlockFailure
+}
 import uk.ac.wellcome.storage.locking.memory.MemoryLockDao
 
 trait VersionPickerFixtures {
 
   def createBrokenLockDao: LockDao[String, UUID] = new LockDao[String, UUID] {
-      override def lock(id: String, contextId: UUID): LockResult = Left(
-        LockFailure(id, new Throwable("BOOM!"))
-      )
+    override def lock(id: String, contextId: UUID): LockResult = Left(
+      LockFailure(id, new Throwable("BOOM!"))
+    )
 
-      override def unlock(contextId: UUID): UnlockResult = Left(
-        UnlockFailure(contextId, new Throwable("BOOM!"))
-      )
-    }
+    override def unlock(contextId: UUID): UnlockResult = Left(
+      UnlockFailure(contextId, new Throwable("BOOM!"))
+    )
+  }
 
   def createLockDao: MemoryLockDao[String, UUID] =
     new MemoryLockDao[String, UUID] {}

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
@@ -6,11 +6,23 @@ import org.scalatest.TryValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, StorageSpaceGenerators}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, UpdateIngestType}
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestShouldRetry}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  StorageSpaceGenerators
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  UpdateIngestType
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestShouldRetry
+}
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.BagVersionerFixtures
-import uk.ac.wellcome.platform.storage.bag_versioner.models.{BagVersionerFailureSummary, BagVersionerSuccessSummary}
+import uk.ac.wellcome.platform.storage.bag_versioner.models.{
+  BagVersionerFailureSummary,
+  BagVersionerSuccessSummary
+}
 
 class BagVersionerTest
     extends AnyFunSpec

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
@@ -5,9 +5,18 @@ import java.time.Instant
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, StorageSpaceGenerators}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, UpdateIngestType}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  StorageSpaceGenerators
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  UpdateIngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.VersionPickerFixtures
 
@@ -161,7 +170,8 @@ class VersionPickerTest
 
         result.left.value shouldBe a[UnableToAssignVersion]
 
-        val err: UnableToAssignVersion = result.left.value.asInstanceOf[UnableToAssignVersion]
+        val err: UnableToAssignVersion =
+          result.left.value.asInstanceOf[UnableToAssignVersion]
         err.ingestVersionManagerError shouldBe a[NewerIngestAlreadyExists]
       }
     }


### PR DESCRIPTION
A failure to get a lock when setting a version should be retryable.

We have seen this issue when runnning https://github.com/wellcomecollection/storage-service/pull/762.