### PR TITLE
Bump scala-libs version to latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  lazy val defaultVersion = "24.1.0"
+  lazy val defaultVersion = "24.3.1"
 
   lazy val versions = new {
     val fixtures = defaultVersion


### PR DESCRIPTION
In order to incorporate changes allowing consistent-read from dynamo stores, (that switch will be added in an incoming PR).