### PR TITLE
Grant blanket read permissions to other AWS accounts

### DIFF
--- a/terraform/critical_prod/locals.tf
+++ b/terraform/critical_prod/locals.tf
@@ -1,19 +1,10 @@
 locals {
   namespace = "storage"
 
-  goobi_task_role_arn = "arn:aws:iam::299497370133:role/goobi_task_role"
-
-  shell_server_1_task_role = "arn:aws:iam::299497370133:role/shell_server_1_task_role"
-  shell_server_2_task_role = "arn:aws:iam::299497370133:role/shell_server_2_task_role"
-  shell_server_3_task_role = "arn:aws:iam::299497370133:role/shell_server_3_task_role"
-  shell_server_4_task_role = "arn:aws:iam::299497370133:role/shell_server_4_task_role"
-
-  catalogue_pipeline_task_role_arn = "arn:aws:iam::760097843905:role/read_storage_s3_role"
-  archivematica_task_role_arn      = "arn:aws:iam::299497370133:role/am-prod-storage-service_task_role"
-
-  workflow_account_principal           = "arn:aws:iam::299497370133:root"
-  digitisation_account_principal       = "arn:aws:iam::404315009621:root"
-  catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
-
-  digirati_account_principal = "arn:aws:iam::653428163053:root"
+  account_ids = {
+    digirati     = "653428163053"
+    digitisation = "404315009621"
+    platform     = "760097843905"
+    workflow     = "299497370133"
+  }
 }

--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -4,7 +4,7 @@ module "critical" {
   namespace = local.namespace
 
   replica_primary_read_principals = [
-    for account_id in values(local.account_ids):
+    for account_id in values(local.account_ids) :
     "arn:aws:iam::${account_id}:root"
   ]
 

--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -4,22 +4,8 @@ module "critical" {
   namespace = local.namespace
 
   replica_primary_read_principals = [
-    local.archivematica_task_role_arn,
-    local.digitisation_account_principal,
-    local.goobi_task_role_arn,
-
-    local.shell_server_1_task_role,
-    local.shell_server_2_task_role,
-    local.shell_server_3_task_role,
-    local.shell_server_4_task_role,
-
-    local.workflow_account_principal,
-    local.catalogue_pipeline_task_role_arn,
-    local.catalogue_pipeline_account_principal,
-
-    "arn:aws:iam::653428163053:user/api",
-    "arn:aws:iam::653428163053:user/echo-fs",
-    local.digirati_account_principal
+    for account_id in values(local.account_ids):
+    "arn:aws:iam::${account_id}:root"
   ]
 
   azure_storage_account_name = "wecostorageprod"

--- a/terraform/critical_staging/locals.tf
+++ b/terraform/critical_staging/locals.tf
@@ -1,19 +1,10 @@
 locals {
   namespace = "storage"
 
-  goobi_task_role_arn = "arn:aws:iam::299497370133:role/goobi_task_role"
-
-  shell_server_1_task_role = "arn:aws:iam::299497370133:role/shell_server_1_task_role"
-  shell_server_2_task_role = "arn:aws:iam::299497370133:role/shell_server_2_task_role"
-  shell_server_3_task_role = "arn:aws:iam::299497370133:role/shell_server_3_task_role"
-  shell_server_4_task_role = "arn:aws:iam::299497370133:role/shell_server_4_task_role"
-
-  catalogue_pipeline_task_role_arn = "arn:aws:iam::760097843905:role/read_storage_s3_role"
-  archivematica_task_role_arn      = "arn:aws:iam::299497370133:role/am-staging-storage-service_task_role"
-
-  workflow_account_principal           = "arn:aws:iam::299497370133:root"
-  digitisation_account_principal       = "arn:aws:iam::404315009621:root"
-  catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
-
-  digirati_account_principal = "arn:aws:iam::653428163053:root"
+  account_ids = {
+    digirati     = "653428163053"
+    digitisation = "404315009621"
+    platform     = "760097843905"
+    workflow     = "299497370133"
+  }
 }

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -4,22 +4,8 @@ module "critical" {
   namespace = "${local.namespace}-staging"
 
   replica_primary_read_principals = [
-    local.archivematica_task_role_arn,
-    local.digitisation_account_principal,
-    local.goobi_task_role_arn,
-
-    local.shell_server_1_task_role,
-    local.shell_server_2_task_role,
-    local.shell_server_3_task_role,
-    local.shell_server_4_task_role,
-
-    local.workflow_account_principal,
-    local.catalogue_pipeline_task_role_arn,
-    local.catalogue_pipeline_account_principal,
-
-    "arn:aws:iam::653428163053:user/api",
-    "arn:aws:iam::653428163053:user/echo-fs",
-    local.digirati_account_principal
+    for account_id in values(local.account_ids):
+    "arn:aws:iam::${account_id}:root"
   ]
 
   azure_storage_account_name = "wecostoragestage"

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -4,7 +4,7 @@ module "critical" {
   namespace = "${local.namespace}-staging"
 
   replica_primary_read_principals = [
-    for account_id in values(local.account_ids):
+    for account_id in values(local.account_ids) :
     "arn:aws:iam::${account_id}:root"
   ]
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4895

Rather than specifying individual roles, which we need to manage, just grant blanket read permission to the entire account.  We can assign permissions to individual roles within those accounts, but without having to keep modifying this block.

We've discussed this change in the past with folks at Digirati, and tested it on some Digirati roles, but apparently never got around to doing it properly.