### PR TITLE
Retry not-found errors in the bag indexer

### DIFF
--- a/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagIndexerWorker.scala
+++ b/indexer/bag_indexer/src/main/scala/uk/ac/wellcome/platform/archive/indexer/bags/BagIndexerWorker.scala
@@ -74,7 +74,8 @@ class BagIndexerWorker(
         // issue, allow retrying the bag in a few minutes.
         // See https://github.com/wellcomecollection/platform/issues/4873
         case Left(BagTrackerNotFoundError()) =>
-          val message = s"Bag indexer asked to index $notification, but the bag tracker doesn't know about that"
+          val message =
+            s"Bag indexer asked to index $notification, but the bag tracker doesn't know about that"
           warn(message)
           Left(
             RetryableIndexingError(

--- a/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/BagIndexerWorkerTest.scala
+++ b/indexer/bag_indexer/src/test/scala/uk/ac/wellcome/platform/archive/indexer/bag/BagIndexerWorkerTest.scala
@@ -5,10 +5,7 @@ import io.circe.Decoder
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.messaging.worker.models.{
-  DeterministicFailure,
-  NonDeterministicFailure
-}
+import uk.ac.wellcome.messaging.worker.models.NonDeterministicFailure
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
@@ -124,15 +121,13 @@ class BagIndexerWorkerTest
     }
   }
 
-  it(
-    "fails with a DeterministicFailure when a DoesNotExistError is encountered"
-  ) {
+  it("fails with a NonDeterministicFailure if a bag doesn't exist") {
     val (t, _) = createT
     withLocalElasticsearchIndex(mapping) { index =>
       withLocalSqsQueue() { queue =>
         withDoesNotExistErrorIndexerWorker(index, queue) { worker =>
           whenReady(worker.process(t)) {
-            _ shouldBe a[DeterministicFailure[_]]
+            _ shouldBe a[NonDeterministicFailure[_]]
           }
         }
       }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4873

It turns out the file finder/indexer already retries these errors.