### PR TITLE
Don't count a 404 callback as an unexpected failure in the reporter

### DIFF
--- a/monitoring/daily_reporter/src/ingests.py
+++ b/monitoring/daily_reporter/src/ingests.py
@@ -3,7 +3,9 @@ import datetime
 
 def is_callback_404(description):
     # e.g. Callback failed for: abcd, got 404 Not Found!
-    return description.startswith("Callback failed for:") and description.endswith("got 404 Not Found!")
+    return description.startswith("Callback failed for:") and description.endswith(
+        "got 404 Not Found!"
+    )
 
 
 def get_dev_status(ingest):

--- a/monitoring/daily_reporter/src/ingests.py
+++ b/monitoring/daily_reporter/src/ingests.py
@@ -1,6 +1,11 @@
 import datetime
 
 
+def is_callback_404(description):
+    # e.g. Callback failed for: abcd, got 404 Not Found!
+    return description.startswith("Callback failed for:") and description.endswith("got 404 Not Found!")
+
+
 def get_dev_status(ingest):
     """
     Get an ingest status that reflects whether we need to pay attention to it.
@@ -27,7 +32,7 @@ def get_dev_status(ingest):
         failure_reasons = [
             ev["description"]
             for ev in ingest["events"]
-            if "failed" in ev["description"]
+            if "failed" in ev["description"] and not is_callback_404(ev["description"])
         ]
 
         if failure_reasons and all(


### PR DESCRIPTION
This has been the failures in the last two days – but a 404 callback is (probably) an issue with the user giving us a bad callback URL or letting it expire, not a storage service error.