### PR TITLE
Make the autoscaling module dependent on the service module

### DIFF
--- a/terraform/modules/service/base/outputs.tf
+++ b/terraform/modules/service/base/outputs.tf
@@ -13,3 +13,7 @@ output "task_role_name" {
 output "task_role_arn" {
   value = module.task_definition.task_role_arn
 }
+
+output "service_name" {
+  value = module.service.name
+}

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -55,7 +55,7 @@ module "scaling" {
   name = var.service_name
 
   cluster_name = var.cluster_name
-  service_name = var.service_name
+  service_name = module.base.service_name
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity


### PR DESCRIPTION
You can't register an autoscaling definition until the associated service has been created, but the previous approach would allow Terraform to create them in parallel -- and sometimes it would get the wrong order.

This change should force Terraform to create the service THEN create the autoscaling definition.

It's a no-op in the existing storage service, but should make planning a bit easier for the prototype.

For https://github.com/wellcomecollection/platform/issues/5206