### PR TITLE
Unexplained bag unpacker errors get flagged by the daily report

### DIFF
--- a/monitoring/daily_reporter/src/ingests.py
+++ b/monitoring/daily_reporter/src/ingests.py
@@ -34,9 +34,9 @@ def get_dev_status(ingest):
             reason.startswith(
                 (
                     "Verification (pre-replicating to archive storage) failed",
-                    "Unpacking failed",
-                    # If we can't assign a version for an unknown reason, we
-                    # should treat that as a storage service error.
+                    # If we can't unpack a bag or assign a version for an
+                    # unknown reason, we should treat that as a storage service error.
+                    "Unpacking failed -",
                     "Assigning bag version failed -",
                 )
             )

--- a/monitoring/daily_reporter/src/test_ingests.py
+++ b/monitoring/daily_reporter/src/test_ingests.py
@@ -62,6 +62,10 @@ from ingests import get_dev_status
             },
             "failed (user error)",
         ),
+        (
+            {"status": "failed", "events": [{"description": "Unpacking failed"}],},
+            "failed (unknown reason)",
+        ),
     ],
 )
 def test_get_dev_status(ingest, expected_dev_status):

--- a/monitoring/daily_reporter/src/test_ingests.py
+++ b/monitoring/daily_reporter/src/test_ingests.py
@@ -1,0 +1,68 @@
+import datetime
+
+import pytest
+
+from ingests import get_dev_status
+
+
+@pytest.mark.parametrize(
+    "ingest, expected_dev_status",
+    [
+        ({"status": "succeeded"}, "succeeded"),
+        (
+            {
+                "status": "accepted",
+                "createdDate": datetime.datetime.now() - datetime.timedelta(seconds=5),
+            },
+            "accepted",
+        ),
+        (
+            {
+                "status": "accepted",
+                "createdDate": datetime.datetime.now() - datetime.timedelta(days=5),
+            },
+            "stalled",
+        ),
+        (
+            {
+                "status": "processing",
+                "createdDate": datetime.datetime.now() - datetime.timedelta(seconds=5),
+            },
+            "processing",
+        ),
+        (
+            {
+                "status": "processing",
+                "createdDate": datetime.datetime.now() - datetime.timedelta(days=5),
+            },
+            "stalled",
+        ),
+        (
+            {
+                "status": "failed",
+                "events": [{"description": "Assigning bag version failed"}],
+            },
+            "failed (unknown reason)",
+        ),
+        (
+            {
+                "status": "failed",
+                "events": [
+                    {
+                        "description": "Assigning bag version failed - newer version of bag etc."
+                    }
+                ],
+            },
+            "failed (user error)",
+        ),
+        (
+            {
+                "status": "failed",
+                "events": [{"description": "Unpacking failed - the bag doesn't exist"}],
+            },
+            "failed (user error)",
+        ),
+    ],
+)
+def test_get_dev_status(ingest, expected_dev_status):
+    assert get_dev_status(ingest) == expected_dev_status

--- a/monitoring/daily_reporter/src/test_ingests.py
+++ b/monitoring/daily_reporter/src/test_ingests.py
@@ -63,7 +63,7 @@ from ingests import get_dev_status
             "failed (user error)",
         ),
         (
-            {"status": "failed", "events": [{"description": "Unpacking failed"}],},
+            {"status": "failed", "events": [{"description": "Unpacking failed"}]},
             "failed (unknown reason)",
         ),
     ],


### PR DESCRIPTION
If a bag fails to unpack and the storage service only says `"Unpacking failed"`, we should be prompted to investigate this by the daily report.

This patch moves those errors from "failure (user error)" to "failure (unknown reason)".

If the bag unpacker includes an explanation (e.g. "the object doesn't exist"), it's still treated as a user error.

For https://github.com/wellcomecollection/platform/issues/4911