### PR TITLE
Pass a list of upload_bucket_arns into the stack module

### DIFF
--- a/terraform/modules/stack/iam_policy_document.tf
+++ b/terraform/modules/stack/iam_policy_document.tf
@@ -101,15 +101,13 @@ data "aws_iam_policy_document" "primary_replica_put_tags" {
   }
 }
 
-data "aws_iam_policy_document" "drop_buckets_readonly" {
+data "aws_iam_policy_document" "upload_buckets_readonly" {
   statement {
     actions = [
       "s3:ListBucket",
     ]
 
-    resources = [
-      "arn:aws:s3:::${var.workflow_bucket_name}",
-    ]
+    resources = var.upload_bucket_arns
   }
 
   statement {
@@ -117,9 +115,7 @@ data "aws_iam_policy_document" "drop_buckets_readonly" {
       "s3:GetObject*",
     ]
 
-    resources = [
-      "arn:aws:s3:::${var.workflow_bucket_name}/*",
-    ]
+    resources = var.upload_bucket_arns
   }
 }
 
@@ -144,18 +140,6 @@ data "aws_iam_policy_document" "s3_large_response_cache" {
     resources = [
       aws_s3_bucket.large_response_cache.arn,
       "${aws_s3_bucket.large_response_cache.arn}/*",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "archivematica_ingests_get" {
-  statement {
-    actions = [
-      "s3:Get*",
-    ]
-
-    resources = [
-      "${var.archivematica_ingests_bucket}/*",
     ]
   }
 }

--- a/terraform/modules/stack/iam_role_policy.tf
+++ b/terraform/modules/stack/iam_role_policy.tf
@@ -142,9 +142,9 @@ resource "aws_iam_role_policy" "bag_verifier_pre_repl_primary_replica_put_tags" 
 
 # bag_unpacker
 
-resource "aws_iam_role_policy" "bag_unpacker_drop_buckets_readonly" {
+resource "aws_iam_role_policy" "bag_unpacker_upload_buckets_readonly" {
   role   = module.bag_unpacker.task_role_name
-  policy = data.aws_iam_policy_document.drop_buckets_readonly.json
+  policy = data.aws_iam_policy_document.upload_buckets_readonly.json
 }
 
 resource "aws_iam_role_policy" "bag_unpacker_unpacked_bags_bucket_readwrite" {
@@ -155,11 +155,6 @@ resource "aws_iam_role_policy" "bag_unpacker_unpacked_bags_bucket_readwrite" {
 resource "aws_iam_role_policy" "bag_unpacker_metrics" {
   role   = module.bag_unpacker.task_role_name
   policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
-resource "aws_iam_role_policy" "bag_unpacker_get_archivematica_ingests" {
-  role   = module.bag_unpacker.task_role_name
-  policy = data.aws_iam_policy_document.archivematica_ingests_get.json
 }
 
 # replica aggregator

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -101,8 +101,16 @@ variable "ingests_table_arn" {
   type = string
 }
 
-variable "workflow_bucket_name" {
-  type = string
+variable "upload_bucket_arns" {
+  description = "ARNs of the S3 buckets where new bags will be uploaded"
+  type        = list(string)
+
+  validation {
+    condition = (
+      length(var.upload_bucket_arns) > 0
+    )
+    error_message = "There must be at least one bucket where you upload bags."
+  }
 }
 
 # versioner table
@@ -116,10 +124,6 @@ variable "versioner_versions_table_name" {
 }
 
 variable "versioner_versions_table_index" {
-  type = string
-}
-
-variable "archivematica_ingests_bucket" {
   type = string
 }
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -18,7 +18,10 @@ locals {
 
   gateway_server_error_alarm_arn = data.terraform_remote_state.infra_shared.outputs.gateway_server_error_alarm_arn
 
-  workflow_bucket_name                 = "wellcomecollection-workflow-export-bagit"
+  # TODO: This value should be exported from the workflow-infra state, not hard-coded
+  workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit"
+  archivematica_ingests_bucket_arn = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
+
   catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
 }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -78,9 +78,11 @@ module "stack_prod" {
     es_password = "prod/indexer/files/es_password"
   }
 
-  workflow_bucket_name = local.workflow_bucket_name
+  upload_bucket_arns = [
+    local.workflow_bucket_arn,
+    local.archivematica_ingests_bucket_arn,
+  ]
 
-  archivematica_ingests_bucket             = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
   bag_register_output_subscribe_principals = [local.catalogue_pipeline_account_principal]
 }
 

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -16,7 +16,7 @@ locals {
 
   gateway_server_error_alarm_arn = data.terraform_remote_state.infra_shared.outputs.gateway_server_error_alarm_arn
 
-  workflow_staging_bucket_name = "wellcomecollection-workflow-export-bagit-stage"
-
-  archivematica_ingests_bucket = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
+  # TODO: This value should be exported from the workflow-infra state, not hard-coded
+  workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit-stage"
+  archivematica_ingests_bucket_arn = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
 }

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -78,9 +78,11 @@ module "stack_staging" {
     es_password = "staging/indexer/files/es_password"
   }
 
-  workflow_bucket_name = local.workflow_staging_bucket_name
+  upload_bucket_arns = [
+    local.workflow_bucket_arn,
+    local.archivematica_ingests_bucket_arn,
+  ]
 
-  archivematica_ingests_bucket             = local.archivematica_ingests_bucket
   bag_register_output_subscribe_principals = []
 
   # This means the staging service might be interrupted (unlikely), but the


### PR DESCRIPTION
This makes the module more generic – it doesn't assume the use of Goobi and Archivematica as the sources of uploaded bags.  As a bonus, it means we only have to attach one IAM policy, instead of two.

Another small step towards https://github.com/wellcomecollection/platform/issues/5206