### PR TITLE
Bump to scala-libs 26.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  lazy val defaultVersion = "26.0.2"
+  lazy val defaultVersion = "26.2.0"
 
   lazy val versions = new {
     val fixtures = defaultVersion


### PR DESCRIPTION
This will roll back the AWS SDK updates, which have completely hosed the staging service.