### PR TITLE
Add a CloudWatch metrics policy in the base module, not for every service

### DIFF
--- a/terraform/modules/service/base/iam.tf
+++ b/terraform/modules/service/base/iam.tf
@@ -1,0 +1,16 @@
+data "aws_iam_policy_document" "cloudwatch_putmetrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "bags_api_metrics" {
+  role   = module.task_definition.task_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
+}

--- a/terraform/modules/stack/iam_policy_document.tf
+++ b/terraform/modules/stack/iam_policy_document.tf
@@ -119,18 +119,6 @@ data "aws_iam_policy_document" "upload_buckets_readonly" {
   }
 }
 
-data "aws_iam_policy_document" "cloudwatch_putmetrics" {
-  statement {
-    actions = [
-      "cloudwatch:PutMetricData",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "s3_large_response_cache" {
   statement {
     actions = [

--- a/terraform/modules/stack/iam_role_policy.tf
+++ b/terraform/modules/stack/iam_role_policy.tf
@@ -5,21 +5,11 @@ resource "aws_iam_role_policy" "bag_register_replica_primary_readonly" {
   policy = data.aws_iam_policy_document.replica_primary_readonly.json
 }
 
-resource "aws_iam_role_policy" "bag_register_metrics" {
-  role   = module.bag_register.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
 # bags_api
 
 resource "aws_iam_role_policy" "bags_api_vhs_manifests_readonly" {
   role   = module.bags_api.task_role_name
   policy = var.vhs_manifests_readwrite_policy
-}
-
-resource "aws_iam_role_policy" "bags_api_metrics" {
-  role   = module.bags_api.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
 
 resource "aws_iam_role_policy" "s3_large_response_cache" {
@@ -34,28 +24,11 @@ resource "aws_iam_role_policy" "bag_indexer_vhs_manifests_readonly" {
   policy = var.vhs_manifests_readonly_policy
 }
 
-resource "aws_iam_role_policy" "bag_indexer_metrics" {
-  role   = module.bag_indexer.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
 # bag_tagger
-
-resource "aws_iam_role_policy" "bag_tagger_metrics" {
-  role   = module.bag_tagger.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
 
 resource "aws_iam_role_policy" "bag_tagger_can_tag_objects" {
   role   = module.bag_tagger.task_role_name
   policy = data.aws_iam_policy_document.allow_tagging_objects.json
-}
-
-# ingests_indexer
-
-resource "aws_iam_role_policy" "ingests_indexer_metrics" {
-  role   = module.ingests_indexer.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
 
 # ingests_service
@@ -63,16 +36,6 @@ resource "aws_iam_role_policy" "ingests_indexer_metrics" {
 resource "aws_iam_role_policy" "ingests_table_readwrite" {
   role   = module.ingest_service.task_role_name
   policy = data.aws_iam_policy_document.table_ingests_readwrite.json
-}
-
-resource "aws_iam_role_policy" "ingests_metrics" {
-  role   = module.ingest_service.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
-resource "aws_iam_role_policy" "ingests_service_metrics" {
-  role   = module.ingest_service.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
 
 resource "aws_iam_role_policy" "ingests_service_table_readwrite" {
@@ -87,17 +50,7 @@ resource "aws_iam_role_policy" "bag_root_finder_unpacked_bags_bucket_readonly" {
   policy = data.aws_iam_policy_document.unpacked_bags_bucket_readonly.json
 }
 
-resource "aws_iam_role_policy" "bag_root_finder_metrics" {
-  role   = module.bag_root_finder.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
 # bag versioner
-
-resource "aws_iam_role_policy" "bag_versioner_metrics" {
-  role   = module.bag_versioner.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
 
 resource "aws_iam_role_policy" "bag_versioner_locking_table" {
   role   = module.bag_versioner.task_role_name
@@ -119,11 +72,6 @@ resource "aws_iam_role_policy" "bag_verifier_pre_repl_unpacked_bags_bucket_reado
 resource "aws_iam_role_policy" "bag_verifier_pre_repl_unpacked_bags_bucket_put_tags" {
   role   = module.bag_verifier_pre_replication.task_role_name
   policy = data.aws_iam_policy_document.unpacked_bags_bucket_put_tags.json
-}
-
-resource "aws_iam_role_policy" "bag_verifier_pre_repl_metrics" {
-  role   = module.bag_verifier_pre_replication.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
 
 # The fetch files in the bag may refer to objects in the primary bucket,
@@ -152,28 +100,11 @@ resource "aws_iam_role_policy" "bag_unpacker_unpacked_bags_bucket_readwrite" {
   policy = data.aws_iam_policy_document.unpacked_bags_bucket_readwrite.json
 }
 
-resource "aws_iam_role_policy" "bag_unpacker_metrics" {
-  role   = module.bag_unpacker.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
-
 # replica aggregator
-
-resource "aws_iam_role_policy" "replica_aggregator_post_repl_metrics" {
-  role   = module.replica_aggregator.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
-}
 
 resource "aws_iam_role_policy" "replica_aggregator_replicas_table" {
   role   = module.replica_aggregator.task_role_name
   policy = data.aws_iam_policy_document.table_replicas_readwrite.json
-}
-
-# notifier
-
-resource "aws_iam_role_policy" "notifier_metrics" {
-  role   = module.notifier.task_role_name
-  policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
 
 # Azure bag verifier

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -482,7 +482,6 @@ module "replicator_verifier_primary" {
   unpacker_bucket_name  = aws_s3_bucket.unpacked_bags.id
 
   ingests_read_policy_json          = data.aws_iam_policy_document.unpacked_bags_bucket_readonly.json
-  cloudwatch_metrics_policy_json    = data.aws_iam_policy_document.cloudwatch_putmetrics.json
   replicator_lock_table_policy_json = module.replicator_lock_table.iam_policy
 
   security_group_ids = [
@@ -536,7 +535,6 @@ module "replicator_verifier_glacier" {
   unpacker_bucket_name  = aws_s3_bucket.unpacked_bags.id
 
   ingests_read_policy_json          = data.aws_iam_policy_document.unpacked_bags_bucket_readonly.json
-  cloudwatch_metrics_policy_json    = data.aws_iam_policy_document.cloudwatch_putmetrics.json
   replicator_lock_table_policy_json = module.replicator_lock_table.iam_policy
 
   security_group_ids = [
@@ -615,7 +613,6 @@ module "replicator_verifier_azure" {
   unpacker_bucket_name  = aws_s3_bucket.unpacked_bags.id
 
   ingests_read_policy_json          = data.aws_iam_policy_document.unpacked_bags_bucket_readonly.json
-  cloudwatch_metrics_policy_json    = data.aws_iam_policy_document.cloudwatch_putmetrics.json
   replicator_lock_table_policy_json = module.replicator_lock_table.iam_policy
 
   security_group_ids = [

--- a/terraform/modules/stack/replifier/iam_replicator.tf
+++ b/terraform/modules/stack/replifier/iam_replicator.tf
@@ -21,11 +21,6 @@ resource "aws_iam_role_policy" "bag_replicator_read_ingests_s3" {
   policy = var.ingests_read_policy_json
 }
 
-resource "aws_iam_role_policy" "bag_replicator_metrics" {
-  role   = module.bag_replicator.task_role_name
-  policy = var.cloudwatch_metrics_policy_json
-}
-
 resource "aws_iam_role_policy" "bag_replicator_lock_table" {
   role   = module.bag_replicator.task_role_name
   policy = var.replicator_lock_table_policy_json

--- a/terraform/modules/stack/replifier/iam_verifier.tf
+++ b/terraform/modules/stack/replifier/iam_verifier.tf
@@ -1,8 +1,3 @@
-resource "aws_iam_role_policy" "bag_verifier_metrics" {
-  role   = module.bag_verifier.task_role_name
-  policy = var.cloudwatch_metrics_policy_json
-}
-
 # The bag verifier needs to be able to read objects from the bucket where
 # the replica is written to.
 

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -47,10 +47,6 @@ variable "ingests_read_policy_json" {
   type = string
 }
 
-variable "cloudwatch_metrics_policy_json" {
-  type = string
-}
-
 variable "replicator_lock_table_policy_json" {
   type = string
 }


### PR DESCRIPTION
This is what we do in the pipeline repo, which seems like a better way to do it – you only need to define it once, not N times.

Discoveries:

* The ingests service was given access to CloudWatch Metrics *twice*
* The file finder/indexer weren't given any access at all