### PR TITLE
Apply default tags for TerraformConfigurationURL to everything

### DIFF
--- a/terraform/app_clients/.terraform.lock.hcl
+++ b/terraform/app_clients/.terraform.lock.hcl
@@ -2,19 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.32.0"
+  version = "3.42.0"
   hashes = [
-    "h1:tY5R3hRBB1v8v3MT+ofoCJ/Vz/b/4PXo3xtBKtw7T4A=",
-    "zh:04e4f700c21b1f58e7603638160bd5ad3b85519c35dc75bada3e52b164d06d3e",
-    "zh:09f2338404d4b2d4dcb29781ac59a6955d935745e896d4ee661d83cac8d7c677",
-    "zh:16bdf96d8139268766921d5b891b865f67936190dc302283ba50b94e42510ec5",
-    "zh:1f0eb671390ee41ddf22faf22d00da636e57164214a37c77f7d3fb1f19ea9cce",
-    "zh:3703b0ba118887cb558085f4b7e732e4e374f455221fcf724bada6f71bd25d55",
-    "zh:a344b8b1d0c541abcfc3a5bd22aa28d1a07aff416db753d53219158a86e956cc",
-    "zh:a4798f3bf4ecbdfcd2ea72061e54053423a47f48812749b2cc7dc8dcf8a11eb4",
-    "zh:aeb5c18afe26388748289f2a3819c7c9210cb669efe01b3e28bf542c51c83bd7",
-    "zh:b0a3f5940f76dbd3ea9699f98f9cabc443c210c06f30caeb792e5843b7550cc1",
-    "zh:baa2854e3fbf3df9653a5e6a0f1093a018dad39312346426f4bcefc2ebfd74cc",
-    "zh:e305b3d227f2013ddd7cf22f2cfa4603a55187c8eddd07f980350a828b67ce49",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }

--- a/terraform/app_clients/provider.tf
+++ b/terraform/app_clients/provider.tf
@@ -9,6 +9,10 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 
+  default_tags {
+    tags = local.default_tags
+  }
+
   region = "eu-west-1"
 }
 
@@ -20,6 +24,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -27,6 +35,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 
   region = "eu-west-1"
@@ -37,6 +49,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::975596993436:role/storage-developer"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 
   region = "eu-west-1"

--- a/terraform/critical_prod/.terraform.lock.hcl
+++ b/terraform/critical_prod/.terraform.lock.hcl
@@ -2,22 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.34.0"
-  constraints = "2.34.0"
+  version = "3.42.0"
   hashes = [
-    "h1:X2iF3h9Xw5U9MI2ALxTupe/9delr6EGm+OhhboU6jxM=",
-    "zh:129b8c715e36ccf719053affba73b6d6c37f70754b9f527b0afd17447df7468f",
-    "zh:3430572e11456013bb193d85e73334a6340ac26a3c8d7990982e7cae6a7d5619",
-    "zh:3bf4d359b046ecb5e2b9cfb3588d88da622542f1bf68dc9089c2f84f714b5190",
-    "zh:3ff70bf04dc802ace720db899339c46091b66f4518ced6e0ea130fedebd3eafb",
-    "zh:65f7d43ec2c6aabbb137eb476fa8d316c4eb9676da67f072f4a25c4e3e1ad1bd",
-    "zh:a0b73e1d438602203553ab9397f40d0db32711f35a0f76bd1f72d40ba239f8b8",
-    "zh:a895d70e98f775269aa3e16a43555cfd3826c2e8d18b83b70a527d7e1a43adcd",
-    "zh:bf5d7e8aaa120d8ab99236bfdbb3a1b31a59408afd14f0d5ff1f059c3d126cf8",
-    "zh:d50418cadbcf10cfd9b57a482417b3cb55381d83d15930fcb8d9bd4e8ec98a2e",
-    "zh:dcec0c2329771b7caad0ac9be85a4766d62f0d29e157ae5162864ae86bb09cbc",
-    "zh:edc3e17ff796f9a1fce453e61384f04d49a7721b1bd0f29bef7f84b170c072ad",
-    "zh:f95e094c4b4c5cdc97f9b7295801986f397ded582ea9edf0d63072dc966b2a22",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }
 

--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -13,8 +13,6 @@ module "critical" {
 
   inventory_bucket = "wellcomecollection-storage-infra"
 
-  tags = local.default_tags
-
   table_name = "vhs-storage-manifests-2020-07-24"
 
   # This gives us another layer of protection for the S3 buckets.

--- a/terraform/critical_prod/provider.tf
+++ b/terraform/critical_prod/provider.tf
@@ -9,6 +9,10 @@ provider "aws" {
     role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
+  default_tags {
+    tags = local.default_tags
+  }
+
   region = var.aws_region
 }
 

--- a/terraform/critical_staging/.terraform.lock.hcl
+++ b/terraform/critical_staging/.terraform.lock.hcl
@@ -2,10 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.34.0"
-  constraints = "2.34.0"
+  version = "3.42.0"
   hashes = [
-    "h1:X2iF3h9Xw5U9MI2ALxTupe/9delr6EGm+OhhboU6jxM=",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }
 

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -13,8 +13,6 @@ module "critical" {
 
   inventory_bucket = "wellcomecollection-storage-infra"
 
-  tags = local.default_tags
-
   table_name = "vhs-storage-staging-manifests-2020-07-24"
 
   # The staging service shouldn't be the only copy of any important data, so

--- a/terraform/critical_staging/provider.tf
+++ b/terraform/critical_staging/provider.tf
@@ -9,6 +9,10 @@ provider "aws" {
     role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
+  default_tags {
+    tags = local.default_tags
+  }
+
   region = var.aws_region
 }
 

--- a/terraform/infra/.terraform.lock.hcl
+++ b/terraform/infra/.terraform.lock.hcl
@@ -2,9 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.34.0"
-  constraints = "2.34.0"
+  version = "3.42.0"
   hashes = [
-    "h1:X2iF3h9Xw5U9MI2ALxTupe/9delr6EGm+OhhboU6jxM=",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }

--- a/terraform/infra/ecr.tf
+++ b/terraform/infra/ecr.tf
@@ -1,94 +1,75 @@
 resource "aws_ecr_repository" "bags_api" {
   name = "uk.ac.wellcome/bags_api"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_indexer" {
   name = "uk.ac.wellcome/bag_indexer"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_register" {
   name = "uk.ac.wellcome/bags"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_replicator" {
   name = "uk.ac.wellcome/bag_replicator"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_root_finder" {
   name = "uk.ac.wellcome/bag_root_finder"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_tagger" {
   name = "uk.ac.wellcome/bag_tagger"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_tracker" {
   name = "uk.ac.wellcome/bag_tracker"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_unpacker" {
   name = "uk.ac.wellcome/bag_unpacker"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_verifier" {
   name = "uk.ac.wellcome/bag_verifier"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "bag_versioner" {
   name = "uk.ac.wellcome/bag_versioner"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "ingests_api" {
   name = "uk.ac.wellcome/ingests_api"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "ingests_indexer" {
   name = "uk.ac.wellcome/ingests_indexer"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "ingests_tracker" {
   name = "uk.ac.wellcome/ingests_tracker"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "ingests_worker" {
   name = "uk.ac.wellcome/ingests_worker"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "nginx" {
   name = "uk.ac.wellcome/nginx"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "notifier" {
   name = "uk.ac.wellcome/notifier"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "replica_aggregator" {
   name = "uk.ac.wellcome/replica_aggregator"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "file_finder" {
   name = "uk.ac.wellcome/file_finder"
-  tags = local.default_tags
 }
 
 resource "aws_ecr_repository" "file_indexer" {
   name = "uk.ac.wellcome/file_indexer"
-  tags = local.default_tags
 }

--- a/terraform/infra/endpoints.tf
+++ b/terraform/infra/endpoints.tf
@@ -4,7 +4,5 @@ resource "aws_route53_zone" "internal" {
   vpc {
     vpc_id = local.storage_vpcs["storage_vpc_id"]
   }
-
-  tags = local.default_tags
 }
 

--- a/terraform/infra/provider.tf
+++ b/terraform/infra/provider.tf
@@ -10,5 +10,9 @@ provider "aws" {
     role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
+  default_tags {
+    tags = local.default_tags
+  }
+
   region = var.aws_region
 }

--- a/terraform/infra/s3_infra.tf
+++ b/terraform/infra/s3_infra.tf
@@ -69,8 +69,6 @@ resource "aws_s3_bucket" "infra" {
 
     enabled = true
   }
-
-  tags = local.default_tags
 }
 
 data "aws_iam_policy_document" "infra_bucket_policy" {

--- a/terraform/modules/critical/dynamo_ingests.tf
+++ b/terraform/modules/critical/dynamo_ingests.tf
@@ -19,6 +19,4 @@ resource "aws_dynamodb_table" "ingests" {
       write_capacity,
     ]
   }
-
-  tags = var.tags
 }

--- a/terraform/modules/critical/dynamo_replicas.tf
+++ b/terraform/modules/critical/dynamo_replicas.tf
@@ -8,6 +8,4 @@ resource "aws_dynamodb_table" "replicas_table" {
     name = "id"
     type = "S"
   }
-
-  tags = var.tags
 }

--- a/terraform/modules/critical/dynamo_versions.tf
+++ b/terraform/modules/critical/dynamo_versions.tf
@@ -29,6 +29,4 @@ resource "aws_dynamodb_table" "versioner_versions_table" {
     hash_key        = "ingestId"
     projection_type = "ALL"
   }
-
-  tags = var.tags
 }

--- a/terraform/modules/critical/s3_replica_glacier.tf
+++ b/terraform/modules/critical/s3_replica_glacier.tf
@@ -41,8 +41,6 @@ resource "aws_s3_bucket" "replica_glacier" {
       days = 90
     }
   }
-
-  tags = var.tags
 }
 
 resource "aws_s3_bucket_inventory" "replica_glacier" {

--- a/terraform/modules/critical/s3_replica_primary.tf
+++ b/terraform/modules/critical/s3_replica_primary.tf
@@ -75,8 +75,6 @@ resource "aws_s3_bucket" "replica_primary" {
       storage_class = "GLACIER"
     }
   }
-
-  tags = var.tags
 }
 
 resource "aws_s3_bucket_policy" "replica_primary_read" {

--- a/terraform/modules/critical/s3_static_content.tf
+++ b/terraform/modules/critical/s3_static_content.tf
@@ -1,6 +1,4 @@
 resource "aws_s3_bucket" "static_content" {
   bucket = "wellcomecollection-public-${var.namespace}-static"
   acl    = "private"
-
-  tags = var.tags
 }

--- a/terraform/modules/critical/variables.tf
+++ b/terraform/modules/critical/variables.tf
@@ -18,10 +18,6 @@ variable "inventory_bucket" {
   type = string
 }
 
-variable "tags" {
-  type = map(string)
-}
-
 variable "table_name" {
   type    = string
   default = ""

--- a/terraform/modules/critical/vhs_manifests.tf
+++ b/terraform/modules/critical/vhs_manifests.tf
@@ -2,8 +2,6 @@ module "vhs_manifests" {
   source = "git::github.com/wellcomecollection/terraform-aws-vhs.git//hash-range-store?ref=v3.3.1"
   name   = "${var.namespace}-manifests"
 
-  tags = var.tags
-
   # These prefixes exist for compatibility with older versions of the VHS
   # Terraform module.  Renaming S3 buckets or DynamoDB tables is hard, so
   # we preserve the existing names rather than change them.
@@ -11,4 +9,6 @@ module "vhs_manifests" {
   table_name_prefix  = "vhs-"
 
   table_name = var.table_name
+
+  tags = {}
 }

--- a/terraform/modules/lambda/cloudwatch_log_group.tf
+++ b/terraform/modules/lambda/cloudwatch_log_group.tf
@@ -2,8 +2,6 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
   name = "/aws/lambda/${var.name}"
 
   retention_in_days = 7
-
-  tags = var.tags
 }
 
 resource "aws_iam_role_policy" "cloudwatch_logs" {

--- a/terraform/modules/lambda/lambda_function.tf
+++ b/terraform/modules/lambda/lambda_function.tf
@@ -21,6 +21,4 @@ resource "aws_lambda_function" "lambda_function" {
   environment {
     variables = var.environment
   }
-
-  tags = var.tags
 }

--- a/terraform/modules/lambda/role.tf
+++ b/terraform/modules/lambda/role.tf
@@ -1,7 +1,6 @@
 resource "aws_iam_role" "iam_role" {
   name               = "lambda_${var.name}_iam_role"
   assume_role_policy = data.aws_iam_policy_document.assume_lambda_role.json
-  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "assume_lambda_role" {

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -43,7 +43,3 @@ variable "memory_size" {
   default = 128
   type    = number
 }
-
-variable "tags" {
-  type = map(string)
-}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -22,10 +22,6 @@ variable "release_label" {
   type = string
 }
 
-variable "tags" {
-  type = map(string)
-}
-
 # Network
 
 variable "private_subnets" {

--- a/terraform/monitoring/.terraform.lock.hcl
+++ b/terraform/monitoring/.terraform.lock.hcl
@@ -2,8 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "2.35.0"
+  version = "3.42.0"
   hashes = [
-    "h1:tFahhxnsS/XpP6MzyaPPuLQVDqC0N28OUqnbz2ogdi4=",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
   ]
 }

--- a/terraform/monitoring/end_to_end_test_lambda/cloudwatch_trigger.tf
+++ b/terraform/monitoring/end_to_end_test_lambda/cloudwatch_trigger.tf
@@ -5,8 +5,6 @@
 resource "aws_cloudwatch_event_rule" "every_day_at_9pm" {
   name                = "trigger-${var.name}"
   schedule_expression = "cron(* 21 * * ? *)"
-
-  tags = var.tags
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_trigger" {

--- a/terraform/monitoring/end_to_end_test_lambda/main.tf
+++ b/terraform/monitoring/end_to_end_test_lambda/main.tf
@@ -11,8 +11,6 @@ module "lambda" {
   s3_key    = "lambdas/monitoring/end_to_end_bag_test.zip"
 
   timeout = 15
-
-  tags = var.tags
 }
 
 output "function_name" {

--- a/terraform/monitoring/end_to_end_test_lambda/variables.tf
+++ b/terraform/monitoring/end_to_end_test_lambda/variables.tf
@@ -9,7 +9,3 @@ variable "description" {
 variable "environment" {
   type = map(string)
 }
-
-variable "tags" {
-  type = map(string)
-}

--- a/terraform/monitoring/lambda_daily_reporter.tf
+++ b/terraform/monitoring/lambda_daily_reporter.tf
@@ -8,8 +8,6 @@ module "daily_reporter_lambda" {
   s3_key    = "lambdas/monitoring/daily_reporter.zip"
 
   timeout = 300
-
-  tags = local.default_tags
 }
 
 data "aws_secretsmanager_secret_version" "storage_service_reporter_slack_webhook" {
@@ -75,7 +73,6 @@ resource "aws_iam_role_policy" "allow_reporter_to_upload_to_s3" {
 resource "aws_cloudwatch_event_rule" "every_day_at_6am" {
   name                = "trigger_daily_reporter"
   schedule_expression = "cron(0 6 * * ? *)"
-  tags                = local.default_tags
 }
 
 resource "aws_lambda_permission" "allow_reporter_cloudwatch_trigger" {

--- a/terraform/monitoring/lambda_end_to_end_bag_test.tf
+++ b/terraform/monitoring/lambda_end_to_end_bag_test.tf
@@ -14,8 +14,6 @@ module "end_to_end_bag_tester_stage" {
 
     API_URL = "https://api-stage.wellcomecollection.org/storage/v1"
   }
-
-  tags = local.default_tags
 }
 
 module "end_to_end_bag_tester_prod" {
@@ -34,8 +32,6 @@ module "end_to_end_bag_tester_prod" {
 
     API_URL = "https://api.wellcomecollection.org/storage/v1"
   }
-
-  tags = local.default_tags
 }
 
 # Allow the CI agent running in BuildKite to trigger the Lambda after

--- a/terraform/monitoring/provider.tf
+++ b/terraform/monitoring/provider.tf
@@ -9,6 +9,10 @@ provider "aws" {
     role_arn = "arn:aws:iam::975596993436:role/storage-developer"
   }
 
+  default_tags {
+    tags = local.default_tags
+  }
+
   region = "eu-west-1"
 }
 
@@ -16,6 +20,10 @@ provider "aws" {
   region = "eu-west-1"
 
   alias = "platform"
+
+  default_tags {
+    tags = local.default_tags
+  }
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"

--- a/terraform/stack_prod/.terraform.lock.hcl
+++ b/terraform/stack_prod/.terraform.lock.hcl
@@ -2,9 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.42.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -20,9 +20,5 @@ locals {
 
   workflow_bucket_name                 = "wellcomecollection-workflow-export-bagit"
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
-
-  default_tags = {
-    TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_prod"
-  }
 }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -84,7 +84,5 @@ module "stack_prod" {
 
   archivematica_ingests_bucket             = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
   bag_register_output_subscribe_principals = [local.catalogue_pipeline_account_principal]
-
-  tags = local.default_tags
 }
 

--- a/terraform/stack_prod/provider.tf
+++ b/terraform/stack_prod/provider.tf
@@ -1,9 +1,19 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_prod"
+  }
+}
+
 provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
   region = var.aws_region
+
+  default_tags {
+    tags = local.default_tags
+  }
 
   # Ignore deployment tags on services
   ignore_tags {

--- a/terraform/stack_staging/.terraform.lock.hcl
+++ b/terraform/stack_staging/.terraform.lock.hcl
@@ -2,21 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "2.60.0"
+  version = "3.42.0"
   hashes = [
-    "h1:PoCbcnZB1WsksfrdRdgatkJkAwl8Li/bacLuZQQdZQI=",
-    "zh:0b5072e4f6a2c1ea423907fd974c5c9a7658345f69370537e6d839aff5e1ef7c",
-    "zh:1828dab2ed5526c668960b12b33eae956af7eb4ab53379f84ae2ac15bf9bc504",
-    "zh:23dfc587225ed67a3428662d2be1b6c3ccdd2397128cfbdf521083b0603a70c8",
-    "zh:2c451e2c7ed62c291c8fca08ee1a76fe51619a3c49ad8c4f2e602d90f6586907",
-    "zh:40338be814d380b17c49ec6001a995a53ab91ada657c0f007ac613856cd3234b",
-    "zh:57ea76706a4ed6d615797b0e83b767507c389e9d97722ca53c57922940450500",
-    "zh:59c4c43694ada234bf650b2cff10f54cc19dae4b537338e34666a3a4d3e49d0d",
-    "zh:6d4da4007b097669cba79c799d541c533bb19daa188918cbd65b2521ee3dafa4",
-    "zh:c8f97ff9f92c59f5b0089980cc05065b009598a1f1f3e5da1140a279eb7f062d",
-    "zh:cfb60c98a3d4ced7eef2340ceff67d4d40fd326663e9c05d0f324761b4427db7",
-    "zh:d32bb76fcdd9dea19f7255a7c0d340db4347d37c4dffb47893bef2d74bbf4ab9",
-    "zh:e4d65c8959d8c4275db0c4020a785d524c0a525f84d2c0af8b91c2e8c208bbcd",
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
   ]
 }
 

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -19,8 +19,4 @@ locals {
   workflow_staging_bucket_name = "wellcomecollection-workflow-export-bagit-stage"
 
   archivematica_ingests_bucket = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
-
-  default_tags = {
-    TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_staging"
-  }
 }

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -88,7 +88,5 @@ module "stack_staging" {
   # staging service doesn't make the same guarantees of uptime and this
   # saves us money.
   use_fargate_spot_for_api = true
-
-  tags = local.default_tags
 }
 

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -1,9 +1,19 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_prod"
+  }
+}
+
 provider "aws" {
   assume_role {
-    role_arn = "arn:aws:iam::975596993436:role/storage-developer"
+    role_arn = "arn:aws:iam::975596993436:role/storage-admin"
   }
 
   region = var.aws_region
+
+  default_tags {
+    tags = local.default_tags
+  }
 
   # Ignore deployment tags on services
   ignore_tags {


### PR DESCRIPTION
This makes use of default tags in the AWS Terraform Provider: https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider

Now pretty much everything has a TerraformConfigurationURL tag with minimal effort on my part.