### PR TITLE
Bring the infra Terraform in line with what's actually deployed

### DIFF
--- a/terraform/infra/.terraform.lock.hcl
+++ b/terraform/infra/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.34.0"
+  constraints = "2.34.0"
+  hashes = [
+    "h1:X2iF3h9Xw5U9MI2ALxTupe/9delr6EGm+OhhboU6jxM=",
+  ]
+}

--- a/terraform/infra/dynamo_deleted_bags.tf
+++ b/terraform/infra/dynamo_deleted_bags.tf
@@ -1,0 +1,22 @@
+resource "aws_dynamodb_table" "deleted_bags" {
+  name           = "deleted_bags"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "ingest_id"
+
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "ingest_id"
+    type = "S"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
+  }
+}

--- a/terraform/infra/provider.tf
+++ b/terraform/infra/provider.tf
@@ -10,6 +10,5 @@ provider "aws" {
     role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
-  region  = var.aws_region
-  version = "2.34.0"
+  region = var.aws_region
 }

--- a/terraform/infra/s3_infra.tf
+++ b/terraform/infra/s3_infra.tf
@@ -10,6 +10,28 @@ resource "aws_s3_bucket" "infra" {
     enabled = true
   }
 
+  # Objects in tmp/ should be deleted
+  lifecycle_rule {
+    id      = "expire_tmp"
+    enabled = true
+
+    prefix = "tmp/"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
   # We use S3 Inventory to write an inventory for our storage buckets to the
   # infra bucket.  We don't need to keep inventories forever, so delete them
   # after 90 days.

--- a/terraform/infra/s3_infra.tf
+++ b/terraform/infra/s3_infra.tf
@@ -55,7 +55,7 @@ resource "aws_s3_bucket" "infra" {
       days = 90
     }
   }
-  
+
   lifecycle_rule {
     id = "expire_noncurrent_versions"
 

--- a/terraform/infra/s3_infra.tf
+++ b/terraform/infra/s3_infra.tf
@@ -55,6 +55,20 @@ resource "aws_s3_bucket" "infra" {
       days = 90
     }
   }
+  
+  lifecycle_rule {
+    id = "expire_noncurrent_versions"
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+
+    enabled = true
+  }
 
   tags = local.default_tags
 }


### PR DESCRIPTION
Turns out I added a couple of lifecycle rules in a PR that never got merged, so if you'd planned/applied Terraform as in master, you'd undo the rules and delete the table that records all the deleted bags. Oops!