### PR TITLE
Run the storage-service in docker-compose

### DIFF
--- a/demo/docker/.gitignore
+++ b/demo/docker/.gitignore
@@ -1,0 +1,1 @@
+localstack

--- a/demo/docker/docker-compose.yml
+++ b/demo/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "DATA_DIR=/tmp/localstack/data"
 
   ingests_tracker:
-    image: "ingests_tracker:43c9ad494468929d4a7edb98da7b93f72ac144af"
+    image: "ingests_tracker:74884e3ba074efb36c6c6632b38d264b29f8f155"
 
     restart: "on-failure"
 
@@ -31,6 +31,23 @@ services:
       - "AWS_REGION=eu-west-1"
 
       - "ingests_table_name=demo-ingests"
-      # - "ingest_tracker_store=memory"
       - "callback_notifications_topic_arn=arn:aws:sns:eu-west-1:000000000000:callback_notifications"
       - "updated_ingests_topic_arn=arn:aws:sns:eu-west-1:000000000000:updated_ingests"
+
+      - "ingests_tracker_host=0.0.0.0"
+
+  ingests_worker:
+    image: "ingests_worker:74884e3ba074efb36c6c6632b38d264b29f8f155"
+
+    restart: "on-failure"
+
+    environment:
+      - "aws_key=test"
+      - "aws_secret=test"
+      - "aws_endpoint=http://aws:4566"
+      - "aws_region=eu-west-1"
+      - "AWS_REGION=eu-west-1"
+
+      - "queue_url=http://aws:4566/000000000000/ingests_worker_input"
+      - "metrics_namespace=ingests_worker"
+      - "ingests_tracker_host=http://ingests_tracker:8080"

--- a/demo/docker/docker-compose.yml
+++ b/demo/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+
+services:
+  aws:
+    image: "localstack/localstack"  # TODO: Pin to a specific version
+    volumes:
+      - "./localstack:/tmp/localstack"
+
+      # Files with extension .sh in this directory will be run when
+      # the container is started for the first time.
+      # See https://github.com/localstack/localstack#initializing-a-fresh-instance
+      - "./init:/docker-entrypoint-initaws.d"
+    ports:
+      - "4566"
+    environment:
+      - "SERVICES=dynamodb,iam,s3,sns,sqs"
+      - "DEFAULT_REGION=eu-west-1"
+      - "HOSTNAME_EXTERNAL=aws"
+      - "DATA_DIR=/tmp/localstack/data"
+
+  ingests_tracker:
+    image: "ingests_tracker:43c9ad494468929d4a7edb98da7b93f72ac144af"
+
+    restart: "on-failure"
+
+    environment:
+      - "aws_key=test"
+      - "aws_secret=test"
+      - "aws_endpoint=http://aws:4566"
+      - "aws_region=eu-west-1"
+      - "AWS_REGION=eu-west-1"
+
+      - "ingests_table_name=demo-ingests"
+      # - "ingest_tracker_store=memory"
+      - "callback_notifications_topic_arn=arn:aws:sns:eu-west-1:000000000000:callback_notifications"
+      - "updated_ingests_topic_arn=arn:aws:sns:eu-west-1:000000000000:updated_ingests"

--- a/demo/docker/init/init.sh
+++ b/demo/docker/init/init.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+apk add --update git terraform
+
+pushd /docker-entrypoint-initaws.d/terraform
+  terraform init
+  terraform apply -auto-approve
+popd

--- a/demo/docker/init/terraform/main.tf
+++ b/demo/docker/init/terraform/main.tf
@@ -1,0 +1,81 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  endpoints {
+    dynamodb = "http://localhost:4566"
+    iam      = "http://localhost:4566"
+    s3       = "http://localhost:4566"
+    sns      = "http://localhost:4566"
+    sqs      = "http://localhost:4566"
+    sts      = "http://localhost:4566"
+  }
+
+  access_key = "test"
+  secret_key = "test"
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_force_path_style         = true
+}
+
+locals {
+  namespace = "demo"
+}
+
+module "metadata_stores" {
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=b24ea38"
+
+  namespace = local.namespace
+
+  vhs_bucket_name = "${local.namespace}-manifests"
+  vhs_table_name  = "${local.namespace}-manifests"
+}
+
+output "ingests_table_name" {
+  value = module.metadata_stores.ingests_table_name
+}
+
+module "working_storage" {
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack/working_storage?ref=b89f88d"
+
+  namespace          = local.namespace
+  bucket_name_prefix = "${local.namespace}-"
+
+  azure_replicator_enabled = false
+}
+
+locals {
+  queue_names = [
+    "ingest_tracker_input"
+  ]
+
+  topic_names = [
+    "callback_notifications",
+    "updated_ingests",
+  ]
+}
+
+resource "aws_sqs_queue" "q" {
+  for_each = toset(local.queue_names)
+
+  name = each.key
+}
+
+output "queue_urls" {
+  value = {
+    for k, queue in aws_sqs_queue.q : k => queue.id
+  }
+}
+
+resource "aws_sns_topic" "t" {
+  for_each = toset(local.topic_names)
+
+  name = each.key
+}
+
+output "topic_arns" {
+  value = {
+    for k, topic in aws_sns_topic.t : k => topic.arn
+  }
+}

--- a/demo/docker/init/terraform/main.tf
+++ b/demo/docker/init/terraform/main.tf
@@ -47,7 +47,7 @@ module "working_storage" {
 
 locals {
   queue_names = [
-    "ingest_tracker_input"
+    "ingests_worker_input"
   ]
 
   topic_names = [

--- a/demo/terraform/.gitignore
+++ b/demo/terraform/.gitignore
@@ -1,0 +1,1 @@
+README.html

--- a/ingests/ingests_tracker/Dockerfile
+++ b/ingests/ingests_tracker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=ingests_tracker
+ENTRYPOINT ["/opt/docker/bin/ingests_tracker"]

--- a/ingests/ingests_tracker/src/main/resources/application.conf
+++ b/ingests/ingests_tracker/src/main/resources/application.conf
@@ -1,4 +1,13 @@
+aws.dynamo.key=${?aws_key}
+aws.dynamo.secret=${?aws_secret}
+aws.dynamo.endpoint=${?aws_endpoint}
+aws.dynamo.region=${?aws_region}
+
+aws.sns.key=${?aws_key}
+aws.sns.secret=${?aws_secret}
+aws.sns.endpoint=${?aws_endpoint}
+aws.sns.region=${?aws_region}
+
 aws.dynamo.tableName=${?ingests_table_name}
 aws.callbackNotifications.sns.topic.arn=${?callback_notifications_topic_arn}
 aws.updatedIngests.sns.topic.arn=${?updated_ingests_topic_arn}
-

--- a/ingests/ingests_tracker/src/main/resources/application.conf
+++ b/ingests/ingests_tracker/src/main/resources/application.conf
@@ -11,3 +11,5 @@ aws.sns.region=${?aws_region}
 aws.dynamo.tableName=${?ingests_table_name}
 aws.callbackNotifications.sns.topic.arn=${?callback_notifications_topic_arn}
 aws.updatedIngests.sns.topic.arn=${?updated_ingests_topic_arn}
+
+ingestsTracker.host=${?ingests_tracker_host}

--- a/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/Main.scala
+++ b/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/Main.scala
@@ -14,6 +14,7 @@ import weco.storage_service.ingests_tracker.tracker.dynamo.DynamoIngestTracker
 import weco.storage.typesafe.DynamoBuilder
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
+import weco.typesafe.config.builders.EnrichConfig._
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -48,9 +49,13 @@ object Main extends WellcomeTypesafeApp {
       config = DynamoBuilder.buildDynamoConfig(config)
     )
 
+    val host = config
+      .getStringOption("ingestsTracker.host")
+      .getOrElse("localhost")
+
     new IngestsTrackerApi[SNSConfig, SNSConfig](
       ingestTracker,
       messagingService
-    )()
+    )(host = host)
   }
 }

--- a/ingests/ingests_worker/Dockerfile
+++ b/ingests/ingests_worker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:edge
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=ingests_worker
+ENTRYPOINT ["/opt/docker/bin/ingests_worker"]


### PR DESCRIPTION
For a slightly easier local demo.

This seems within the realm of possibility now. So far:

- ✅ Starting the localstack container to simulate AWS services, run Terraform to define infrastructure
- ✅ Start the ingests tracker and have it write ingests to DynamoDB
- ✅ Start the ingests worker and have it read from the SQS queue

Current issues:

- ⚠️ Creating SNS topics doesn't work if I blow away the localstack container:

    ```
    Error: error reading SNS Topic (arn:aws:sns:eu-west-1:000000000000:callback_notifications): :
    aws_1              | 	status code: 404, request id:
    ```

- ⚠️ I need to the ingests tracker to publish on 0.0.0.0 so it can be reached by the ingests worker.