### PR TITLE
Support spaces, and only spaces, in the external identifier

### DIFF
--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -16,9 +16,9 @@ import uk.ac.wellcome.platform.archive.bag_tracker.services.{
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
-  BagVersion,
-  ExternalIdentifier
+  BagVersion
 }
+import uk.ac.wellcome.platform.archive.common.http.LookupExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
   StorageSpace
@@ -38,7 +38,8 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
     with CreateBag
     with GetBag
     with GetLatestBag
-    with LookupBagVersions {
+    with LookupBagVersions
+    with LookupExternalIdentifier {
   implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
 
   // Note: there are points where this API could fail if passed invalid data,
@@ -72,7 +73,7 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
             (space, externalIdentifier) =>
               val bagId = BagId(
                 space = StorageSpace(space),
-                externalIdentifier = ExternalIdentifier(externalIdentifier)
+                externalIdentifier = decodeExternalIdentifier(externalIdentifier)
               )
 
               get {
@@ -90,7 +91,7 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
             (space, externalIdentifier) =>
               val bagId = BagId(
                 space = StorageSpace(space),
-                externalIdentifier = ExternalIdentifier(externalIdentifier)
+                externalIdentifier = decodeExternalIdentifier(externalIdentifier)
               )
 
               parameter('version.as[Int] ?) {

--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/BagTrackerApi.scala
@@ -14,10 +14,7 @@ import uk.ac.wellcome.platform.archive.bag_tracker.services.{
   LookupBagVersions
 }
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.StorageManifestDao
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagId,
-  BagVersion
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.http.LookupExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageManifest,
@@ -73,7 +70,8 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
             (space, externalIdentifier) =>
               val bagId = BagId(
                 space = StorageSpace(space),
-                externalIdentifier = decodeExternalIdentifier(externalIdentifier)
+                externalIdentifier =
+                  decodeExternalIdentifier(externalIdentifier)
               )
 
               get {
@@ -91,7 +89,8 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
             (space, externalIdentifier) =>
               val bagId = BagId(
                 space = StorageSpace(space),
-                externalIdentifier = decodeExternalIdentifier(externalIdentifier)
+                externalIdentifier =
+                  decodeExternalIdentifier(externalIdentifier)
               )
 
               parameter('version.as[Int] ?) {

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.bag_tracker.client
 
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bag_tracker.BagTrackerApi
 import uk.ac.wellcome.platform.archive.bag_tracker.fixtures.BagTrackerFixtures
@@ -45,3 +46,13 @@ trait BagTrackerClientTestCases
     with GetBagTestCases
     with GetLatestBagTestCases
     with ListVersionsTestCases
+    with TableDrivenPropertyChecks {
+  val unusualIdentifiers: TableFor1[String] = Table(
+    "externalIdentifier",
+    "miro images",
+    "miro+images",
+    "miro%20images",
+    "miro/A images",
+    "alfa/bravo"
+  )
+}

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/BagTrackerClientTestCases.scala
@@ -47,12 +47,11 @@ trait BagTrackerClientTestCases
     with GetLatestBagTestCases
     with ListVersionsTestCases
     with TableDrivenPropertyChecks {
+
   val unusualIdentifiers: TableFor1[String] = Table(
     "externalIdentifier",
+    "alfa/bravo",
     "miro images",
-    "miro+images",
-    "miro%20images",
-    "miro/A images",
-    "alfa/bravo"
+    "miro/A images"
   )
 }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
@@ -66,7 +66,9 @@ trait GetBagTestCases
 
         withApi(initialManifests = Seq(manifest)) { _ =>
           withClient(trackerHost) { client =>
-            whenReady(client.getBag(bagId = manifest.id, version = manifest.version)) {
+            whenReady(
+              client.getBag(bagId = manifest.id, version = manifest.version)
+            ) {
               _.right.value shouldBe manifest
             }
           }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
@@ -26,6 +26,8 @@ trait GetBagTestCases
     with BagTrackerClientTestBase
     with StorageManifestGenerators
     with TableDrivenPropertyChecks {
+  val unusualIdentifiers: TableFor1[String]
+
   describe("getBag") {
     it("finds the correct version of a bag") {
       val space = createStorageSpace
@@ -54,15 +56,8 @@ trait GetBagTestCases
       }
     }
 
-    val spaceEncodedIdentifiers = Table(
-      "externalIdentifier",
-      "miro images",
-      "miro+images",
-      "miro%20images"
-    )
-
-    it("finds a bag with spaces in the identifier") {
-      forAll(spaceEncodedIdentifiers) { identifier =>
+    it("finds a bag with unusual identifiers") {
+      forAll(unusualIdentifiers) { identifier =>
         val manifest = createStorageManifestWith(
           bagInfo = createBagInfoWith(
             externalIdentifier = ExternalIdentifier(identifier)

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
@@ -4,7 +4,11 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   StorageManifestGenerators
@@ -43,6 +47,26 @@ trait GetBagTestCases
 
           whenReady(future) {
             _.right.value shouldBe manifests(4)
+          }
+        }
+      }
+    }
+
+    it("finds a bag with spaces in the identifier") {
+      val space = createStorageSpace
+      val externalIdentifier = ExternalIdentifier("miro images")
+
+      val manifest = createStorageManifestWith(
+        space = space,
+        bagInfo = createBagInfoWith(externalIdentifier = externalIdentifier)
+      )
+
+      withApi(initialManifests = Seq(manifest)) { _ =>
+        withClient(trackerHost) { client =>
+          val future = client.getBag(bagId = manifest.id, version = manifest.version)
+
+          whenReady(future) {
+            _.right.value shouldBe manifest
           }
         }
       }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
 import uk.ac.wellcome.platform.archive.bag_tracker.storage.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
@@ -26,6 +26,8 @@ trait GetLatestBagTestCases
     with BagTrackerClientTestBase
     with StorageManifestGenerators
     with TableDrivenPropertyChecks {
+
+  val unusualIdentifiers: TableFor1[String]
 
   describe("getLatestBag()") {
     it("finds the latest version of a bag") {
@@ -53,15 +55,8 @@ trait GetLatestBagTestCases
       }
     }
 
-    val spaceEncodedIdentifiers = Table(
-      "externalIdentifier",
-      "miro images",
-      "miro+images",
-      "miro%20images"
-    )
-
     it("finds a bag with spaces in the identifier") {
-      forAll(spaceEncodedIdentifiers) { identifier =>
+      forAll(unusualIdentifiers) { identifier =>
         val manifest = createStorageManifestWith(
           bagInfo = createBagInfoWith(
             externalIdentifier = ExternalIdentifier(identifier)

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.bag_tracker.client
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
 import uk.ac.wellcome.platform.archive.bag_tracker.models.{
   BagVersionEntry,
   BagVersionList
@@ -30,6 +30,8 @@ trait ListVersionsTestCases
     with BagIdGenerators
     with StorageManifestGenerators
     with TableDrivenPropertyChecks {
+  val unusualIdentifiers: TableFor1[String]
+
   describe("listVersionsOf") {
     it("finds a single version of a bag") {
       val manifest = createStorageManifest
@@ -130,15 +132,8 @@ trait ListVersionsTestCases
       }
     }
 
-    val spaceEncodedIdentifiers = Table(
-      "externalIdentifier",
-      "miro images",
-      "miro+images",
-      "miro%20images"
-    )
-
     it("lists versions of a bag with spaces in the identifier") {
-      forAll(spaceEncodedIdentifiers) { identifier =>
+      forAll(unusualIdentifiers) { identifier =>
         val manifest = createStorageManifestWith(
           bagInfo = createBagInfoWith(
             externalIdentifier = ExternalIdentifier(identifier)

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
@@ -152,7 +152,9 @@ trait ListVersionsTestCases
 
         withApi(initialManifests = Seq(manifest)) { _ =>
           withClient(trackerHost) { client =>
-            whenReady(client.listVersionsOf(bagId = manifest.id, maybeBefore = None)) {
+            whenReady(
+              client.listVersionsOf(bagId = manifest.id, maybeBefore = None)
+            ) {
               _.right.value shouldBe expectedList
             }
           }

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
@@ -203,32 +203,6 @@ class VersionPickerTest
     }
   }
 
-  it("escape the lock names") {
-    val lockDao = createLockDao
-
-    withVersionPicker(lockDao) { picker =>
-      val ingestId = createIngestID
-      val externalIdentifier = ExternalIdentifier("x:y")
-      val storageSpace = StorageSpace("a:b")
-
-      picker.chooseVersion(
-        externalIdentifier = externalIdentifier,
-        ingestId = ingestId,
-        ingestType = CreateIngestType,
-        ingestDate = Instant.now(),
-        storageSpace = storageSpace
-      )
-
-      lockDao.getCurrentLocks shouldBe empty
-    // TODO: Restore history on the MemoryLockDao
-    // TODO: Why?
-//      lockDao.history.map { _.id } should contain theSameElementsAs List(
-//        s"ingest:$ingestId",
-//        s"external:a%3Ab:x%3Ay"
-//      )
-    }
-  }
-
   it("fails with FailedToGetLock if there is a LockFailure") {
     val lockDao = createBrokenLockDao
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
@@ -5,10 +5,7 @@ import java.time.Instant
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.{
   ExternalIdentifierGenerators,
   StorageSpaceGenerators
@@ -17,7 +14,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   CreateIngestType,
   UpdateIngestType
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.VersionPickerFixtures
 
 class VersionPickerTest

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecordTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecordTest.scala
@@ -19,14 +19,6 @@ class DynamoVersionRecordTest
     DynamoVersionRecord(versionRecord).toVersionRecord shouldBe versionRecord
   }
 
-  it("handles a VersionRecord with a colon in the externalIdentifier") {
-    val versionRecord = createVersionRecordWith(
-      externalIdentifier = ExternalIdentifier("x:y")
-    )
-
-    DynamoVersionRecord(versionRecord).toVersionRecord shouldBe versionRecord
-  }
-
   it("handles a VersionRecord with a colon in the storageSpace") {
     val versionRecord = createVersionRecordWith(
       storageSpace = StorageSpace("x:y")
@@ -37,10 +29,10 @@ class DynamoVersionRecordTest
 
   it("creates human-readable IDs") {
     val versionRecord = createVersionRecordWith(
-      externalIdentifier = ExternalIdentifier("x:y"),
+      externalIdentifier = ExternalIdentifier("x/c d"),
       storageSpace = StorageSpace("a:b")
     )
 
-    DynamoVersionRecord(versionRecord).id shouldBe BagId("a:b/x:y")
+    DynamoVersionRecord(versionRecord).id shouldBe BagId("a:b/x/c d")
   }
 }

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -1,8 +1,5 @@
 package uk.ac.wellcome.platform.storage.bags.api
 
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
-
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
@@ -11,6 +8,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
   ExternalIdentifier
 }
+import uk.ac.wellcome.platform.archive.common.http.LookupExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.LargeResponses
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bags.api.responses.{
@@ -21,7 +19,12 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 import scala.concurrent.duration._
 
-trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
+trait BagsApi
+  extends LargeResponses
+    with LookupBag
+    with LookupBagVersions
+    with LookupExternalIdentifier {
+
   private val routes: Route = pathPrefix("bags") {
     concat(
       // We look for /versions at the end of the path: this means we should
@@ -104,25 +107,6 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
         }
       }
     )
-  }
-
-  private def decodeExternalIdentifier(
-    remaining: String
-  ): ExternalIdentifier = {
-    // Sometimes we have an external identifier with slashes.
-    // For maximum flexibility, we want to support both URL-encoded
-    // and complete path versions.
-    //
-    // For example, if the external identifier is "alfa/bravo",
-    // you could look up both of:
-    //
-    //    /bags/space-id/alfa/bravo
-    //    /bags/space-id/alfa%2Fbravo
-    //
-    val underlying =
-      URLDecoder.decode(remaining, StandardCharsets.UTF_8.toString)
-
-    ExternalIdentifier(underlying)
   }
 
   val bags: Route = wrapLargeResponses(routes)

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import scala.concurrent.duration._
 
 trait BagsApi
-  extends LargeResponses
+    extends LargeResponses
     with LookupBag
     with LookupBagVersions
     with LookupExternalIdentifier {

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -241,27 +241,46 @@ class LookupBagApiTest
       ("manifest", "path"),
       // when the identifier is URL encoded
       (manifestWithSlash, s"${manifestWithSlash.space}/alfa%2Fbravo"),
-      (manifestWithSlash, s"${manifestWithSlash.space}/alfa%2Fbravo?version=${manifestWithSlash.version}"),
+      (
+        manifestWithSlash,
+        s"${manifestWithSlash.space}/alfa%2Fbravo?version=${manifestWithSlash.version}"
+      ),
       // when the identifier is not URL encoded
       (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo"),
-      (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo?version=${manifestWithSlash.version}"),
+      (
+        manifestWithSlash,
+        s"${manifestWithSlash.space}/alfa/bravo?version=${manifestWithSlash.version}"
+      ),
       // when the identifier has a space
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images?version=${manifestWithSlashAndSpace.version}"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images?version=${manifestWithSlashAndSpace.version}"),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro/A%20images"
+      ),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro/A%20images?version=${manifestWithSlashAndSpace.version}"
+      ),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro%2FA%20images"
+      ),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro%2FA%20images?version=${manifestWithSlashAndSpace.version}"
+      )
     )
 
-    forAll(lookupPaths) { case (manifest, path) =>
-      withConfiguredApp(initialManifests = Seq(manifest)) {
-        case (_, _, baseUrl) =>
-          whenGetRequestReady(s"$baseUrl/bags/$path") { response =>
-            response.status shouldBe StatusCodes.OK
+    forAll(lookupPaths) {
+      case (manifest, path) =>
+        withConfiguredApp(initialManifests = Seq(manifest)) {
+          case (_, _, baseUrl) =>
+            whenGetRequestReady(s"$baseUrl/bags/$path") { response =>
+              response.status shouldBe StatusCodes.OK
 
-            withStringEntity(response.entity) {
-              assertJsonMatches(_, manifest)
+              withStringEntity(response.entity) {
+                assertJsonMatches(_, manifest)
+              }
             }
-          }
         }
     }
   }

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -248,12 +248,8 @@ class LookupBagApiTest
       // when the identifier has a space
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images"),
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images?version=${manifestWithSlashAndSpace.version}"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A images"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A images?version=${manifestWithSlashAndSpace.version}"),
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images"),
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images?version=${manifestWithSlashAndSpace.version}"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA images"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA images?version=${manifestWithSlashAndSpace.version}"),
     )
 
     forAll(lookupPaths) { case (manifest, path) =>

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
@@ -212,24 +212,31 @@ class LookupBagVersionsApiTest
       // when the identifier is not URL encoded
       (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo/versions"),
       // when the identifier has s apce
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images/versions"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images/versions"),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro/A%20images/versions"
+      ),
+      (
+        manifestWithSlashAndSpace,
+        s"${manifestWithSlashAndSpace.space}/miro%2FA%20images/versions"
+      )
     )
 
-    forAll(testCases) { case (manifest, path) =>
-      withConfiguredApp(initialManifests = Seq(manifest)) {
-        case (_, _, baseUrl) =>
-          val expectedJson = expectedVersionList(
-            expectedVersionJson(manifest)
-          )
+    forAll(testCases) {
+      case (manifest, path) =>
+        withConfiguredApp(initialManifests = Seq(manifest)) {
+          case (_, _, baseUrl) =>
+            val expectedJson = expectedVersionList(
+              expectedVersionJson(manifest)
+            )
 
-          whenGetRequestReady(s"$baseUrl/bags/$path") { response =>
-            response.status shouldBe StatusCodes.OK
+            whenGetRequestReady(s"$baseUrl/bags/$path") { response =>
+              response.status shouldBe StatusCodes.OK
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedJson)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedJson)
+              }
             }
-          }
         }
     }
   }

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
@@ -210,12 +210,10 @@ class LookupBagVersionsApiTest
       // when the identifier is URL encoded
       (manifestWithSlash, s"${manifestWithSlash.space}/alfa%2Fbravo/versions"),
       // when the identifier is not URL encoded
-      (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo/version"),
+      (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo/versions"),
       // when the identifier has s apce
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images/versions"),
       (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images/versions"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA images/versions"),
-      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A images/versions"),
     )
 
     forAll(testCases) { case (manifest, path) =>

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model._
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagVersion,
@@ -35,7 +36,8 @@ class LookupBagVersionsApiTest
     with DisplayJsonHelpers
     with JsonAssertions
     with S3Fixtures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with TableDrivenPropertyChecks {
 
   it("returns a 404 NotFound if there are no manifests for this bag ID") {
     withConfiguredApp() {
@@ -190,51 +192,45 @@ class LookupBagVersionsApiTest
     }
   }
 
-  val storageManifestWithSlash: StorageManifest = createStorageManifestWith(
-    bagInfo = createBagInfoWith(
-      externalIdentifier = ExternalIdentifier("alfa/bravo")
+  it("finds versions of bags with unusual external identifiers") {
+    val manifestWithSlash: StorageManifest = createStorageManifestWith(
+      bagInfo = createBagInfoWith(
+        externalIdentifier = ExternalIdentifier("alfa/bravo")
+      )
     )
-  )
 
-  it(
-    "finds versions of a bag with a slash in the external identifier (URL-encoded)"
-  ) {
-    withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifestWithSlash.id.space}/alfa%2Fbravo/versions"
+    val manifestWithSlashAndSpace: StorageManifest = createStorageManifestWith(
+      bagInfo = createBagInfoWith(
+        externalIdentifier = ExternalIdentifier("miro/A images")
+      )
+    )
 
-        val expectedJson = expectedVersionList(
-          expectedVersionJson(storageManifestWithSlash)
-        )
+    val testCases = Table(
+      ("manifest", "path"),
+      // when the identifier is URL encoded
+      (manifestWithSlash, s"${manifestWithSlash.space}/alfa%2Fbravo/versions"),
+      // when the identifier is not URL encoded
+      (manifestWithSlash, s"${manifestWithSlash.space}/alfa/bravo/version"),
+      // when the identifier has s apce
+      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A%20images/versions"),
+      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA%20images/versions"),
+      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro%2FA images/versions"),
+      (manifestWithSlashAndSpace, s"${manifestWithSlashAndSpace.space}/miro/A images/versions"),
+    )
 
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
+    forAll(testCases) { case (manifest, path) =>
+      withConfiguredApp(initialManifests = Seq(manifest)) {
+        case (_, _, baseUrl) =>
+          val expectedJson = expectedVersionList(
+            expectedVersionJson(manifest)
+          )
 
-          withStringEntity(response.entity) {
-            assertJsonStringsAreEqual(_, expectedJson)
-          }
-        }
-    }
-  }
+          whenGetRequestReady(s"$baseUrl/bags/$path") { response =>
+            response.status shouldBe StatusCodes.OK
 
-  it(
-    "finds versions of a bag with a slash in the external identifier (not URL-encoded)"
-  ) {
-    withConfiguredApp(initialManifests = Seq(storageManifestWithSlash)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifestWithSlash.id.space}/alfa/bravo/versions"
-
-        val expectedJson = expectedVersionList(
-          expectedVersionJson(storageManifestWithSlash)
-        )
-
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
-
-          withStringEntity(response.entity) {
-            assertJsonStringsAreEqual(_, expectedJson)
+            withStringEntity(response.entity) {
+              assertJsonStringsAreEqual(_, expectedJson)
+            }
           }
         }
     }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -62,6 +62,21 @@ class ExternalIdentifier(val underlying: String) {
     "External identifier cannot contain consecutive slashes"
   )
 
+  // We're super careful about the characters we allow in external identifiers,
+  // because anything we use will end up in a URL for the bags API:
+  //
+  //    /bags/{space}/{externalIdentifier}
+  //
+  // It's easier to block characters that don't URL-encode well rather than
+  // trying to handle the mess that is URL-encoding.
+  //
+  // If we need to revisit this, we should consider rethinking the bags API.
+  val regex: String = "^[a-zA-Z0-9_\\-/ ]+$"
+  require(
+    underlying.matches(regex),
+    s"External identifier must match regex: $regex"
+  )
+
   // Normally we use case classes for immutable data, which provide these
   // methods for us.
   //

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/LookupExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/LookupExternalIdentifier.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.archive.common.http
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+
+trait LookupExternalIdentifier {
+
+  // Decode an external identifier provided as part of a URL.
+  //
+  // Sometimes we have an external identifier with slashes or spaces.
+  // For maximum flexibility, we want to support both URL-encoded
+  // and complete path versions.
+  //
+  // For example, if the external identifier is "alfa/bravo",
+  // you could look up both of:
+  //
+  //    /bags/space-id/alfa/bravo
+  //    /bags/space-id/alfa%2Fbravo
+  //
+  protected def decodeExternalIdentifier(s: String): ExternalIdentifier =
+    ExternalIdentifier(
+      URLDecoder.decode(s, StandardCharsets.UTF_8.toString)
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -73,6 +73,18 @@ class ExternalIdentifierTest extends AnyFunSpec with Matchers {
     )
   }
 
+  it("blocks creating an external identifier with unusual characters") {
+    assertFailsRequirement(
+      identifier = "miro+space",
+      message = "External identifier must match regex: ^[a-zA-Z0-9_\\-/ ]+$"
+    )
+
+    assertFailsRequirement(
+      identifier = "miro%20space",
+      message = "External identifier must match regex: ^[a-zA-Z0-9_\\-/ ]+$"
+    )
+  }
+
   private def assertFailsRequirement(
     identifier: String,
     message: String


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4889

This PR:

* Updates the bags API and bag tracker to support bags with spaces in the identifier
* Blocks adding any other unexpected characters as part of new external identifiers