### PR TITLE
Return a 404, not a 500 if somebody looks up an invalid external ID

### DIFF
--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -131,8 +131,7 @@ trait BagsApi
                 NotFound -> UserErrorResponse(
                   context = contextURL,
                   statusCode = StatusCodes.NotFound,
-                  description =
-                    s"Storage manifest $space/$remaining not found"
+                  description = s"Storage manifest $space/$remaining not found"
                 )
               )
           }

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -1,14 +1,18 @@
 package uk.ac.wellcome.platform.storage.bags.api
 
+import akka.http.scaladsl.model.StatusCodes.NotFound
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagId,
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.http.LookupExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.http.models.UserErrorResponse
 import uk.ac.wellcome.platform.archive.common.storage.LargeResponses
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.storage.bags.api.responses.{
@@ -18,6 +22,7 @@ import uk.ac.wellcome.platform.storage.bags.api.responses.{
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 
 trait BagsApi
     extends LargeResponses
@@ -35,74 +40,101 @@ trait BagsApi
       // slash appended!
       //
       pathSuffix("versions" /) {
-        path(Segment / Remaining) { (space, remaining) =>
-          val bagId = BagId(
-            space = StorageSpace(space),
-            externalIdentifier = decodeExternalIdentifier(remaining)
-          )
+        path(Segment / Remaining) {
+          (space, remaining) =>
+            get {
+              Try { decodeExternalIdentifier(remaining) } match {
+                case Success(externalIdentifier) =>
+                  val bagId = BagId(
+                    space = StorageSpace(space),
+                    externalIdentifier = externalIdentifier
+                  )
 
-          get {
-            parameter('before.as[String] ?) { maybeBefore =>
-              withFuture {
-                lookupVersions(
-                  bagId = bagId,
-                  maybeBeforeString = maybeBefore
-                )
+                  parameter('before.as[String] ?) { maybeBefore =>
+                    withFuture {
+                      lookupVersions(
+                        bagId = bagId,
+                        maybeBeforeString = maybeBefore
+                      )
+                    }
+                  }
+
+                case Failure(_) =>
+                  complete(
+                    NotFound -> UserErrorResponse(
+                      context = contextURL,
+                      statusCode = StatusCodes.NotFound,
+                      description =
+                        s"No storage manifest versions found for $space/$remaining"
+                    )
+                  )
               }
             }
-          }
         }
       },
       // Look up a single manifest.
       path(Segment / Remaining) { (space, remaining) =>
-        val bagId = BagId(
-          space = StorageSpace(space),
-          externalIdentifier = decodeExternalIdentifier(remaining)
-        )
-
-        val chemistAndDruggist = BagId(
-          space = StorageSpace("digitised"),
-          externalIdentifier = ExternalIdentifier("b19974760")
-        )
-
         get {
-          // This is some special casing to handle Chemist & Druggist, which
-          // is enormous.  If somebody tries to retrieve it, direct them straight
-          // to the cached response.
-          //
-          // We should fix the bags API so retrieving this API doesn't cause the
-          // app to run out of heap space/memory.
-          //
-          // See https://github.com/wellcomecollection/platform/issues/4549
-          bagId match {
-            case id if id == chemistAndDruggist =>
-              val url = s3Uploader
-                .getPresignedGetURL(
-                  location = S3ObjectLocation(
-                    bucket =
-                      "wellcomecollection-storage-prod-large-response-cache",
-                    key = "responses/digitised/b19974760/v1"
-                  ),
-                  expiryLength = 1 days
-                )
-                .right
-                .get
+          Try { decodeExternalIdentifier(remaining) } match {
+            case Success(externalIdentifier) =>
+              val bagId = BagId(
+                space = StorageSpace(space),
+                externalIdentifier = externalIdentifier
+              )
 
+              val chemistAndDruggist = BagId(
+                space = StorageSpace("digitised"),
+                externalIdentifier = ExternalIdentifier("b19974760")
+              )
+
+              // This is some special casing to handle Chemist & Druggist, which
+              // is enormous.  If somebody tries to retrieve it, direct them straight
+              // to the cached response.
+              //
+              // We should fix the bags API so retrieving this API doesn't cause the
+              // app to run out of heap space/memory.
+              //
+              // See https://github.com/wellcomecollection/platform/issues/4549
+              bagId match {
+                case id if id == chemistAndDruggist =>
+                  val url = s3Uploader
+                    .getPresignedGetURL(
+                      location = S3ObjectLocation(
+                        bucket =
+                          "wellcomecollection-storage-prod-large-response-cache",
+                        key = "responses/digitised/b19974760/v1"
+                      ),
+                      expiryLength = 1 days
+                    )
+                    .right
+                    .get
+
+                  complete(
+                    HttpResponse(
+                      status = StatusCodes.TemporaryRedirect,
+                      headers = Location(url.toExternalForm) :: Nil
+                    )
+                  )
+                case _ =>
+                  parameter('version.as[String] ?) { maybeVersionString =>
+                    withFuture {
+                      lookupBag(
+                        bagId = bagId,
+                        maybeVersionString = maybeVersionString
+                      )
+                    }
+                  }
+              }
+
+            case Failure(_) =>
               complete(
-                HttpResponse(
-                  status = StatusCodes.TemporaryRedirect,
-                  headers = Location(url.toExternalForm) :: Nil
+                NotFound -> UserErrorResponse(
+                  context = contextURL,
+                  statusCode = StatusCodes.NotFound,
+                  description =
+                    s"Storage manifest $space/$remaining not found"
                 )
               )
-            case _ =>
-              parameter('version.as[String] ?) { maybeVersionString =>
-                withFuture {
-                  lookupBag(
-                    bagId = bagId,
-                    maybeVersionString = maybeVersionString
-                  )
-                }
-              }
           }
         }
       }

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -373,6 +373,24 @@ class LookupBagApiTest
           }
       }
     }
+
+    it("if you look up an 'invalid' external identifier") {
+      val bagId = s"space/a.b"
+
+      withConfiguredApp() {
+        case (_, metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/bags/$bagId") { response =>
+            assertIsUserErrorResponse(
+              response,
+              description = s"Storage manifest $bagId not found",
+              statusCode = StatusCodes.NotFound,
+              label = "Not Found"
+            )
+
+            assertMetricSent(metrics, result = HttpMetricResults.UserError)
+          }
+      }
+    }
   }
 
   it("returns a 500 error if looking up the bag fails") {

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
@@ -296,6 +296,24 @@ class LookupBagVersionsApiTest
     }
   }
 
+  it("returns a 404 if you look up an 'invalid' external identifier") {
+    val bagId = s"space/a.b"
+
+    withConfiguredApp() {
+      case (_, metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/bags/$bagId/versions") { response =>
+          assertIsUserErrorResponse(
+            response,
+            description = s"No storage manifest versions found for $bagId",
+            statusCode = StatusCodes.NotFound,
+            label = "Not Found"
+          )
+
+          assertMetricSent(metrics, result = HttpMetricResults.UserError)
+        }
+    }
+  }
+
   it("returns a 500 if looking up the lists of versions fails") {
     withBrokenApp {
       case (metrics, baseUrl) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/LookupExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/LookupExternalIdentifier.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.common.http
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 
 trait LookupExternalIdentifier {


### PR DESCRIPTION
We throw an IllegalArgumentException if you try to look up a bag with an external identifier that doesn't match our internal rules -- but these rules aren't part of the storage service spec, and we should 404 rather than returning a 500 error.

I've only done this in the public-facing API – you should never get as far as calling the internal bag tracker API with an invalid external identifier.

Closes https://github.com/wellcomecollection/platform/issues/5049