### PR TITLE
Use the LargeStreamReader to increase reliability a little further

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/FixityChecker.scala
@@ -169,6 +169,17 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         )
 
       case None =>
+        // Note: it is possible for something to go wrong *after* we open
+        // the input stream, e.g. if the stream gets interrupted.
+        //
+        // This may be a retryable error -- e.g. a timeout -- and we could
+        // do some retrying, rather than failing the entire ingest.
+        //
+        // In practice, those errors are extremely rare, and using the chunked
+        // stream readers (see https://github.com/wellcomecollection/storage-service/pull/825)
+        // should make them even rarer.  This is an obvious place to add more
+        // retrying logic if it looks like we need it, but I'm not going to
+        // futz with code that works almost perfectly already. ~ AWLC, 31 March 2021
         openInputStream(expectedFileFixity, location) match {
           case Left(err) => Left(err)
           case Right(inputStream) =>

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -48,6 +48,10 @@ object AzureFixityChecker {
     //      java.util.concurrent.TimeoutException: Did not observe any item or terminal
     //      signal within 60000ms in 'map' (and no fallback has been configured))
     //
+    // Note: in hindsight, this may have been less to do with Azure, and more to do with
+    // the constrained bandwidth on the NAT instance we were using to talk to Azure when
+    // we did the initial migration.  The managed NAT Gateway has more capacity.
+    //
     // I had the idea to shrink the size of the buffer by looking at AzCopy, a utility
     // for downloading large blobs from Azure… as files.  The actual download code seems
     // to be in the Azure Blob Storage library for Go.  It downloads blobs 4MB at a time.

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.archive.bagverifier.fixity.azure
 
 import java.net.URI
 import com.azure.storage.blob.BlobServiceClient
+import org.apache.commons.io.FileUtils
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.{
   ExpectedFileFixity,
@@ -61,7 +62,7 @@ object AzureFixityChecker {
     // not by much.
     //
     // This bufferSize has successfully verified a blob which was 166 GiB in size.
-    val streamReader = AzureLargeStreamReader(bufferSize = 16 * 1024 * 1024) // 16 MB
+    val streamReader = AzureLargeStreamReader(bufferSize = 16 * FileUtils.ONE_MB)
 
     val sizeFinder = new AzureSizeFinder()
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/azure/AzureFixityChecker.scala
@@ -62,7 +62,9 @@ object AzureFixityChecker {
     // not by much.
     //
     // This bufferSize has successfully verified a blob which was 166 GiB in size.
-    val streamReader = AzureLargeStreamReader(bufferSize = 16 * FileUtils.ONE_MB)
+    val streamReader = AzureLargeStreamReader(
+      bufferSize = 16 * FileUtils.ONE_MB
+    )
 
     val sizeFinder = new AzureSizeFinder()
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -4,14 +4,14 @@ import java.net.URI
 
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
+import org.apache.commons.io.FileUtils
 import uk.ac.wellcome.platform.archive.bagverifier.fixity.FixityChecker
 import uk.ac.wellcome.platform.archive.bagverifier.storage.Locatable
 import uk.ac.wellcome.platform.archive.bagverifier.storage.s3.S3Locatable
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.services.SizeFinder
-import uk.ac.wellcome.storage.services.s3.S3SizeFinder
+import uk.ac.wellcome.storage.services.s3.{S3LargeStreamReader, S3SizeFinder}
 import uk.ac.wellcome.storage.store
-import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage.tags.Tags
 import uk.ac.wellcome.storage.tags.s3.S3Tags
@@ -26,7 +26,7 @@ class S3FixityChecker(
 
 object S3FixityChecker {
   def apply()(implicit s3Client: AmazonS3) = {
-    val streamReader = new S3StreamStore()
+    val streamReader = new S3LargeStreamReader(bufferSize = 128 * FileUtils.ONE_MB)
     val sizeFinder = new S3SizeFinder()
     val tags = new S3Tags()
     val locator = S3Locatable.s3UriLocatable

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/fixity/s3/S3FixityChecker.scala
@@ -26,7 +26,9 @@ class S3FixityChecker(
 
 object S3FixityChecker {
   def apply()(implicit s3Client: AmazonS3) = {
-    val streamReader = new S3LargeStreamReader(bufferSize = 128 * FileUtils.ONE_MB)
+    val streamReader = new S3LargeStreamReader(
+      bufferSize = 128 * FileUtils.ONE_MB
+    )
     val sizeFinder = new S3SizeFinder()
     val tags = new S3Tags()
     val locator = S3Locatable.s3UriLocatable


### PR DESCRIPTION
Last night, we had a failure in one of the S3 bag verifiers because the connection timed out midway through reading an object. The object in question was multiple gigabytes in size (an MXF file).

This patch is my attempt to make this sort of failure less likely in future.

---

A quick refresher:

A timeout when reading an object isn't an uncommon failure mode: the larger the file, the longer you need to hold the screen open, the higher the risk of something dropping in the middle. To get around this in the bag _unpacker_, we divide large objects into smaller pieces, and then stitch the pieces back together in memory. Additionally, we read all the bytes for each piece immediately, so we're not holding a connection open for a long time. We also have retry logic around reading each piece.

I have a blog post about this: https://alexwlchan.net/2019/09/streaming-large-s3-objects/ and you can see our current implementation here: https://github.com/wellcomecollection/scala-libs/blob/master/storage/src/main/scala/uk/ac/wellcome/storage/services/LargeStreamReader.scala

We already use this "break the object into smaller pieces" reader for the Azure verifier, but we never went back and added it to S3. This reader should be a direct drop-in for the "read it all in one go" that we were previously using, but hopefully a bit more reliable.

---

The "more correct" fix would be to modify the verifier so that it spots a retryable error midway through reading an object, and doesn't fail the entire ingest. I've added a comment in the rough code location where we'd add this, but I'm not going to do it today. This code already works pretty well, and adding even more retry logic would be a lot of work for very marginal gain.