### PR TITLE
Continue to make the storage-service more region agnostic

### DIFF
--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=6d55162"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=ba1da89"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=8306392"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=2cf78b5"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=8306392"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=ba1da89"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=2cf78b5"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/demo_stack/cognito.tf
+++ b/demo/terraform/demo_stack/cognito.tf
@@ -59,10 +59,12 @@ resource "aws_cognito_user_pool_client" "client" {
 }
 
 module "client_secrets" {
-  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.0.1"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.2.0"
 
   key_value_map = {
     "client_id"     = aws_cognito_user_pool_client.client.id
     "client_secret" = aws_cognito_user_pool_client.client.client_secret
   }
+
+  deletion_mode = "IMMEDIATE"
 }

--- a/demo/terraform/demo_stack/elastic.tf
+++ b/demo/terraform/demo_stack/elastic.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 module "elasticsearch_secrets" {
-  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.1.0"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.2.0"
 
   key_value_map = {
     "elasticsearch/user"     = local.elasticsearch_user

--- a/demo/terraform/demo_stack/elastic.tf
+++ b/demo/terraform/demo_stack/elastic.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 module "elasticsearch_secrets" {
-  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.0.1"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.1.0"
 
   key_value_map = {
     "elasticsearch/user"     = local.elasticsearch_user
@@ -48,6 +48,8 @@ module "elasticsearch_secrets" {
     "shared/logging/es_user" = local.elasticsearch_user
     "shared/logging/es_pass" = local.elasticsearch_password
   }
+
+  deletion_mode = "IMMEDIATE"
 }
 
 resource "aws_elasticsearch_domain" "elasticsearch" {

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=fbe61c1"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=a0979ee"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=e9ca67e"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=fbe61c1"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=caab5b2"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=e9ca67e"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=a0979ee"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=52e10ed"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -96,6 +96,6 @@ module "stack" {
 
   app_containers = {
     container_registry = "public.ecr.aws/y1p3h6z3"
-    container_tag      = "latest"
+    container_tag      = "ref.c3b7e5a1557ba0115a31ad06e6a7edd5ad143a64"
   }
 }

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=a0979ee"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=52e10ed"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=caab5b2"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=e9ca67e"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -3,8 +3,8 @@ module "stack" {
 
   namespace = var.short_namespace
 
-  min_capacity = 0
-  max_capacity = 1
+  min_capacity = var.min_capacity
+  max_capacity = var.max_capacity
 
   vpc_id = module.vpc.vpc_id
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=fbe61c1"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=a0979ee"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=e9ca67e"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=fbe61c1"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/demo_stack/variables.tf
+++ b/demo/terraform/demo_stack/variables.tf
@@ -10,3 +10,16 @@ variable "cidr_block" {
   type    = string
   default = "172.14.0.0/16"
 }
+
+# Set the min/max scaling of the ECS tasks.  By default they scale down
+# to idle when not in use; increasing the max capacity temporarily will
+# warm up the pipeline and get bags stored quickly.
+variable "min_capacity" {
+  type    = number
+  default = 0
+}
+
+variable "max_capacity" {
+  type    = number
+  default = 1
+}

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=ba1da89"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=2cf78b5"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"
@@ -19,7 +19,7 @@ provider "aws" {
     role_arn = "arn:aws:iam::241906670800:role/dam_prototype-admin"
   }
 
-  region = "eu-west-1"
+  region = "eu-west-3"
 }
 
 terraform {

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=2cf78b5"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=8306392"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,8 +1,9 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=8306392"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"
+  min_capacity = 1
 }
 
 output "elasticsearch_host" { value = module.demo_stack.elasticsearch_host }

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,5 +1,5 @@
 module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=6d55162"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=ba1da89"
 
   namespace       = "weco-dams-prototype"
   short_namespace = "weco"

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,20 +1,3 @@
-module "demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
-
-  namespace       = "weco-dams-prototype"
-  short_namespace = "weco"
-  min_capacity = 1
-}
-
-output "elasticsearch_host" { value = module.demo_stack.elasticsearch_host }
-output "kibana_endpoint" { value = module.demo_stack.kibana_endpoint }
-output "token_url" { value = module.demo_stack.token_url }
-output "api_url" { value = module.demo_stack.api_url }
-output "replica_primary_bucket_name" { value = module.demo_stack.replica_primary_bucket_name }
-output "replica_glacier_bucket_name" { value = module.demo_stack.replica_glacier_bucket_name }
-output "uploads_bucket_name" { value = module.demo_stack.uploads_bucket_name }
-output "unpacked_bags_bucket_name" { value = module.demo_stack.unpacked_bags_bucket_name }
-
 provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::241906670800:role/dam_prototype-admin"
@@ -22,6 +5,43 @@ provider "aws" {
 
   region = "eu-west-3"
 }
+
+
+
+
+module "us_demo_stack" {
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
+
+  namespace       = "weco-us-dams-prototype"
+  short_namespace = "weco-us"
+
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+output "us_elasticsearch_host" { value = module.us_demo_stack.elasticsearch_host }
+output "us_kibana_endpoint" { value = module.us_demo_stack.kibana_endpoint }
+output "us_token_url" { value = module.us_demo_stack.token_url }
+output "us_api_url" { value = module.us_demo_stack.api_url }
+output "us_replica_primary_bucket_name" { value = module.us_demo_stack.replica_primary_bucket_name }
+output "us_replica_glacier_bucket_name" { value = module.us_demo_stack.replica_glacier_bucket_name }
+output "us_uploads_bucket_name" { value = module.us_demo_stack.uploads_bucket_name }
+output "us_unpacked_bags_bucket_name" { value = module.us_demo_stack.unpacked_bags_bucket_name }
+
+provider "aws" {
+  alias = "us_east_1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::241906670800:role/dam_prototype-admin"
+  }
+
+  region = "us-east-1"
+}
+
+
+
+
 
 terraform {
   backend "s3" {

--- a/docs/howto/ingest-a-bag.md
+++ b/docs/howto/ingest-a-bag.md
@@ -62,24 +62,24 @@ To store a bag in the storage service:
     curl -X POST "$API_URL/ingests" \
       --header "Authorization: $ACCESS_TOKEN" \
       --header "Content-Type: application/json" \
-      --data '{
-        "type": "Ingest",
-        "ingestType": {"id": "$INGEST_TYPE", "type": "IngestType"},
-        "space": {"id": "$SPACE", "type": "Space"},
-        "sourceLocation": {
-          "provider": {"id": "amazon-s3", "type": "Provider"},
-          "bucket": "$UPLOADS_BUCKET",
-          "path": "$UPLOADED_BAG_KEY",
-          "type": "Location"
+      --data "{
+        \"type\": \"Ingest\",
+        \"ingestType\": {\"id\": \"$INGEST_TYPE\", \"type\": \"IngestType\"},
+        \"space\": {\"id\": \"$SPACE\", \"type\": \"Space\"},
+        \"sourceLocation\": {
+          \"provider\": {\"id\": \"amazon-s3\", \"type\": \"Provider\"},
+          \"bucket\": \"$UPLOADS_BUCKET\",
+          \"path\": \"$UPLOADED_BAG_KEY\",
+          \"type\": \"Location\"
         },
-        "bag": {
-          "info": {
-            "externalIdentifier": "$EXTERNAL_IDENTIFIER",
-            "type": "BagInfo"
+        \"bag\": {
+          \"info\": {
+            \"externalIdentifier\": \"$EXTERNAL_IDENTIFIER\",
+            \"type\": \"BagInfo\"
           },
-          "type": "Bag"
+          \"type\": \"Bag\"
         }
-      }'
+      }"
     ```
 
     This returns a response like:

--- a/terraform/modules/critical/metadata_stores/dynamo_ingests.tf
+++ b/terraform/modules/critical/metadata_stores/dynamo_ingests.tf
@@ -12,8 +12,6 @@ resource "aws_dynamodb_table" "ingests" {
   }
 
   lifecycle {
-    prevent_destroy = true
-
     ignore_changes = [
       read_capacity,
       write_capacity,

--- a/terraform/modules/critical/metadata_stores/vhs_manifests.tf
+++ b/terraform/modules/critical/metadata_stores/vhs_manifests.tf
@@ -1,5 +1,5 @@
 module "vhs_manifests" {
-  source = "git::github.com/wellcomecollection/terraform-aws-vhs.git//multi-version-store?ref=v4.0.5"
+  source = "git::github.com/wellcomecollection/terraform-aws-vhs.git//multi-version-store?ref=v4.2.0"
   name   = "${var.namespace}-manifests"
 
   bucket_name = var.vhs_bucket_name

--- a/terraform/modules/queue/main.tf
+++ b/terraform/modules/queue/main.tf
@@ -1,11 +1,6 @@
-locals {
-  queue_name = replace(var.name, "-", "_")
-}
-
 module "queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name = replace(var.name, "-", "_")
-  aws_region = var.aws_region
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name = var.name
   topic_arns = var.topic_arns
 
   visibility_timeout_seconds = var.visibility_timeout_seconds
@@ -15,8 +10,8 @@ module "queue" {
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
-  queue_name = local.queue_name
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
+  queue_name = module.queue.name
 
   queue_high_actions = var.queue_high_actions
   queue_low_actions  = var.queue_low_actions

--- a/terraform/modules/queue/variables.tf
+++ b/terraform/modules/queue/variables.tf
@@ -1,9 +1,6 @@
 variable "name" {
 }
 
-variable "aws_region" {
-}
-
 variable "topic_arns" {
   type = list(string)
 }

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -22,6 +22,8 @@ module "base" {
   #     enabled Availability Zone has at least one registered target
   #
   # See: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html
+  #
+  # TODO: Consider parametrising this using https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones
   desired_task_count = max(3, var.desired_task_count)
 
   security_group_ids = var.security_group_ids

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -541,8 +541,6 @@ module "replicator_verifier_primary" {
 
   dlq_alarm_arn = var.dlq_alarm_arn
 
-  aws_region = var.aws_region
-
   service_discovery_namespace_id = local.service_discovery_namespace_id
 
   deployment_service_env             = var.release_label
@@ -595,8 +593,6 @@ module "replicator_verifier_glacier" {
   max_capacity = var.max_capacity
 
   dlq_alarm_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 
   service_discovery_namespace_id = local.service_discovery_namespace_id
 
@@ -675,8 +671,6 @@ module "replicator_verifier_azure" {
   max_capacity = var.max_capacity
 
   dlq_alarm_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 
   service_discovery_namespace_id = local.service_discovery_namespace_id
 

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -40,7 +40,6 @@ module "ingests_input_queue" {
 
   queue_low_actions = []
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 
   # Updates sent to the ingests monitor can fail with a ConditionalUpdate error
@@ -84,7 +83,6 @@ module "updated_ingests_queue" {
     module.ingests_indexer.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -107,7 +105,6 @@ module "notifier_input_queue" {
     module.notifier.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -144,7 +141,6 @@ module "bag_unpacker_queue" {
     module.bag_unpacker.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -177,7 +173,6 @@ module "bag_root_finder_queue" {
     module.bag_root_finder.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -214,7 +209,6 @@ module "bag_verifier_pre_replicate_queue" {
     module.bag_verifier_pre_replication.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -247,7 +241,6 @@ module "bag_versioner_queue" {
     module.bag_versioner.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -286,7 +279,6 @@ module "replica_aggregator_input_queue" {
     module.replica_aggregator.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 
   # The aggregator may have to retry messages if two replicas complete
@@ -323,7 +315,6 @@ module "bag_register_input_queue" {
     module.bag_register.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 
   # Only a handful of big bags take more than half an hour to assemble
@@ -368,7 +359,6 @@ module "registered_bag_notifications_queue" {
 
   role_names = []
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -402,7 +392,6 @@ module "bag_indexer_input_queue" {
     module.bag_indexer.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -436,7 +425,6 @@ module "file_finder_input_queue" {
     module.file_finder.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -471,7 +459,6 @@ module "file_indexer_input_queue" {
     module.file_indexer.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -497,6 +484,5 @@ module "bag_tagger_input_queue" {
     module.bag_tagger.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }

--- a/terraform/modules/stack/replifier/messaging.tf
+++ b/terraform/modules/stack/replifier/messaging.tf
@@ -22,7 +22,6 @@ module "bag_replicator_input_queue" {
     module.bag_replicator.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 
@@ -59,7 +58,6 @@ module "bag_verifier_queue" {
     module.bag_verifier.scale_down_arn,
   ]
 
-  aws_region    = var.aws_region
   dlq_alarm_arn = var.dlq_alarm_arn
 }
 

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -18,10 +18,6 @@ variable "replica_type" {
   type = string
 }
 
-variable "aws_region" {
-  type = string
-}
-
 variable "topic_arns" {
   type = list(string)
 }

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -30,11 +30,6 @@ variable "vpc_id" {
   type = string
 }
 
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
-
 # Storage manifests VHS
 
 variable "vhs_manifests_bucket_name" {


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5241

This patch:

* Will delete secrets immediately when the demo stack is torn down
* Use Scala apps that don't hard-code their region as `eu-west-1`
* Use a version of the SQS queue module that doesn't need a region variable set (https://github.com/wellcomecollection/terraform-aws-sqs/pull/7)