### PR TITLE
Fix a couple of missing .right.value in tests

### DIFF
--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetBagTestCases.scala
@@ -69,7 +69,7 @@ trait GetBagTestCases
             whenReady(
               client.getBag(bagId = manifest.id, version = manifest.version)
             ) {
-              _.right.value shouldBe manifest
+              _.value shouldBe manifest
             }
           }
         }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/GetLatestBagTestCases.scala
@@ -66,7 +66,7 @@ trait GetLatestBagTestCases
         withApi(initialManifests = Seq(manifest)) { _ =>
           withClient(trackerHost) { client =>
             whenReady(client.getLatestBag(bagId = manifest.id)) {
-              _.right.value shouldBe manifest
+              _.value shouldBe manifest
             }
           }
         }

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/client/ListVersionsTestCases.scala
@@ -155,7 +155,7 @@ trait ListVersionsTestCases
             whenReady(
               client.listVersionsOf(bagId = manifest.id, maybeBefore = None)
             ) {
-              _.right.value shouldBe expectedList
+              _.value shouldBe expectedList
             }
           }
         }


### PR DESCRIPTION
This is breaking tests on master; I'm not sure why it wasn't caught by #795.