### PR TITLE
Wire up config to allow picking a different Fluentbit container

### DIFF
--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -43,14 +43,14 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.7.0"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "app"
 
   image = var.api_container_image
@@ -61,7 +61,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -38,6 +38,8 @@ module "base" {
   deployment_service_env  = var.deployment_service_env
 
   use_fargate_spot = var.use_fargate_spot
+
+  logging_container = var.logging_container
 }
 
 module "nginx_container" {

--- a/terraform/modules/service/bags/variables.tf
+++ b/terraform/modules/service/bags/variables.tf
@@ -79,3 +79,13 @@ variable "deployment_service_env" {
   type        = string
   description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
 }
+
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,5 +1,5 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=31e8d0f"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.7.0"
   namespace = var.service_name
 
   container_registry = var.logging_container["container_registry"]
@@ -8,13 +8,13 @@ module "log_router_container" {
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.7.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.7.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -27,7 +27,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.7.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,6 +1,10 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=31e8d0f"
   namespace = var.service_name
+
+  container_registry = var.logging_container["container_registry"]
+  container_name     = var.logging_container["container_name"]
+  container_tag      = var.logging_container["container_tag"]
 }
 
 module "log_router_container_secrets_permissions" {

--- a/terraform/modules/service/base/variables.tf
+++ b/terraform/modules/service/base/variables.tf
@@ -59,3 +59,13 @@ variable "deployment_service_env" {
   type        = string
   description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
 }
+
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -46,14 +46,14 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.7.0"
 
   forward_port      = var.external_api_container_port
   log_configuration = module.base.log_configuration
 }
 
 module "external_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "api"
 
   image = var.external_api_container_image
@@ -65,13 +65,13 @@ module "external_api_container" {
 }
 
 module "external_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.7.0"
   secrets   = var.external_api_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "worker"
 
   image = var.worker_container_image
@@ -83,13 +83,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.7.0"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -101,7 +101,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.7.0"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -41,6 +41,8 @@ module "base" {
   # We don't use Fargate Spot for the ingests service, because it includes the
   # external-facing ingests API which has to stay up.
   use_fargate_spot = false
+
+  logging_container = var.logging_container
 }
 
 module "nginx_container" {

--- a/terraform/modules/service/ingest/variables.tf
+++ b/terraform/modules/service/ingest/variables.tf
@@ -102,3 +102,13 @@ variable "deployment_service_env" {
   type        = string
   description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
 }
+
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -32,7 +32,7 @@ module "base" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.7.0"
   name   = "app"
 
   image = var.container_image
@@ -44,13 +44,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.7.0"
   secrets   = var.secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "scaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.7.0"
 
   name = var.service_name
 

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -27,6 +27,8 @@ module "base" {
   deployment_service_env  = var.deployment_service_env
 
   use_fargate_spot = var.use_fargate_spot
+
+  logging_container = var.logging_container
 }
 
 module "app_container" {

--- a/terraform/modules/service/worker/variables.tf
+++ b/terraform/modules/service/worker/variables.tf
@@ -77,3 +77,13 @@ variable "deployment_service_env" {
   type        = string
   description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
 }
+
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -46,6 +46,8 @@ module "ingest_service" {
 
   deployment_service_name = "ingests-service"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 module "ingests_indexer" {
@@ -85,6 +87,8 @@ module "ingests_indexer" {
 
   deployment_service_name = "ingests-indexer"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag_indexer
@@ -123,6 +127,8 @@ module "bag_indexer" {
 
   deployment_service_name = "bags-indexer"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # file finder
@@ -159,6 +165,8 @@ module "file_finder" {
 
   deployment_service_name = "file-finder"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # file indexer
@@ -196,6 +204,8 @@ module "file_indexer" {
 
   deployment_service_name = "file-indexer"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bags_api
@@ -245,6 +255,8 @@ module "bags_api" {
 
   deployment_service_name = "bags-api"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 
@@ -296,6 +308,8 @@ module "bag_unpacker" {
 
   deployment_service_name = "bag-unpacker"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag root finder
@@ -336,6 +350,8 @@ module "bag_root_finder" {
 
   deployment_service_name = "bag-root-finder"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag tagger
@@ -374,6 +390,8 @@ module "bag_tagger" {
 
   deployment_service_name = "bag-tagger"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag_verifier
@@ -416,6 +434,8 @@ module "bag_verifier_pre_replication" {
 
   deployment_service_name = "bag-verifer-pre-replication"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag versioner
@@ -460,6 +480,8 @@ module "bag_versioner" {
 
   deployment_service_name = "bag-versioner"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 module "replicator_verifier_primary" {
@@ -513,6 +535,8 @@ module "replicator_verifier_primary" {
   deployment_service_env             = var.release_label
   deployment_service_name_replicator = "bag-replicator-primary"
   deployment_service_name_verifier   = "bag-verifier-primary"
+
+  logging_container = var.logging_container
 }
 
 module "replicator_verifier_glacier" {
@@ -566,6 +590,8 @@ module "replicator_verifier_glacier" {
   deployment_service_env             = var.release_label
   deployment_service_name_replicator = "bag-replicator-glacier"
   deployment_service_name_verifier   = "bag-verifier-glacier"
+
+  logging_container = var.logging_container
 }
 
 locals {
@@ -644,6 +670,8 @@ module "replicator_verifier_azure" {
   deployment_service_env             = var.release_label
   deployment_service_name_replicator = "bag-replicator-azure"
   deployment_service_name_verifier   = "bag-verifier-azure"
+
+  logging_container = var.logging_container
 }
 
 # replica_aggregator
@@ -680,6 +708,8 @@ module "replica_aggregator" {
 
   deployment_service_name = "replica-aggregator"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # bag_register
@@ -720,6 +750,8 @@ module "bag_register" {
 
   deployment_service_name = "bag-register"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # notifier
@@ -756,6 +788,8 @@ module "notifier" {
 
   deployment_service_name = "notifier"
   deployment_service_env  = var.release_label
+
+  logging_container = var.logging_container
 }
 
 # storage API

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -45,6 +45,8 @@ module "bag_replicator" {
   deployment_service_env  = var.deployment_service_env
 
   use_fargate_spot = true
+
+  logging_container = var.logging_container
 }
 
 # bag_verifier
@@ -87,5 +89,7 @@ module "bag_verifier" {
   deployment_service_env  = var.deployment_service_env
 
   use_fargate_spot = true
+
+  logging_container = var.logging_container
 }
 

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -126,3 +126,12 @@ variable "max_capacity" {
   type = number
 }
 
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -166,3 +166,12 @@ variable "use_fargate_spot_for_api" {
   default = false
 }
 
+variable "logging_container" {
+  description = "Specifies container used for logging within applications."
+
+  type = object({
+    container_registry = string
+    container_name     = string
+    container_tag      = string
+  })
+}

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -89,5 +89,10 @@ module "stack_prod" {
   ]
 
   bag_register_output_subscribe_principals = [local.catalogue_pipeline_account_principal]
-}
 
+  logging_container = {
+    container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
+    container_name     = "fluentbit"
+    container_tag      = "2ccd2c68f38aa77a8ac1a32fe3ea54bbbd397a38"
+  }
+}

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -94,5 +94,11 @@ module "stack_staging" {
   # staging service doesn't make the same guarantees of uptime and this
   # saves us money.
   use_fargate_spot_for_api = true
+
+  logging_container = {
+    container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
+    container_name     = "fluentbit"
+    container_tag      = "2ccd2c68f38aa77a8ac1a32fe3ea54bbbd397a38"
+  }
 }
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5206, requires https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/35

I'll need to update to a released version of terraform-aws-ecs-service before I merge this.