### PR TITLE
Implement reindexing consistency and retry

### DIFF
--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
@@ -29,6 +29,9 @@ class DynamoStorageManifestDao(
   s3Client: AmazonS3
 ) extends StorageManifestDao {
 
+  //  By default reads are eventually consistent
+  //  See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
+  //  The StronglyConsistent mode ensures that we always read the most recent data
   implicit val consistencyMode: ConsistencyMode =
     StronglyConsistent
 

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
@@ -11,17 +11,9 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, DynamoHashRangeEntry}
-import uk.ac.wellcome.storage.s3.{
-  S3Config,
-  S3ObjectLocation,
-  S3ObjectLocationPrefix
-}
+import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.VersionedStore
-import uk.ac.wellcome.storage.store.dynamo.{
-  DynamoHashRangeStore,
-  DynamoHybridStoreWithMaxima,
-  DynamoVersionedHybridStore
-}
+import uk.ac.wellcome.storage.store.dynamo.{ConsistencyMode, DynamoHashRangeStore, DynamoHybridStoreWithMaxima, DynamoVersionedHybridStore, StronglyConsistent}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.{ReadError, StoreReadError}
@@ -36,6 +28,9 @@ class DynamoStorageManifestDao(
   dynamoClient: AmazonDynamoDB,
   s3Client: AmazonS3
 ) extends StorageManifestDao {
+
+  implicit val consistencyMode: ConsistencyMode =
+    StronglyConsistent
 
   implicit val indexedStore
     : DynamoHashRangeStore[BagId, Int, S3ObjectLocation] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  lazy val defaultVersion = "24.3.1"
+  lazy val defaultVersion = "24.4.0"
 
   lazy val versions = new {
     val fixtures = defaultVersion


### PR DESCRIPTION
These changes were proposed to fix an issue indexing bags that is [likely to be something else](https://github.com/wellcomecollection/storage-service/pull/791). 

They're still a good idea though. 

This change:

- Makes the bag tracker use strongly consistent reads so we can be sure that we never report a bag in an incorrect state
- Makes the bag indexer retry on a non-zero delay if something goes wrong (a zero length delay is unhelpful if a dependent service is temporarily unavailable).