### PR TITLE
Verify that our bags include a bag declaration

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -48,6 +48,7 @@ trait ReplicatedBagVerifier[
 trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
 ]] extends Logging
+    with VerifyBagDeclaration[BagLocation, BagPrefix]
     with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
@@ -117,6 +118,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
     implicit et: EnsureTrailingSlash[BagPrefix]
   ): Either[BagVerifierError, FixityListResult[BagLocation]] =
     for {
+      _ <- verifyBagDeclaration(root)
 
       _ <- verifyExternalIdentifier(
         bag = bag,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/azure/AzureReplicatedBagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/azure/AzureReplicatedBagVerifier.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.storage.listing.Listing
 import uk.ac.wellcome.storage.listing.azure.AzureBlobLocationListing
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.store.azure.AzureStreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 
 class AzureReplicatedBagVerifier(
@@ -30,7 +31,8 @@ class AzureReplicatedBagVerifier(
     AzureBlobLocationPrefix,
     Bag
   ],
-  val srcReader: StreamStore[S3ObjectLocation]
+  val srcReader: StreamStore[S3ObjectLocation],
+  val streamReader: StreamStore[AzureBlobLocation]
 ) extends ReplicatedBagVerifier[AzureBlobLocation, AzureBlobLocationPrefix] {
 
   override def getRelativePath(
@@ -60,7 +62,8 @@ object AzureReplicatedBagVerifier {
       listing,
       resolvable,
       fixityListChecker,
-      srcReader
+      srcReader,
+      streamReader = new AzureStreamStore()
     )
   }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/s3/S3BagVerifier.scala
@@ -47,7 +47,8 @@ class S3StandaloneBagVerifier(
     S3ObjectLocation,
     S3ObjectLocationPrefix,
     Bag
-  ]
+  ],
+  val streamReader: S3StreamStore
 ) extends BagVerifier[
       StandaloneBagVerifyContext,
       S3ObjectLocation,
@@ -73,7 +74,8 @@ class S3ReplicatedBagVerifier(
     S3ObjectLocationPrefix,
     Bag
   ],
-  val srcReader: StreamStore[S3ObjectLocation]
+  val srcReader: StreamStore[S3ObjectLocation],
+  val streamReader: S3StreamStore
 ) extends ReplicatedBagVerifier[
       S3ObjectLocation,
       S3ObjectLocationPrefix
@@ -97,7 +99,8 @@ object S3BagVerifier {
       bagReader,
       listing,
       resolvable,
-      fixityListChecker
+      fixityListChecker,
+      streamReader = new S3StreamStore()
     )
   }
   def replicated(
@@ -116,7 +119,8 @@ object S3BagVerifier {
       listing,
       resolvable,
       fixityListChecker,
-      srcReader = streamStore
+      srcReader = streamStore,
+      streamReader = streamStore
     )
   }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -13,7 +13,9 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
 ]] {
   protected val streamReader: Readable[BagLocation, InputStreamWithLength]
 
-  private val declaration = new Regex("BagIt-Version: \\d\\.\\d+\nTag-File-Character-Encoding: UTF-8\n?")
+  private val declaration = new Regex(
+    "BagIt-Version: \\d\\.\\d+\nTag-File-Character-Encoding: UTF-8\n?"
+  )
 
   // Quoting from the BagIt spec (https://tools.ietf.org/html/rfc8493#section-2.1.1):
   //
@@ -38,14 +40,18 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
       case Right(Identified(_, inputStream)) if inputStream.length > 1000 =>
         inputStream.close()
         Left(
-          BagVerifierError("Error loading Bag Declaration (bagit.txt): too large")
+          BagVerifierError(
+            "Error loading Bag Declaration (bagit.txt): too large"
+          )
         )
 
       case Right(Identified(_, inputStream)) =>
         stringCodec.fromStream(inputStream) match {
           case Left(_) =>
             Left(
-              BagVerifierError("Error loading Bag Declaration (bagit.txt): could not be decoded as UTF-8")
+              BagVerifierError(
+                "Error loading Bag Declaration (bagit.txt): could not be decoded as UTF-8"
+              )
             )
 
           case Right(declaration()) =>
@@ -53,18 +59,27 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
 
           case Right(_) =>
             Left(
-              BagVerifierError("Error loading Bag Declaration (bagit.txt): not correctly formatted")
+              BagVerifierError(
+                "Error loading Bag Declaration (bagit.txt): not correctly formatted"
+              )
             )
         }
 
       case Left(err: NotFoundError) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("Error loading Bag Declaration (bagit.txt): no such file!"))
+          BagVerifierError(
+            err.e,
+            userMessage =
+              Some("Error loading Bag Declaration (bagit.txt): no such file!")
+          )
         )
 
       case Left(err) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("Error loading Bag Declaration (bagit.txt)"))
+          BagVerifierError(
+            err.e,
+            userMessage = Some("Error loading Bag Declaration (bagit.txt)")
+          )
         )
     }
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -30,6 +30,12 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
         Left(
           BagVerifierError(err.e, userMessage = Some("No Bag Declaration in bag (no bagit.txt)"))
         )
+
+      case Left(err) =>
+        Left(
+          BagVerifierError(err.e, userMessage = Some("Unable to read Bag Declaration from bag (bagit.txt)"))
+        )
+
       case _ => Right(())
     }
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -38,14 +38,14 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
       case Right(Identified(_, inputStream)) if inputStream.length > 1000 =>
         inputStream.close()
         Left(
-          BagVerifierError("The Bag Declaration (bagit.txt) is too large")
+          BagVerifierError("Error loading Bag Declaration (bagit.txt): too large")
         )
 
       case Right(Identified(_, inputStream)) =>
         stringCodec.fromStream(inputStream) match {
           case Left(_) =>
             Left(
-              BagVerifierError("The Bag Declaration (bagit.txt) could not be decoded as UTF-8")
+              BagVerifierError("Error loading Bag Declaration (bagit.txt): could not be decoded as UTF-8")
             )
 
           case Right(declaration()) =>
@@ -53,18 +53,18 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
 
           case Right(_) =>
             Left(
-              BagVerifierError("The Bag Declaration (bagit.txt) is not correctly formatted")
+              BagVerifierError("Error loading Bag Declaration (bagit.txt): not correctly formatted")
             )
         }
 
       case Left(err: NotFoundError) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("No Bag Declaration (bagit.txt) in bag"))
+          BagVerifierError(err.e, userMessage = Some("Error loading Bag Declaration (bagit.txt): no such file!"))
         )
 
       case Left(err) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("Unable to read Bag Declaration (bagit.txt) from bag"))
+          BagVerifierError(err.e, userMessage = Some("Error loading Bag Declaration (bagit.txt)"))
         )
     }
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{Location, Prefix}
+import uk.ac.wellcome.storage.{Location, NotFoundError, Prefix}
 
 trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
@@ -24,13 +24,13 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
   //
   def verifyBagDeclaration(root: BagPrefix): Either[BagVerifierError, Unit] = {
     val location = root.asLocation("bagit.txt")
-    println(location)
 
-//    Right(())
-////    srcReader.get(location) match {
-////      case Right(stream)
-////      case Left(err) =>
-////        Left(BagVerifierError(s"Unable to read bagit.txt: $err"))
-////    }
-//  }
+    srcReader.get(location) match {
+      case Left(err: NotFoundError) =>
+        Left(
+          BagVerifierError(err.e, userMessage = Some("No Bag Declaration in bag (no bagit.txt)"))
+        )
+      case _ => Right(())
+    }
+  }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -11,7 +11,7 @@ import scala.util.matching.Regex
 trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
 ]] {
-  protected val srcReader: Readable[BagLocation, InputStreamWithLength]
+  protected val streamReader: Readable[BagLocation, InputStreamWithLength]
 
   private val declaration = new Regex("BagIt-Version: \\d\\.\\d+\nTag-File-Character-Encoding: UTF-8\n?")
 
@@ -30,7 +30,7 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
   def verifyBagDeclaration(root: BagPrefix): Either[BagVerifierError, Unit] = {
     val location = root.asLocation("bagit.txt")
 
-    srcReader.get(location) match {
+    streamReader.get(location) match {
 
       // If the bagit.txt file is too big, something is definitely wrong.
       // We'll be loading the whole file into memory because it should be small;

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -3,12 +3,17 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.{Location, NotFoundError, Prefix}
+import uk.ac.wellcome.storage.{Identified, Location, NotFoundError, Prefix}
+import uk.ac.wellcome.storage.streaming.Codec._
+
+import scala.util.matching.Regex
 
 trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
   BagLocation
 ]] {
   protected val srcReader: Readable[BagLocation, InputStreamWithLength]
+
+  private val declaration = new Regex("BagIt-Version: \\d\\.\\d+\nTag-File-Character-Encoding: UTF-8\n?")
 
   // Quoting from the BagIt spec (https://tools.ietf.org/html/rfc8493#section-2.1.1):
   //
@@ -26,17 +31,41 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
     val location = root.asLocation("bagit.txt")
 
     srcReader.get(location) match {
+
+      // If the bagit.txt file is too big, something is definitely wrong.
+      // We'll be loading the whole file into memory because it should be small;
+      // if it's not, don't explode with an out-of-memory.
+      case Right(Identified(_, inputStream)) if inputStream.length > 1000 =>
+        inputStream.close()
+        Left(
+          BagVerifierError("The Bag Declaration (bagit.txt) is too large")
+        )
+
+      case Right(Identified(_, inputStream)) =>
+        stringCodec.fromStream(inputStream) match {
+          case Left(_) =>
+            Left(
+              BagVerifierError("The Bag Declaration (bagit.txt) could not be decoded as UTF-8")
+            )
+
+          case Right(declaration()) =>
+            Right(())
+
+          case Right(_) =>
+            Left(
+              BagVerifierError("The Bag Declaration (bagit.txt) is not correctly formatted")
+            )
+        }
+
       case Left(err: NotFoundError) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("No Bag Declaration in bag (no bagit.txt)"))
+          BagVerifierError(err.e, userMessage = Some("No Bag Declaration (bagit.txt) in bag"))
         )
 
       case Left(err) =>
         Left(
-          BagVerifierError(err.e, userMessage = Some("Unable to read Bag Declaration from bag (bagit.txt)"))
+          BagVerifierError(err.e, userMessage = Some("Unable to read Bag Declaration (bagit.txt) from bag"))
         )
-
-      case _ => Right(())
     }
   }
 }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclaration.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
+
+import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
+import uk.ac.wellcome.storage.store.Readable
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
+import uk.ac.wellcome.storage.{Location, Prefix}
+
+trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] {
+  protected val srcReader: Readable[BagLocation, InputStreamWithLength]
+
+  // Quoting from the BagIt spec (https://tools.ietf.org/html/rfc8493#section-2.1.1):
+  //
+  //    The "bagit.txt" tag file MUST consist of exactly two lines in this
+  //    order:
+  //
+  //    BagIt-Version: M.N
+  //    Tag-File-Character-Encoding: ENCODING
+  //
+  // The spec requires that M.N be the BagIt version, and ENCODING be any encoding
+  // recognised by the IANA.  We are slightly more restrictive -- we require that
+  // this be "UTF-8".
+  //
+  def verifyBagDeclaration(root: BagPrefix): Either[BagVerifierError, Unit] = {
+    val location = root.asLocation("bagit.txt")
+    println(location)
+
+//    Right(())
+////    srcReader.get(location) match {
+////      case Right(stream)
+////      case Left(err) =>
+////        Left(BagVerifierError(s"Unable to read bagit.txt: $err"))
+////    }
+//  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -288,6 +288,17 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     }
   }
 
+  it("fails a bag if the bag declaration does not exist") {
+    val badBuilder = new BagBuilderImpl {
+      override def createBagDeclaration: Option[ManifestFile] = None
+    }
+
+    assertBagIncomplete(badBuilder) {
+      case (ingestFailed, _) =>
+        ingestFailed.maybeUserFacingMessage.get shouldBe "Error loading Bag Declaration (bagit.txt): no such file!"
+    }
+  }
+
   it("fails if the external identifier in the bag-info.txt is incorrect") {
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier.underlying

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -89,4 +89,89 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     err.userMessage.get shouldBe "Unable to read Bag Declaration from bag (bagit.txt)"
     err.e shouldBe expectedErr
   }
+
+  it("fails if the bagit.txt has no BagIt-Version line") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("Tag-File-Character-Encoding: UTF-8\n").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "The Bag Declaration is missing BagIt-Version (bagit.txt)"
+  }
+
+  it("fails if the bagit.txt has no Tag-File-Character-Encoding line") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 0.97\n").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "The Bag Declaration is missing Tag-File-Character-Encoding (bagit.txt)"
+  }
+
+  it("fails if the bagit.txt is empty") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 0.97\n").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "The Bag Declaration is missing BagIt-Version and Tag-File-Character-Encoding (bagit.txt)"
+  }
+
+  it("fails if the bagit.txt has an unwanted key") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key: ShouldNotBeHere").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "The Bag Declaration has an unwanted key: Extra-Key (bagit.txt)"
+  }
+
+  it("fails if the bagit.txt has unwanted keys") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key1: ShouldNotBeHere\nExtra-Key2: ShouldNotBeHere").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "The Bag Declaration has unwanted keys: Extra-Key1, Extra-Key2 (bagit.txt)"
+  }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -80,7 +80,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
   }
 
   it("fails if the bagit.txt is empty") {
-    assertFails("BagIt-Version: 0.97\n")
+    assertFails("")
   }
 
   it("fails if the bagit.txt is nonsense") {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -41,7 +41,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     val store = MemoryStreamStore[MemoryLocation]()
 
     val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
-      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+      override protected val streamReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
@@ -59,7 +59,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     )
 
     val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
-      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = brokenStore
+      override protected val streamReader: Readable[MemoryLocation, InputStreamWithLength] = brokenStore
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
@@ -111,7 +111,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     store.put(root.asLocation("bagit.txt"))(stringCodec.toStream(contents).value)
 
     val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
-      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+      override protected val streamReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
     testWith(verifier)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -45,7 +45,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "No Bag Declaration (bagit.txt) in bag"
+    err.userMessage.get shouldBe "Error loading Bag Declaration (bagit.txt): no such file!"
   }
 
   it("fails if it can't read the bagit.txt") {
@@ -63,7 +63,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "Unable to read Bag Declaration (bagit.txt) from bag"
+    err.userMessage.get shouldBe "Error loading Bag Declaration (bagit.txt)"
     err.e shouldBe expectedErr
   }
 
@@ -86,7 +86,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
   it("fails if the bagit.txt is nonsense") {
     assertFails(
       randomAlphanumeric(length = 2000),
-      expectedMessage = "The Bag Declaration (bagit.txt) is too large"
+      expectedMessage = "Error loading Bag Declaration (bagit.txt): too large"
     )
   }
 
@@ -117,7 +117,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     testWith(verifier)
   }
 
-  def assertFails[R](contents: String, expectedMessage: String = "The Bag Declaration (bagit.txt) is not correctly formatted"): Assertion = {
+  def assertFails[R](contents: String, expectedMessage: String = "Error loading Bag Declaration (bagit.txt): not correctly formatted"): Assertion = {
     implicit val root: MemoryLocationPrefix = createMemoryLocationPrefix
 
     withVerifier(contents) { verifier =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -57,3 +57,16 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     }
 
     verifier.verifyBagDeclaration(root) shouldBe Right(())
+  }
+
+  it("fails if it can't find a bagit.txt") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
+    err.userMessage.get shouldBe "No Bag Declaration in bag (no bagit.txt)"
+  }
+}

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -1,0 +1,59 @@
+package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.storage.generators.MemoryLocationGenerators
+import uk.ac.wellcome.storage.providers.memory.{MemoryLocation, MemoryLocationPrefix}
+import uk.ac.wellcome.storage.store.Readable
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.streaming.InputStreamWithLength
+
+class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValues with MemoryLocationGenerators {
+  it("verifies a valid bagit.txt (v0.97)") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    verifier.verifyBagDeclaration(root) shouldBe Right(())
+  }
+
+  it("verifies a valid bagit.txt (v1.0)") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    verifier.verifyBagDeclaration(root) shouldBe Right(())
+  }
+
+  it("verifies a valid bagit.txt trailing newline)") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream("BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n").value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    verifier.verifyBagDeclaration(root) shouldBe Right(())

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -68,7 +68,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "No Bag Declaration in bag (no bagit.txt)"
+    err.userMessage.get shouldBe "No Bag Declaration (bagit.txt) in bag"
   }
 
   it("fails if it can't read the bagit.txt") {
@@ -86,7 +86,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
     }
 
     val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "Unable to read Bag Declaration from bag (bagit.txt)"
+    err.userMessage.get shouldBe "Unable to read Bag Declaration (bagit.txt) from bag"
     err.e shouldBe expectedErr
   }
 
@@ -103,8 +103,8 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
       override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
-    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "The Bag Declaration is missing BagIt-Version (bagit.txt)"
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is not correctly formatted"
   }
 
   it("fails if the bagit.txt has no Tag-File-Character-Encoding line") {
@@ -120,8 +120,8 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
       override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
-    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "The Bag Declaration is missing Tag-File-Character-Encoding (bagit.txt)"
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is not correctly formatted"
   }
 
   it("fails if the bagit.txt is empty") {
@@ -137,8 +137,25 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
       override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
-    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "The Bag Declaration is missing BagIt-Version and Tag-File-Character-Encoding (bagit.txt)"
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is not correctly formatted"
+  }
+
+  it("fails if the bagit.txt is nonsense") {
+    val store = MemoryStreamStore[MemoryLocation]()
+
+    val root = createMemoryLocationPrefix
+
+    store.put(root.asLocation("bagit.txt"))(
+      stringCodec.toStream(randomAlphanumeric(length = 2000)).value
+    )
+
+    val verifier = new VerifyBagDeclaration[MemoryLocation, MemoryLocationPrefix] {
+      override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
+    }
+
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is too large"
   }
 
   it("fails if the bagit.txt has an unwanted key") {
@@ -154,8 +171,8 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
       override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
-    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "The Bag Declaration has an unwanted key: Extra-Key (bagit.txt)"
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is not correctly formatted"
   }
 
   it("fails if the bagit.txt has unwanted keys") {
@@ -171,7 +188,7 @@ class VerifyBagDeclarationTest extends AnyFunSpec with Matchers with EitherValue
       override protected val srcReader: Readable[MemoryLocation, InputStreamWithLength] = store
     }
 
-    val err = verifier.verifyBagDeclaration(createMemoryLocationPrefix).left.value
-    err.userMessage.get shouldBe "The Bag Declaration has unwanted keys: Extra-Key1, Extra-Key2 (bagit.txt)"
+    val err = verifier.verifyBagDeclaration(root).left.value
+    err.userMessage.get shouldBe "The Bag Declaration (bagit.txt) is not correctly formatted"
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -122,14 +122,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
       externalIdentifier = externalIdentifier
     )
 
-    val bagItFile =
-      ManifestFile(
-        name = s"bagit.txt",
-        contents = """
-                     |BagIt-Version: 0.97
-                     |Tag-File-Character-Encoding: UTF-8
-                   """.stripMargin.trim
-      )
+    val bagItFile = Seq(createBagDeclaration).flatten
 
     val bagInfoFile =
       createBagInfo(bagInfo)
@@ -151,7 +144,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     val tagManifestFiles: List[ManifestFile] =
       payloadManifest.toList ++
         bagInfoFile.toList ++
-        fetchFile.toList ++ List(bagItFile)
+        fetchFile.toList ++ bagItFile
 
     val tagManifest = createTagManifest(tagManifestFiles)
       .map { contents =>
@@ -234,6 +227,17 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
         entries.map { entry =>
           (entry.name, createDigest(entry.contents))
         }
+      )
+    )
+
+  protected def createBagDeclaration: Option[ManifestFile] =
+    Some(
+      ManifestFile(
+        name = s"bagit.txt",
+        contents = """
+                     |BagIt-Version: 0.97
+                     |Tag-File-Character-Encoding: UTF-8
+                   """.stripMargin.trim
       )
     )
 


### PR DESCRIPTION
The first "required element" [in the BagIt spec](https://tools.ietf.org/html/rfc8493#section-2.1.1) is a "Bag Declaration", aka bagit.txt:

> The "bagit.txt" tag file MUST consist of exactly two lines in this order:
>
> ```
> BagIt-Version: M.N
> Tag-File-Character-Encoding: ENCODING
> ```

We didn't have any code that checked for the presence of this file; now we do. I'm running a script to check we have an appropriate bagit.txt file in all the existing bags.
