### PR TITLE
Move the static content bucket to the stack module

### DIFF
--- a/terraform/critical_prod/outputs.tf
+++ b/terraform/critical_prod/outputs.tf
@@ -28,12 +28,6 @@ output "replica_azure_container_name" {
   value = module.critical.replica_azure_container_name
 }
 
-# Static bucket
-
-output "static_content_bucket_name" {
-  value = module.critical.static_content_bucket_name
-}
-
 # Storage manifests VHS
 
 output "vhs_manifests_bucket_name" {

--- a/terraform/critical_staging/outputs.tf
+++ b/terraform/critical_staging/outputs.tf
@@ -28,12 +28,6 @@ output "replica_azure_container_name" {
   value = module.critical.replica_azure_container_name
 }
 
-# Static bucket
-
-output "static_content_bucket_name" {
-  value = module.critical.static_content_bucket_name
-}
-
 # Storage manifests VHS
 
 output "vhs_manifests_bucket_name" {

--- a/terraform/modules/critical/outputs.tf
+++ b/terraform/modules/critical/outputs.tf
@@ -34,10 +34,6 @@ output "ingests_table_arn" {
   value = aws_dynamodb_table.ingests.arn
 }
 
-output "static_content_bucket_name" {
-  value = aws_s3_bucket.static_content.bucket
-}
-
 # Replica buckets
 
 output "replica_primary_bucket_name" {

--- a/terraform/modules/critical/s3_static_content.tf
+++ b/terraform/modules/critical/s3_static_content.tf
@@ -1,4 +1,0 @@
-resource "aws_s3_bucket" "static_content" {
-  bucket = "wellcomecollection-public-${var.namespace}-static"
-  acl    = "private"
-}

--- a/terraform/modules/critical/vhs_manifests.tf
+++ b/terraform/modules/critical/vhs_manifests.tf
@@ -1,14 +1,11 @@
 module "vhs_manifests" {
-  source = "git::github.com/wellcomecollection/terraform-aws-vhs.git//hash-range-store?ref=v3.3.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-vhs.git//multi-version-store?ref=v4.0.5"
   name   = "${var.namespace}-manifests"
 
   # These prefixes exist for compatibility with older versions of the VHS
   # Terraform module.  Renaming S3 buckets or DynamoDB tables is hard, so
   # we preserve the existing names rather than change them.
   bucket_name_prefix = "wellcomecollection-vhs-"
-  table_name_prefix  = "vhs-"
 
   table_name = var.table_name
-
-  tags = {}
 }

--- a/terraform/modules/stack/api/static_objects.tf
+++ b/terraform/modules/stack/api/static_objects.tf
@@ -4,4 +4,3 @@ resource "aws_s3_bucket_object" "context" {
   content = file("${path.module}/context.json")
   etag    = filemd5("${path.module}/context.json")
 }
-

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -769,5 +769,5 @@ module "api" {
     "${var.cognito_storage_api_identifier}/bags",
   ]
 
-  static_content_bucket_name = var.static_content_bucket_name
+  static_content_bucket_name = aws_s3_bucket.static_content.bucket
 }

--- a/terraform/modules/stack/s3_static_content.tf
+++ b/terraform/modules/stack/s3_static_content.tf
@@ -1,0 +1,8 @@
+locals {
+  static_bucket_name = var.namespace == "storage-prod" ? "wellcomecollection-public-storage-static" : "wellcomecollection-public-${var.namespace}-static"
+}
+
+resource "aws_s3_bucket" "static_content" {
+  bucket = local.static_bucket_name
+  acl    = "private"
+}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -69,10 +69,6 @@ variable "azure_container_name" {
   type = string
 }
 
-variable "static_content_bucket_name" {
-  type = string
-}
-
 variable "azure_ssm_parameter_base" {
   type = string
 }

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -33,8 +33,6 @@ module "stack_prod" {
   replica_glacier_bucket_name = data.terraform_remote_state.critical_prod.outputs.replica_glacier_bucket_name
   azure_container_name        = "wellcomecollection-storage-replica-netherlands"
 
-  static_content_bucket_name = data.terraform_remote_state.critical_prod.outputs.static_content_bucket_name
-
   vhs_manifests_bucket_name = data.terraform_remote_state.critical_prod.outputs.vhs_manifests_bucket_name
   vhs_manifests_table_name  = data.terraform_remote_state.critical_prod.outputs.vhs_manifests_table_name
 

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -32,7 +32,6 @@ module "stack_staging" {
   replica_primary_bucket_name = data.terraform_remote_state.critical_staging.outputs.replica_primary_bucket_name
   replica_glacier_bucket_name = data.terraform_remote_state.critical_staging.outputs.replica_glacier_bucket_name
   azure_container_name        = "wellcomecollection-storage-staging-replica-netherlands"
-  static_content_bucket_name  = data.terraform_remote_state.critical_staging.outputs.static_content_bucket_name
 
   vhs_manifests_bucket_name = data.terraform_remote_state.critical_staging.outputs.vhs_manifests_bucket_name
   vhs_manifests_table_name  = data.terraform_remote_state.critical_staging.outputs.vhs_manifests_table_name


### PR DESCRIPTION
This is an optimisation I noticed while looking at https://github.com/wellcomecollection/platform/issues/5206

The static content bucket is very definitely not persistent storage.