### PR TITLE
Only import boto3 when it's required

### DIFF
--- a/python_client/CHANGELOG.md
+++ b/python_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.3.3 - 2021-04-26
+
+You no longer need to install boto3 if you're not using the `prod_client()` and `staging_client()` helpers.
+
 ## v2.3.0 / v2.3.1 / v2.3.2 - 2021-03-15
 
 This adds two helpers `prod_client()` and `staging_client()` for getting prebuilt clients that pull credentials from Secrets Manager.

--- a/python_client/src/wellcome_storage_service/secrets.py
+++ b/python_client/src/wellcome_storage_service/secrets.py
@@ -2,6 +2,7 @@
 Fetches credentials for the dev client from Secrets Manager.
 """
 
+
 def get_session():
     """
     Creates a boto3 Session with the storage-developer role.

--- a/python_client/src/wellcome_storage_service/secrets.py
+++ b/python_client/src/wellcome_storage_service/secrets.py
@@ -2,13 +2,12 @@
 Fetches credentials for the dev client from Secrets Manager.
 """
 
-import boto3
-
-
 def get_session():
     """
     Creates a boto3 Session with the storage-developer role.
     """
+    import boto3
+
     role_arn = "arn:aws:iam::975596993436:role/storage-developer"
     sts_client = boto3.client("sts")
     assumed_role_object = sts_client.assume_role(

--- a/python_client/src/wellcome_storage_service/version.py
+++ b/python_client/src/wellcome_storage_service/version.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
-__version_info__ = (2, 3, 2)
+__version_info__ = (2, 3, 3)
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
You can use boto3 to fetch the storage service OAuth secrets from Secrets Manager -- but that's not the only auth mechanism available. You can also get secrets from environment variables, at which point having boto3 installed is unnecessary.

Requiring boto3 was causing particular issues for the ingest inspector, because it has to install all its packages on startup, and boto3 brings in quite a few of its own dependencies.  Allowing us to run the ingest inspector without boto3 should make it start up quite a bit faster.

Fixed while looking at https://github.com/wellcomecollection/platform/issues/5148