### PR TITLE
Lifecycle TIFFs to Glacier storage

### DIFF
--- a/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
+++ b/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
@@ -16,6 +16,15 @@ object TagRules {
   ): Map[StorageManifestFile, Map[String, String]] =
     createContentTypeTags(manifest)
 
+  /** Create tags of the form Map("Content-Type" -> [MIME type])
+    *
+    * Our tags are based on the official list of MIME types from
+    * http://www.iana.org/assignments/media-types/media-types.xhtml
+    *
+    * We prefer to tag with MIME types because these are standardised tags
+    * that might be useful elsewhere, rather than inventing an unnecessary
+    * tagging scheme solely for the storage service.
+    */
   private def createContentTypeTags(
     manifest: StorageManifest
   ): Map[StorageManifestFile, Map[String, String]] = {
@@ -30,6 +39,14 @@ object TagRules {
         // Services like DLCS will use the MP4 to serve videos on the web.
         case f if manifest.space == StorageSpace("digitised") && f.hasExtension(".mxf") =>
           f -> "application/mxf"
+
+        // In our digitised manuscripts workflow, we keep both the original TIFF
+        // and the edited JP2 from LayoutWizzard.
+        //
+        // We apply a Content-Type tag so the TIFF can be lifecycled to a
+        // cold storage tier, because DLCS will use the JP2 to serve images on the web.
+        case f if manifest.space == StorageSpace("digitised") && f.hasExtension(".tif", ".tiff") =>
+          f -> "image/tiff"
       }
 
     contentTypes
@@ -38,10 +55,13 @@ object TagRules {
   }
 
   implicit class FileOps(f: StorageManifestFile) {
-    def hasExtension(ext: String): Boolean = {
-      assert(ext.startsWith("."))
-      assert(ext.toLowerCase == ext)
-      f.path.toLowerCase.endsWith(ext )
+    def hasExtension(exts: String*): Boolean = {
+      exts.foreach { e =>
+        assert(e.startsWith("."))
+        assert(e.toLowerCase == e)
+      }
+
+      exts.exists(f.path.toLowerCase.endsWith)
     }
   }
 }

--- a/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
+++ b/bag_tagger/src/main/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRules.scala
@@ -37,7 +37,10 @@ object TagRules {
         // We apply a Content-Type tag so the MXF can be lifecycled to a
         // cold storage tier, because we don't need immediate access to it.
         // Services like DLCS will use the MP4 to serve videos on the web.
-        case f if manifest.space == StorageSpace("digitised") && f.hasExtension(".mxf") =>
+        case f
+            if manifest.space == StorageSpace("digitised") && f.hasExtension(
+              ".mxf"
+            ) =>
           f -> "application/mxf"
 
         // In our digitised manuscripts workflow, we keep both the original TIFF
@@ -45,13 +48,17 @@ object TagRules {
         //
         // We apply a Content-Type tag so the TIFF can be lifecycled to a
         // cold storage tier, because DLCS will use the JP2 to serve images on the web.
-        case f if manifest.space == StorageSpace("digitised") && f.hasExtension(".tif", ".tiff") =>
+        case f
+            if manifest.space == StorageSpace("digitised") && f.hasExtension(
+              ".tif",
+              ".tiff"
+            ) =>
           f -> "image/tiff"
       }
 
-    contentTypes
-      .map { case (f, contentType) => f -> Map("Content-Type" -> contentType) }
-      .toMap
+    contentTypes.map {
+      case (f, contentType) => f -> Map("Content-Type" -> contentType)
+    }.toMap
   }
 
   implicit class FileOps(f: StorageManifestFile) {

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/BagTaggerFeatureTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/BagTaggerFeatureTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.storage.bag_tagger
 
-import org.scalatest.concurrent.Eventually
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
@@ -17,7 +16,6 @@ import uk.ac.wellcome.storage.tags.s3.S3Tags
 class BagTaggerFeatureTest
     extends AnyFunSpec
     with BagTaggerFixtures
-    with Eventually
     with Matchers
     with StorageManifestGenerators {
 

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/fixtures/BagTaggerFixtures.scala
@@ -2,9 +2,7 @@ package uk.ac.wellcome.platform.storage.bag_tagger.fixtures
 
 import io.circe.Decoder
 import org.scalatest.Suite
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
@@ -24,14 +22,11 @@ import uk.ac.wellcome.platform.storage.bag_tagger.services.{
   BagTaggerWorker,
   TagRules
 }
-import uk.ac.wellcome.storage.fixtures.{AzureFixtures, S3Fixtures}
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
 
 trait BagTaggerFixtures
     extends OperationFixtures
-    with Akka
-    with SQS
     with S3Fixtures
-    with AzureFixtures
     with BagTrackerFixtures
     with StorageManifestDaoFixture
     with AlpakkaSQSWorkerFixtures { this: Suite =>

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
@@ -75,7 +75,8 @@ class TagRulesTest
       }
 
       it("for TIFFs that use two 'f's in the extension") {
-        val tiffFile = createStorageManifestFileWith(name = "b1842700_0001.tiff")
+        val tiffFile =
+          createStorageManifestFileWith(name = "b1842700_0001.tiff")
 
         val manifest = createStorageManifestWith(
           space = StorageSpace("digitised"),

--- a/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
+++ b/bag_tagger/src/test/scala/uk/ac/wellcome/platform/storage/bag_tagger/services/TagRulesTest.scala
@@ -58,4 +58,67 @@ class TagRulesTest
       }
     }
   }
+
+  describe("Content-Type=application/tif for TIFF manuscripts masters") {
+    describe("it applies a tag") {
+      it("for TIFFs in the digitised space") {
+        val tifFile = createStorageManifestFileWith(name = "b1842700_0001.tif")
+
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(tifFile)
+        )
+
+        TagRules.chooseTags(manifest) shouldBe Map(
+          tifFile -> Map("Content-Type" -> "image/tiff")
+        )
+      }
+
+      it("for TIFFs that use two 'f's in the extension") {
+        val tiffFile = createStorageManifestFileWith(name = "b1842700_0001.tiff")
+
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(tiffFile)
+        )
+
+        TagRules.chooseTags(manifest) shouldBe Map(
+          tiffFile -> Map("Content-Type" -> "image/tiff")
+        )
+      }
+
+      it("whose file extension is uppercase") {
+        val tifFile = createStorageManifestFileWith(name = "b1842700_0001.TIF")
+
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(tifFile)
+        )
+
+        TagRules.chooseTags(manifest) shouldBe Map(
+          tifFile -> Map("Content-Type" -> "image/tiff")
+        )
+      }
+    }
+
+    describe("it does not apply a tag") {
+      it("to non-TIFF files") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("digitised"),
+          files = Seq(createStorageManifestFileWith(name = "b1842700_0001.jp2"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe empty
+      }
+
+      it("to TIFF files outside the digitised space") {
+        val manifest = createStorageManifestWith(
+          space = StorageSpace("born-digital"),
+          files = Seq(createStorageManifestFileWith(name = "330-19_19a.tif"))
+        )
+
+        TagRules.chooseTags(manifest) shouldBe empty
+      }
+    }
+  }
 }

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -58,6 +58,24 @@ resource "aws_s3_bucket" "replica_primary" {
     }
   }
 
+  # See comment in TagRules.scala -- this is about moving high-resolution
+  # TIFFs in our manuscripts workflow to Glacier.
+  lifecycle_rule {
+    id      = "move_digitised_tif_to_glacier"
+    enabled = true
+
+    prefix = "digitised/"
+
+    tags = {
+      "Content-Type" = "image/tiff"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+
   tags = var.tags
 }
 

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -20,6 +20,8 @@ resource "aws_s3_bucket" "replica_primary" {
     id      = "move_mxf_objects_to_glacier"
     enabled = true
 
+    prefix = "digitised/"
+
     tags = {
       "Content-Type" = "application/mxf"
     }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5124

Quick recap for those unfamiliar with this feature:

The **bag tagger** gets a notification when a bag is successfully stored in the storage service – similar to the METS adapter in the catalogue.

It looks through all the files in the bag, and it decides whether to add [tags to the S3 objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html). (We don't currently apply tags to objects in Azure, because [their tagging implementation was added after we did the Azure work](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-index-how-to?tabs=azure-portal).) We use those tags to trigger S3 lifecycle rules, in particular to cycle large preservation files to Glacier, with access copies staying in Standard-IA.

Previously we were only lifecycling MXFs from the A/V workflow; now we're lifecycling TIFFs as well.

See https://stacks.wellcomecollection.org/large-things-living-in-cold-places-66cbc3603e14 for more explanation of the “why” of this feature.

The Terraform change is deployed (although will do nothing; we don't have any files tagged like this yet). It was a quick change, and I've tidied up TagRules so it should be easier to add more rules like this in the future.