### PR TITLE
Verify that payload files are in data/, tag files are in the root

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -126,7 +126,9 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
       )
 
       _ <- verifyPayloadOxumFileCount(bag)
+
       _ <- verifyPayloadFilenames(bag.manifest)
+      _ <- verifyTagFileFilenames(bag.tagManifest)
 
       _ <- verifyFetchPrefixes(
         fetch = bag.fetch,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -126,6 +126,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
       )
 
       _ <- verifyPayloadOxumFileCount(bag)
+      _ <- verifyPayloadFilenames(bag.manifest)
 
       _ <- verifyFetchPrefixes(
         fetch = bag.fetch,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -53,7 +53,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
     with VerifyExternalIdentifier
     with VerifyFetch[BagLocation, BagPrefix]
     with VerifyPayloadOxum
-    with VerifyLegalFilenames
+    with VerifyFilenames
     with VerifyNoUnreferencedFiles[BagLocation, BagPrefix] {
 
   val bagReader: BagReader[BagLocation, BagPrefix]
@@ -139,7 +139,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix], BagLocation <: Loca
       filenames = (bag.manifest.entries ++ bag.tagManifest.entries).map {
         case (path, _) => path.value
       }
-      _ <- verifyLegalFilenames(filenames.toSeq)
+      _ <- verifyAllowedFilenames(filenames.toSeq)
 
       verificationResult <- verifyChecksumAndSize(
         root = root,

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
-import uk.ac.wellcome.platform.archive.common.bagit.models.PayloadManifest
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  PayloadManifest,
+  TagManifest
+}
 
 trait VerifyFilenames {
   def verifyAllowedFilenames(
@@ -48,6 +51,30 @@ trait VerifyFilenames {
       Left(
         BagVerifierError(
           s"Not all payload files are in the data/ directory: ${badPaths.mkString(", ")}"
+        )
+      )
+    }
+  }
+
+  // The BagIt spec does not make recommendations where tag files should be stored;
+  // we require that all tag files are stored in the root of the bag.
+  // e.g. you can't put a tag file in the "data/" directory.
+  //
+  // This ensures a clean separation of BagIt elements and payload files.
+  //
+  // The tag manifest lists all files *except* the "manifest-{algorithm}.txt" tag manifest
+  // itself.  We have a separate check (VerifyNoUnreferencedFiles) that would warn us if
+  // there's a tag manifest somewhere other than the root of the bag.
+  def verifyTagFileFilenames(manifest: TagManifest): Either[BagVerifierError, Unit] = {
+    val paths = manifest.entries.map { case (path, _) => path.value }
+    val badPaths = paths.filter { _.contains("/") }
+
+    if (badPaths.isEmpty) {
+      Right(())
+    } else {
+      Left(
+        BagVerifierError(
+          s"Not all tag files are in the root directory: ${badPaths.mkString(", ")}"
         )
       )
     }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 import uk.ac.wellcome.platform.archive.bagverifier.models.BagVerifierError
 import uk.ac.wellcome.platform.archive.common.bagit.models.PayloadManifest
 
-trait VerifyLegalFilenames {
-  def verifyLegalFilenames(
+trait VerifyFilenames {
+  def verifyAllowedFilenames(
     filenames: Seq[String]
   ): Either[BagVerifierError, Unit] = {
     // Azure blob storage does not support blob names that end with a `.`

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenames.scala
@@ -41,7 +41,9 @@ trait VerifyFilenames {
   // in the "data/" directory.
   //
   // See https://tools.ietf.org/html/rfc8493#section-2.1.2
-  def verifyPayloadFilenames(manifest: PayloadManifest): Either[BagVerifierError, Unit] = {
+  def verifyPayloadFilenames(
+    manifest: PayloadManifest
+  ): Either[BagVerifierError, Unit] = {
     val paths = manifest.entries.map { case (path, _) => path.value }
     val badPaths = paths.filterNot { _.startsWith("data/") }
 
@@ -65,7 +67,9 @@ trait VerifyFilenames {
   // The tag manifest lists all files *except* the "manifest-{algorithm}.txt" tag manifest
   // itself.  We have a separate check (VerifyNoUnreferencedFiles) that would warn us if
   // there's a tag manifest somewhere other than the root of the bag.
-  def verifyTagFileFilenames(manifest: TagManifest): Either[BagVerifierError, Unit] = {
+  def verifyTagFileFilenames(
+    manifest: TagManifest
+  ): Either[BagVerifierError, Unit] = {
     val paths = manifest.entries.map { case (path, _) => path.value }
     val badPaths = paths.filter { _.contains("/") }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -341,6 +341,23 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     }
   }
 
+  it("fails a bag if there are tag files outside the root directory") {
+    val badBuilder = new BagBuilderImpl {
+      override protected def createTagManifest(entries: Seq[ManifestFile]): Option[String] =
+        super.createTagManifest(
+          entries ++ Seq(
+            ManifestFile("data/bagit.txt", contents = "123"),
+            ManifestFile("tags/metadata.csv", contents = "123")
+          )
+        )
+    }
+
+    assertBagIncomplete(badBuilder) {
+      case (ingestFailed, _) =>
+        ingestFailed.maybeUserFacingMessage.get should startWith("Not all tag files are in the root directory:")
+    }
+  }
+
   it("fails if the external identifier in the bag-info.txt is incorrect") {
     val space = createStorageSpace
     val externalIdentifier = createExternalIdentifier.underlying

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTestCases.scala
@@ -309,7 +309,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         version: BagVersion,
         payloadFileCount: Int,
         isFetch: Boolean
-     ): Seq[PayloadEntry] = {
+      ): Seq[PayloadEntry] = {
         val bagRoot = createBagRootPath(space, externalIdentifier, version)
 
         // We don't want to put these files in the fetch.txt, or we'll get a
@@ -331,19 +331,29 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
             }
           }
 
-        super.createPayloadFiles(space, externalIdentifier, version, payloadFileCount, isFetch) ++ badFiles
+        super.createPayloadFiles(
+          space,
+          externalIdentifier,
+          version,
+          payloadFileCount,
+          isFetch
+        ) ++ badFiles
       }
     }
 
     assertBagIncomplete(badBuilder) {
       case (ingestFailed, _) =>
-        ingestFailed.maybeUserFacingMessage.get should startWith("Not all payload files are in the data/ directory")
+        ingestFailed.maybeUserFacingMessage.get should startWith(
+          "Not all payload files are in the data/ directory"
+        )
     }
   }
 
   it("fails a bag if there are tag files outside the root directory") {
     val badBuilder = new BagBuilderImpl {
-      override protected def createTagManifest(entries: Seq[ManifestFile]): Option[String] =
+      override protected def createTagManifest(
+        entries: Seq[ManifestFile]
+      ): Option[String] =
         super.createTagManifest(
           entries ++ Seq(
             ManifestFile("data/bagit.txt", contents = "123"),
@@ -354,7 +364,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
     assertBagIncomplete(badBuilder) {
       case (ingestFailed, _) =>
-        ingestFailed.maybeUserFacingMessage.get should startWith("Not all tag files are in the root directory:")
+        ingestFailed.maybeUserFacingMessage.get should startWith(
+          "Not all tag files are in the root directory:"
+        )
     }
   }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
@@ -10,10 +10,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5}
 
-class VerifyFilenamesTest
-    extends AnyFunSpec
-    with Matchers
-    with EitherValues {
+class VerifyFilenamesTest extends AnyFunSpec with Matchers with EitherValues {
   val verifier: VerifyFilenames =
     new VerifyFilenames {}
 
@@ -49,7 +46,7 @@ class VerifyFilenamesTest
         entries = Map(
           BagPath("data/README.txt") -> ChecksumValue("123"),
           BagPath("data/animals/cat.jpg") -> ChecksumValue("123"),
-          BagPath("data/animals/dog.png") -> ChecksumValue("123"),
+          BagPath("data/animals/dog.png") -> ChecksumValue("123")
         )
       )
 
@@ -72,7 +69,7 @@ class VerifyFilenamesTest
           BagPath("data/README.txt") -> ChecksumValue("123"),
           BagPath("data/animals/cat.jpg") -> ChecksumValue("123"),
           BagPath("dog.png") -> ChecksumValue("123"),
-          BagPath("tags/metadata.csv") -> ChecksumValue("123"),
+          BagPath("tags/metadata.csv") -> ChecksumValue("123")
         )
       )
 
@@ -103,7 +100,7 @@ class VerifyFilenamesTest
         entries = Map(
           BagPath("bagit.txt") -> ChecksumValue("123"),
           BagPath("data/bag-info.txt") -> ChecksumValue("123"),
-          BagPath("tags/metadata.csv") -> ChecksumValue("123"),
+          BagPath("tags/metadata.csv") -> ChecksumValue("123")
         )
       )
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
@@ -5,7 +5,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagPath,
-  PayloadManifest
+  PayloadManifest,
+  TagManifest
 }
 import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5}
 
@@ -79,6 +80,37 @@ class VerifyFilenamesTest
       err.e.getMessage shouldBe "Not all payload files are in the data/ directory: dog.png, tags/metadata.csv"
       err.userMessage shouldBe Some(
         "Not all payload files are in the data/ directory: dog.png, tags/metadata.csv"
+      )
+    }
+  }
+
+  describe("verifyTagFileFilenames") {
+    it("allows tag files in the root") {
+      val manifest = TagManifest(
+        checksumAlgorithm = MD5,
+        entries = Map(
+          BagPath("bagit.txt") -> ChecksumValue("123"),
+          BagPath("bag-info.txt") -> ChecksumValue("123")
+        )
+      )
+
+      verifier.verifyTagFileFilenames(manifest) shouldBe Right(())
+    }
+
+    it("fails a manifest with tag files in subdirectories") {
+      val manifest = TagManifest(
+        checksumAlgorithm = MD5,
+        entries = Map(
+          BagPath("bagit.txt") -> ChecksumValue("123"),
+          BagPath("data/bag-info.txt") -> ChecksumValue("123"),
+          BagPath("tags/metadata.csv") -> ChecksumValue("123"),
+        )
+      )
+
+      val err = verifier.verifyTagFileFilenames(manifest).left.value
+      err.e.getMessage shouldBe "Not all tag files are in the root directory: data/bag-info.txt, tags/metadata.csv"
+      err.userMessage shouldBe Some(
+        "Not all tag files are in the root directory: data/bag-info.txt, tags/metadata.csv"
       )
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyFilenamesTest.scala
@@ -9,29 +9,29 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5}
 
-class VerifyLegalFilenamesTest
+class VerifyFilenamesTest
     extends AnyFunSpec
     with Matchers
     with EitherValues {
-  val verifier: VerifyLegalFilenames =
-    new VerifyLegalFilenames {}
+  val verifier: VerifyFilenames =
+    new VerifyFilenames {}
 
-  describe("verifyLegalFilenames") {
+  describe("verifyAllowedFilenames") {
     it("allows legal filenames") {
-      verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(
+      verifier.verifyAllowedFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(
         ()
       )
     }
 
     it("flags a file with a trailing dot") {
-      val err = verifier.verifyLegalFilenames(Seq("bad.jpg.")).left.value
+      val err = verifier.verifyAllowedFilenames(Seq("bad.jpg.")).left.value
       err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg."
       err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg.")
     }
 
     it("flags multiple files with a trailing dot") {
       val err = verifier
-        .verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif"))
+        .verifyAllowedFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif"))
         .left
         .value
       err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
@@ -11,26 +11,28 @@ class VerifyLegalFilenamesTest
   val verifier: VerifyLegalFilenames =
     new VerifyLegalFilenames {}
 
-  it("allows legal filenames") {
-    verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(
-      ()
-    )
-  }
+  describe("verifyLegalFilenames") {
+    it("allows legal filenames") {
+      verifier.verifyLegalFilenames(Seq("cat.jpg", "dog.png", "fish.gif")) shouldBe Right(
+        ()
+      )
+    }
 
-  it("flags a file with a trailing dot") {
-    val err = verifier.verifyLegalFilenames(Seq("bad.jpg.")).left.value
-    err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg."
-    err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg.")
-  }
+    it("flags a file with a trailing dot") {
+      val err = verifier.verifyLegalFilenames(Seq("bad.jpg.")).left.value
+      err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg."
+      err.userMessage shouldBe Some("Filenames cannot end with a .: bad.jpg.")
+    }
 
-  it("flags multiple files with a trailing dot") {
-    val err = verifier
-      .verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif"))
-      .left
-      .value
-    err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."
-    err.userMessage shouldBe Some(
-      "Filenames cannot end with a .: bad.jpg., alsobad.png."
-    )
+    it("flags multiple files with a trailing dot") {
+      val err = verifier
+        .verifyLegalFilenames(Seq("bad.jpg.", "alsobad.png.", "good.tif"))
+        .left
+        .value
+      err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."
+      err.userMessage shouldBe Some(
+        "Filenames cannot end with a .: bad.jpg., alsobad.png."
+      )
+    }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/verify/steps/VerifyLegalFilenamesTest.scala
@@ -3,6 +3,11 @@ package uk.ac.wellcome.platform.archive.bagverifier.verify.steps
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagPath,
+  PayloadManifest
+}
+import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5}
 
 class VerifyLegalFilenamesTest
     extends AnyFunSpec
@@ -32,6 +37,48 @@ class VerifyLegalFilenamesTest
       err.e.getMessage shouldBe "Filenames cannot end with a .: bad.jpg., alsobad.png."
       err.userMessage shouldBe Some(
         "Filenames cannot end with a .: bad.jpg., alsobad.png."
+      )
+    }
+  }
+
+  describe("verifyPayloadFilenames") {
+    it("allows filenames that start with data/") {
+      val manifest = PayloadManifest(
+        checksumAlgorithm = MD5,
+        entries = Map(
+          BagPath("data/README.txt") -> ChecksumValue("123"),
+          BagPath("data/animals/cat.jpg") -> ChecksumValue("123"),
+          BagPath("data/animals/dog.png") -> ChecksumValue("123"),
+        )
+      )
+
+      verifier.verifyPayloadFilenames(manifest) shouldBe Right(())
+    }
+
+    it("allows an empty manifest") {
+      val manifest = PayloadManifest(
+        checksumAlgorithm = MD5,
+        entries = Map.empty
+      )
+
+      verifier.verifyPayloadFilenames(manifest) shouldBe Right(())
+    }
+
+    it("fails a manifest with filenames outside data/") {
+      val manifest = PayloadManifest(
+        checksumAlgorithm = MD5,
+        entries = Map(
+          BagPath("data/README.txt") -> ChecksumValue("123"),
+          BagPath("data/animals/cat.jpg") -> ChecksumValue("123"),
+          BagPath("dog.png") -> ChecksumValue("123"),
+          BagPath("tags/metadata.csv") -> ChecksumValue("123"),
+        )
+      )
+
+      val err = verifier.verifyPayloadFilenames(manifest).left.value
+      err.e.getMessage shouldBe "Not all payload files are in the data/ directory: dog.png, tags/metadata.csv"
+      err.userMessage shouldBe Some(
+        "Not all payload files are in the data/ directory: dog.png, tags/metadata.csv"
       )
     }
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilder.scala
@@ -98,14 +98,16 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
       space = space,
       externalIdentifier = externalIdentifier,
       version = version,
-      payloadFileCount = payloadFileCount - fetchEntryCount
+      payloadFileCount = payloadFileCount - fetchEntryCount,
+      isFetch = false
     )
 
     val fetchEntries = createPayloadFiles(
       space = space,
       externalIdentifier = externalIdentifier,
       version = version.copy(underlying = version.underlying - 1),
-      payloadFileCount = fetchEntryCount
+      payloadFileCount = fetchEntryCount,
+      isFetch = true
     )
 
     val payloadManifest =
@@ -285,11 +287,12 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
     // This mimics the structure of bags stored by the replicator
     s"$space/$externalIdentifier/$version"
 
-  private def createPayloadFiles(
+  protected def createPayloadFiles(
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
     version: BagVersion,
-    payloadFileCount: Int
+    payloadFileCount: Int,
+    isFetch: Boolean
   ): Seq[PayloadEntry] = {
     val bagRoot = createBagRootPath(space, externalIdentifier, version)
 


### PR DESCRIPTION
Second part of https://github.com/wellcomecollection/platform/issues/4931, follows #807 

I think all our bags already follow these two rules. The "data/" rule is required by the BagIt spec and one we've not been rigidly enforcing; tag files in the root is a convention we've adopted that we should discuss if we ever want to break (rather than letting it slip through quietly).