### PR TITLE
Update scala-libs to v25.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  lazy val defaultVersion = "25.0.2"
+  lazy val defaultVersion = "25.1.0"
 
   lazy val versions = new {
     val fixtures = defaultVersion


### PR DESCRIPTION
Some slightly better logging from SQSStream, and removing some deprecated EnrichConfig methods which shouldn't have an effect.