### PR TITLE
Make the Azure replicator optional

### DIFF
--- a/terraform/modules/stack/dynamo.tf
+++ b/terraform/modules/stack/dynamo.tf
@@ -13,6 +13,8 @@ module "replicator_lock_table" {
 }
 
 resource "aws_dynamodb_table" "azure_verifier_tags" {
+  count = local.azure_replicator_count
+
   name     = "${var.namespace}_azure_verifier_tags"
   hash_key = "id"
 

--- a/terraform/modules/stack/iam_policy_document.tf
+++ b/terraform/modules/stack/iam_policy_document.tf
@@ -172,9 +172,7 @@ data "aws_iam_policy_document" "azure_verifier_tags_readwrite" {
       "dynamodb:PutItem",
     ]
 
-    resources = [
-      aws_dynamodb_table.azure_verifier_tags.arn,
-    ]
+    resources = aws_dynamodb_table.azure_verifier_tags.*.arn
   }
 }
 

--- a/terraform/modules/stack/iam_role_policy.tf
+++ b/terraform/modules/stack/iam_role_policy.tf
@@ -179,6 +179,8 @@ resource "aws_iam_role_policy" "notifier_metrics" {
 # Azure bag verifier
 
 resource "aws_iam_role_policy" "allow_azure_verifier_access_cache" {
-  role   = module.replicator_verifier_azure.verifier_task_role_name
+  count = local.azure_replicator_count
+
+  role   = module.replicator_verifier_azure[count.index].verifier_task_role_name
   policy = data.aws_iam_policy_document.azure_verifier_tags_readwrite.json
 }

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -5,21 +5,24 @@ module "ingests_topic" {
 
   name = "${var.namespace}_ingests"
 
-  role_names = [
-    module.bag_register.task_role_name,
-    module.bag_root_finder.task_role_name,
-    module.bag_verifier_pre_replication.task_role_name,
-    module.bag_unpacker.task_role_name,
-    module.notifier.task_role_name,
-    module.bag_versioner.task_role_name,
-    module.replica_aggregator.task_role_name,
-    module.replicator_verifier_primary.replicator_task_role_name,
-    module.replicator_verifier_primary.verifier_task_role_name,
-    module.replicator_verifier_glacier.replicator_task_role_name,
-    module.replicator_verifier_glacier.verifier_task_role_name,
-    module.replicator_verifier_azure.replicator_task_role_name,
-    module.replicator_verifier_azure.verifier_task_role_name,
-  ]
+  role_names = concat(
+    [
+      module.bag_register.task_role_name,
+      module.bag_root_finder.task_role_name,
+      module.bag_verifier_pre_replication.task_role_name,
+      module.bag_unpacker.task_role_name,
+      module.notifier.task_role_name,
+      module.bag_versioner.task_role_name,
+      module.replica_aggregator.task_role_name,
+      module.replicator_verifier_primary.replicator_task_role_name,
+      module.replicator_verifier_primary.verifier_task_role_name,
+      module.replicator_verifier_glacier.replicator_task_role_name,
+      module.replicator_verifier_glacier.verifier_task_role_name,
+      
+    ],
+    module.replicator_verifier_azure.*.replicator_task_role_name,
+    module.replicator_verifier_azure.*.verifier_task_role_name,
+  )
 }
 
 module "ingests_input_queue" {
@@ -265,11 +268,13 @@ module "replica_aggregator_input_queue" {
 
   name = "${var.namespace}_replica_aggregator_input"
 
-  topic_arns = [
-    module.replicator_verifier_primary.verifier_output_topic_arn,
-    module.replicator_verifier_glacier.verifier_output_topic_arn,
-    module.replicator_verifier_azure.verifier_output_topic_arn
-  ]
+  topic_arns = concat(
+    [
+      module.replicator_verifier_primary.verifier_output_topic_arn,
+      module.replicator_verifier_glacier.verifier_output_topic_arn,
+    ],
+    module.replicator_verifier_azure.*.verifier_output_topic_arn,
+  )
 
   role_names = [module.replica_aggregator.task_role_name]
 

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -18,7 +18,7 @@ module "ingests_topic" {
       module.replicator_verifier_primary.verifier_task_role_name,
       module.replicator_verifier_glacier.replicator_task_role_name,
       module.replicator_verifier_glacier.verifier_task_role_name,
-      
+
     ],
     module.replicator_verifier_azure.*.replicator_task_role_name,
     module.replicator_verifier_azure.*.verifier_task_role_name,

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -66,11 +66,13 @@ variable "replica_glacier_bucket_name" {
 }
 
 variable "azure_container_name" {
-  type = string
+  description = "The Azure container to use for replication.  If this value is null, the storage service will not replicate to Azure."
+  type        = string
 }
 
 variable "azure_ssm_parameter_base" {
-  type = string
+  description = "Prefix for the Secrets Manager secrets 'read_write_sas_url' and 'read_only_sas_url' that give access to Azure."
+  type        = string
 }
 
 variable "cognito_storage_api_identifier" {


### PR DESCRIPTION
For the DAMS prototype project, we don't want to require an Azure account and do replication into Azure.  Make it optional, so if the caller doesn't specify an Azure Blob container, we won't replicate there.

I had to do a small state change in our stacks to make this a no-op plan:

    $ terraform state mv module.stack_prod.module.replicator_verifier_azure module.stack_prod.module.replicator_verifier_azure[0]

I haven't tested this with the "no Azure" configuration, because I don't want to affect our existing environments -- I'm hoping to try it in the DAMS prototype account soon.

For https://github.com/wellcomecollection/platform/issues/5206