### PR TITLE
Bump the version of terraform-aws-ecs-service to v3.9.2

### DIFF
--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=fb7559b"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=7fb0120"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=7fb0120"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=6d55162"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=f0ba7e2"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=82377ba"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=82377ba"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=caab5b2"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=82377ba"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=caab5b2"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=f0ba7e2"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=82377ba"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=7fb0120"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=6d55162"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=fb7559b"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=7fb0120"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -43,7 +43,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.2"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
@@ -54,7 +54,7 @@ module "nginx_container" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "app"
 
   image = var.api_container_image
@@ -65,7 +65,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -43,7 +43,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.3"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
@@ -54,7 +54,7 @@ module "nginx_container" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "app"
 
   image = var.api_container_image
@@ -65,7 +65,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,5 +1,5 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.2"
   namespace = var.service_name
 
   container_registry = var.logging_container["container_registry"]
@@ -8,13 +8,13 @@ module "log_router_container" {
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.2"
 
   cpu    = var.cpu
   memory = var.memory
@@ -27,7 +27,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.2"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,5 +1,5 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.3"
   namespace = var.service_name
 
   container_registry = var.logging_container["container_registry"]
@@ -8,13 +8,13 @@ module "log_router_container" {
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.3"
 
   cpu    = var.cpu
   memory = var.memory
@@ -27,7 +27,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.3"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -46,7 +46,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.3"
 
   forward_port      = var.external_api_container_port
   log_configuration = module.base.log_configuration
@@ -57,7 +57,7 @@ module "nginx_container" {
 }
 
 module "external_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "api"
 
   image = var.external_api_container_image
@@ -69,13 +69,13 @@ module "external_api_container" {
 }
 
 module "external_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
   secrets   = var.external_api_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "worker"
 
   image = var.worker_container_image
@@ -87,13 +87,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -105,7 +105,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -46,7 +46,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.2"
 
   forward_port      = var.external_api_container_port
   log_configuration = module.base.log_configuration
@@ -57,7 +57,7 @@ module "nginx_container" {
 }
 
 module "external_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "api"
 
   image = var.external_api_container_image
@@ -69,13 +69,13 @@ module "external_api_container" {
 }
 
 module "external_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
   secrets   = var.external_api_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "worker"
 
   image = var.worker_container_image
@@ -87,13 +87,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -105,7 +105,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -32,7 +32,7 @@ module "base" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
   name   = "app"
 
   image = var.container_image
@@ -44,13 +44,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
   secrets   = var.secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "scaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.3"
 
   name = var.service_name
 

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -32,7 +32,7 @@ module "base" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.2"
   name   = "app"
 
   image = var.container_image
@@ -44,13 +44,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.2"
   secrets   = var.secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "scaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.2"
 
   name = var.service_name
 


### PR DESCRIPTION
Brings in https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/39, so hopefully you can spin up the logging container outside eu-west-1.