### PR TITLE
Fix the refs in the demo stack, add a script for bumping them

### DIFF
--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=302cb69"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=fde1cff"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=06213c4"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=302cb69"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=4457ad5"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=06213c4"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=f8fce1c"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=4457ad5"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/bump_refs.py
+++ b/demo/terraform/bump_refs.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import os
+import re
+import subprocess
+import sys
+
+
+def get_file_paths_under(root="."):
+    """Generates the paths to every file under ``root``."""
+    if not os.path.isdir(root):
+        raise ValueError(f"Cannot find files under non-existent directory: {root!r}")
+
+    for dirpath, _, filenames in os.walk(root):
+        for f in filenames:
+            if os.path.isfile(os.path.join(dirpath, f)):
+                yield os.path.join(dirpath, f)
+
+
+def update_commit_id(line, commit_id):
+    return re.sub(
+        r'source = "github\.com/wellcomecollection/storage-service\.git//(?P<directory>[^\?]+)\?ref=[a-f0-9]+"',
+        f'source = "github.com/wellcomecollection/storage-service.git//\g<directory>?ref={commit_id}"',
+        line
+    )
+
+
+def update_file(path, commit_id):
+    old_lines = list(open(path))
+    new_lines = [update_commit_id(line, commit_id) for line in old_lines]
+
+    if old_lines != new_lines:
+        with open(path, "w") as outfile:
+            outfile.write("".join(new_lines))
+        subprocess.check_call(["git", "add", path])
+
+
+if __name__ == '__main__':
+    try:
+        commit_id = sys.argv[1]
+    except IndexError:
+        sys.exit(f"Usage: {__file__} <COMMIT_ID>")
+
+    for path in get_file_paths_under("demo_stack"):
+        if path.endswith(".tf"):
+            update_file(path, commit_id)
+
+    subprocess.check_call(["git", "commit", "-m", f"Bump module references in the demo stack to {commit_id}"])
+
+    current_commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode("utf8")[:7]
+
+    for f in ("README.md", "main.tf"):
+        update_file(f, current_commit)
+        subprocess.check_call(["git", "add", f])
+
+    subprocess.check_call(["git", "commit", "-m", f"Bump module references in the demo stack README to {current_commit}"])

--- a/demo/terraform/bump_refs.py
+++ b/demo/terraform/bump_refs.py
@@ -27,7 +27,7 @@ def get_file_paths_under(root="."):
 def update_commit_id(line, commit_id):
     return re.sub(
         r'source = "github\.com/wellcomecollection/storage-service\.git//(?P<directory>[^\?]+)\?ref=[a-f0-9]+"',
-        f'source = "github.com/wellcomecollection/storage-service.git//\g<directory>?ref={commit_id}"',
+        f'source = "github.com/wellcomecollection/storage-service.git//\\g<directory>?ref={commit_id}"',
         line
     )
 

--- a/demo/terraform/bump_refs.py
+++ b/demo/terraform/bump_refs.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+"""
+This script bumps all the module references in the demo stack to
+a given Git commit, then bumps the README and example instance to match.
+
+This is meant to make it easier to keep the demo working/up-to-date with
+changes in the storage service.
+"""
 
 import os
 import re

--- a/demo/terraform/demo_stack/cognito.tf
+++ b/demo/terraform/demo_stack/cognito.tf
@@ -59,7 +59,7 @@ resource "aws_cognito_user_pool_client" "client" {
 }
 
 module "client_secrets" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=b24ea38"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=4457ad5"
 
   key_value_map = {
     "client_id"     = aws_cognito_user_pool_client.client.id

--- a/demo/terraform/demo_stack/cognito.tf
+++ b/demo/terraform/demo_stack/cognito.tf
@@ -59,7 +59,7 @@ resource "aws_cognito_user_pool_client" "client" {
 }
 
 module "client_secrets" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=4457ad5"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.0.1"
 
   key_value_map = {
     "client_id"     = aws_cognito_user_pool_client.client.id

--- a/demo/terraform/demo_stack/elastic.tf
+++ b/demo/terraform/demo_stack/elastic.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 module "elasticsearch_secrets" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=b24ea38"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=4457ad5"
 
   key_value_map = {
     "elasticsearch/user"     = local.elasticsearch_user

--- a/demo/terraform/demo_stack/elastic.tf
+++ b/demo/terraform/demo_stack/elastic.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 module "elasticsearch_secrets" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/secrets?ref=4457ad5"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.0.1"
 
   key_value_map = {
     "elasticsearch/user"     = local.elasticsearch_user

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=4457ad5"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=4622342"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=4622342"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=e78ef5d"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=b24ea38"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=4457ad5"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=4622342"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=e78ef5d"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=4457ad5"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=4622342"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=1b4648911f12d27b78cdde48c86054d7cdee8115"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=4457ad5"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -10,8 +10,8 @@ module "stack" {
 
   private_subnets = module.vpc.private_subnets
 
-  dlq_alarm_arn   = module.dlq_alarm.arn
-  alarm_topic_arn = module.gateway_server_error_alarm.arn
+  dlq_alarm_arn   = aws_sns_topic.dlq_alarm.arn
+  alarm_topic_arn = aws_sns_topic.gateway_server_error_alarm.arn
 
   cognito_user_pool_arn          = aws_cognito_user_pool.pool.arn
   cognito_storage_api_identifier = aws_cognito_resource_server.storage_api.identifier

--- a/demo/terraform/demo_stack/topics.tf
+++ b/demo/terraform/demo_stack/topics.tf
@@ -1,9 +1,23 @@
-module "dlq_alarm" {
-  source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"
-  name   = "shared_dlq_alarm"
+# These SNS topics receive notifications from CloudWatch alarms,
+# in particular:
+#
+#   - If we repeatedly fail to process a message on an SQS queue, the
+#     message is eventually sent to a dead-letter queue (DLQ) using
+#     an SQS redrive policy.
+#
+#   - 5XX server errors in the API Gateway distribution.
+#
+# Both of these events will trigger a CloudWatch alarm, which sends
+# a notification to these topics.
+#
+# There's nothing in the demo stack that acts on these alarms.  We wire
+# these up to a Lambda function that posts to an internal Slack channel,
+# but this mechanism isn't in a fit state for reuse.
+
+resource "aws_sns_topic" "dlq_alarm" {
+  name = "shared_dlq_alarm"
 }
 
-module "gateway_server_error_alarm" {
-  source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"
-  name   = "gateway_server_error_alarm"
+resource "aws_sns_topic" "gateway_server_error_alarm" {
+  name = "gateway_server_error_alarm"
 }

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=4457ad5"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=06213c4"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=f8fce1c"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=4457ad5"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=06213c4"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=302cb69"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=302cb69"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=fde1cff"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"


### PR DESCRIPTION
Me, last week: _"I've made a demo of the storage service. It just works™!"_

Literally anybody trying to use it: _"No. No it does not."_

---

We use Git commit refs to refer to the modules throughout the demo because they're consistent, reproducible references. For our other Terraform modules we use tags and semantic versioning (e.g. `v1.2.3`), but we don't have any versioning like that set up in the storage service repo yet.

It turns out the demo currently points at a commit ref that no longer exists, oops.

It worked on my machine because I'd run `terraform init` when the commit did exist, Terraform cached the module, and then didn't try to fetch it again later. Anybody else trying to init the demo would get an error trying to fetch a non-existent commit.

This patch adds a script to auto-bump all the Git commit refs throughout the demo, plus a few other module-related fixes while I was in here.

We could add a task in CI to check the validity of the demo modules, but that involves a bunch of build systems complexity I can't quite be bothered to deal with right now.