### PR TITLE
Remove the unused getLatestVersion method

### DIFF
--- a/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDao.scala
@@ -17,9 +17,6 @@ trait StorageManifestDao {
     StorageManifest
   ]
 
-  def getLatestVersion(id: BagId): Either[ReadError, BagVersion] =
-    vhs.store.max(id).map { BagVersion(_) }
-
   def getLatest(id: BagId): Either[ReadError, StorageManifest] =
     vhs.getLatest(id).map { _.identifiedT }
 

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   StorageManifestGenerators
 }
 import uk.ac.wellcome.storage.{
-  NoMaximaValueError,
   NoVersionExistsError,
   VersionAlreadyExistsError,
   WriteError

--- a/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
+++ b/bag_tracker/src/test/scala/uk/ac/wellcome/platform/archive/bag_tracker/storage/StorageManifestDaoTestCases.scala
@@ -200,38 +200,5 @@ trait StorageManifestDaoTestCases[Context]
         }
       }
     }
-
-    it("finds the latest version") {
-      val storageManifest = createStorageManifest
-
-      val manifests = (0 to 5).map { version =>
-        storageManifest.copy(version = BagVersion(version))
-      }
-
-      withContext { implicit context =>
-        withDao { dao =>
-          manifests.foreach { manifest =>
-            dao.put(manifest) shouldBe a[Right[_, _]]
-          }
-
-          dao
-            .getLatestVersion(storageManifest.id)
-            .value shouldBe BagVersion(5)
-        }
-      }
-    }
-
-    it("returns a NoMaximaValueError() error if there is no latest version") {
-      val bagId = createBagId
-
-      withContext { implicit context =>
-        withDao { dao =>
-          dao
-            .getLatestVersion(bagId)
-            .left
-            .value shouldBe a[NoMaximaValueError]
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
As part of https://github.com/wellcomecollection/platform/issues/4913, I’m looking at the Maxima class from scala-libs – and in particular, where it's used.

I discovered this method in storage-service is only used in the tests, so we can safely delete it.