### PR TITLE
Remove some unused packager settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ def setupProject(
   project
     .in(new File(folder))
     .settings(Common.settings: _*)
-    .settings(DockerCompose.settings: _*)
     .enablePlugins(DockerComposePlugin)
     .enablePlugins(JavaAppPackaging)
     .dependsOn(dependsOn: _*)

--- a/project/Packager.scala
+++ b/project/Packager.scala
@@ -1,9 +1,0 @@
-import sbt._
-
-import com.tapad.docker.DockerComposePlugin.autoImport._
-
-object DockerCompose {
-  val settings: Seq[Def.Setting[_]] = Seq(
-    composeNoBuild := true
-  )
-}


### PR DESCRIPTION
Currently these are dropping warnings in CI:

    there are 21 keys that are not used by any other settings/tasks:[0J

    * bag_indexer / composeNoBuild[0J
    +- /var/lib/buildkite-agent/builds/buildkite-elasticstack-i-07028dbe4122c20cd-1/wellcomecollection/storage-service/project/Packager.scala:7[0J