### PR TITLE
Remove the typesafe_config_base container

### DIFF
--- a/bag_register/Dockerfile
+++ b/bag_register/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=bag_register
+ENTRYPOINT ["/opt/docker/bin/bag_register"]

--- a/bag_replicator/Dockerfile
+++ b/bag_replicator/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_replicator
+ENTRYPOINT ["/opt/docker/bin/bag_replicator"]

--- a/bag_root_finder/Dockerfile
+++ b/bag_root_finder/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_root_finder
+ENTRYPOINT ["/opt/docker/bin/bag_root_finder"]

--- a/bag_tagger/Dockerfile
+++ b/bag_tagger/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_tagger
+ENTRYPOINT ["/opt/docker/bin/bag_tagger"]

--- a/bag_tracker/Dockerfile
+++ b/bag_tracker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=bag_tracker
+ENTRYPOINT ["/opt/docker/bin/bag_tracker"]

--- a/bag_unpacker/Dockerfile
+++ b/bag_unpacker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_unpacker
+ENTRYPOINT ["/opt/docker/bin/bag_unpacker"]

--- a/bag_verifier/Dockerfile
+++ b/bag_verifier/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_verifier
+ENTRYPOINT ["/opt/docker/bin/bag_verifier"]

--- a/bag_versioner/Dockerfile
+++ b/bag_versioner/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_versioner
+ENTRYPOINT ["/opt/docker/bin/bag_versioner"]

--- a/bags_api/Dockerfile
+++ b/bags_api/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=bags_api
+ENTRYPOINT ["/opt/docker/bin/bags_api"]

--- a/indexer/bag_indexer/Dockerfile
+++ b/indexer/bag_indexer/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT bag_indexer
+ENTRYPOINT ["/opt/docker/bin/bag_indexer"]

--- a/indexer/file_finder/Dockerfile
+++ b/indexer/file_finder/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT file_finder
+ENTRYPOINT ["/opt/docker/bin/file_finder"]

--- a/indexer/file_indexer/Dockerfile
+++ b/indexer/file_indexer/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT file_indexer
+ENTRYPOINT ["/opt/docker/bin/file_indexer"]

--- a/indexer/ingests_indexer/Dockerfile
+++ b/indexer/ingests_indexer/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT ingests_indexer
+ENTRYPOINT ["/opt/docker/bin/ingests_indexer"]

--- a/ingests/ingests_api/Dockerfile
+++ b/ingests/ingests_api/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=ingests_api
+ENTRYPOINT ["/opt/docker/bin/ingests_api"]

--- a/ingests/ingests_tracker/Dockerfile
+++ b/ingests/ingests_tracker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=ingests_tracker
+ENTRYPOINT ["/opt/docker/bin/ingests_tracker"]

--- a/ingests/ingests_worker/Dockerfile
+++ b/ingests/ingests_worker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=ingests_worker
+ENTRYPOINT ["/opt/docker/bin/ingests_worker"]

--- a/notifier/Dockerfile
+++ b/notifier/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT notifier
+ENTRYPOINT ["/opt/docker/bin/notifier"]

--- a/replica_aggregator/Dockerfile
+++ b/replica_aggregator/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT replica_aggregator
+ENTRYPOINT ["/opt/docker/bin/replica_aggregator"]


### PR DESCRIPTION
The typesafe_config_base image has a couple of issues:

- It fetches ECS_METADATA_URI on startup, even though we no longer need to do this – it's a holdover from an old approach to doing logging.
- It obscures exactly how the image is being built, and what's available.
- Actually finding the Dockerfile for this image is very hard to impossible.

Since we don't need it, let's simplify the Dockerfile.

For https://github.com/wellcomecollection/platform/issues/4619