### PR TITLE
Expire non-current versions in our permanent storage buckets

### DIFF
--- a/terraform/modules/critical/s3_replica_glacier.tf
+++ b/terraform/modules/critical/s3_replica_glacier.tf
@@ -16,6 +16,25 @@ resource "aws_s3_bucket" "replica_glacier" {
     }
   }
 
+  lifecycle_rule {
+    id      = "expire_noncurrent_versions"
+    enabled = var.enable_s3_versioning
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 90
+    }
+  }
+
   tags = var.tags
 }
 

--- a/terraform/modules/critical/s3_replica_glacier.tf
+++ b/terraform/modules/critical/s3_replica_glacier.tf
@@ -16,6 +16,13 @@ resource "aws_s3_bucket" "replica_glacier" {
     }
   }
 
+  # In general, these permanent storage buckets should follow
+  # Write-Once, Read-Many (WORM).
+  #
+  # It's extremely unusual for us to delete objects.  Enabling versioning gives
+  # us a safety net against accidental deletions -- if we delete something, we can
+  # recover it -- but we do want deleted objects to disappear eventually,
+  # e.g. for data protection.
   lifecycle_rule {
     id      = "expire_noncurrent_versions"
     enabled = var.enable_s3_versioning

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -30,6 +30,13 @@ resource "aws_s3_bucket" "replica_primary" {
     }
   }
 
+  # In general, these permanent storage buckets should follow
+  # Write-Once, Read-Many (WORM).
+  #
+  # It's extremely unusual for us to delete objects.  Enabling versioning gives
+  # us a safety net against accidental deletions -- if we delete something, we can
+  # recover it -- but we do want deleted objects to disappear eventually,
+  # e.g. for data protection.
   lifecycle_rule {
     id      = "expire_noncurrent_versions"
     enabled = var.enable_s3_versioning

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -30,6 +30,25 @@ resource "aws_s3_bucket" "replica_primary" {
     }
   }
 
+  lifecycle_rule {
+    id      = "expire_noncurrent_versions"
+    enabled = var.enable_s3_versioning
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 90
+    }
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
Although we have versioning enabled, we never actually delete the old versions once they're gone!

I've applied this in staging and it looks fine (although we don't actually enable versioning on the staging buckets); I'll apply in prod once this has been reviewed.