### PR TITLE
Support Windows line endings in the bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
@@ -6,6 +6,7 @@ import weco.storage.streaming.InputStreamWithLength
 import weco.storage.{Identified, Location, NotFoundError, Prefix}
 import weco.storage.streaming.Codec._
 
+import scala.io.Source
 import scala.util.matching.Regex
 
 trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
@@ -85,8 +86,10 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
     * it isn't if not.
     *
     */
-  private def validateDeclaration(contents: String): Either[String, Unit] =
-    contents.linesIterator.toList match {
+  private def validateDeclaration(contents: String): Either[String, Unit] = {
+    val lines = Source.fromString(contents).getLines().toList
+
+    lines match {
       case Seq(versionLine(), encodingLine()) => Right(())
       case Seq(versionLine(), encodingLinePrefix()) =>
         Left("encoding must be UTF-8")
@@ -95,4 +98,5 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
       case Seq(_, _)              => Left("not correctly formatted")
       case other                  => Left(s"expected 2 lines, got ${other.size}")
     }
+  }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
@@ -55,8 +55,11 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
             )
 
           case Right(declaration) =>
-            validateDeclaration(declaration)
-              .left.map { message => BagVerifierError(s"Error loading Bag Declaration (bagit.txt): $message") }
+            validateDeclaration(declaration).left.map { message =>
+              BagVerifierError(
+                s"Error loading Bag Declaration (bagit.txt): $message"
+              )
+            }
         }
 
       case Left(err: NotFoundError) =>
@@ -84,11 +87,12 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
     */
   private def validateDeclaration(contents: String): Either[String, Unit] =
     contents.lines.toList match {
-      case Seq(versionLine(), encodingLine())       => Right(())
-      case Seq(versionLine(), encodingLinePrefix()) => Left("encoding must be UTF-8")
-      case Seq(versionLine(), _)                    => Left("encoding line was not correct")
-      case Seq(_, encodingLine())                   => Left("version line was not correct")
-      case Seq(_, _)                                => Left("not correctly formatted")
-      case other                                    => Left(s"expected 2 lines, got ${other.size}")
+      case Seq(versionLine(), encodingLine()) => Right(())
+      case Seq(versionLine(), encodingLinePrefix()) =>
+        Left("encoding must be UTF-8")
+      case Seq(versionLine(), _)  => Left("encoding line was not correct")
+      case Seq(_, encodingLine()) => Left("version line was not correct")
+      case Seq(_, _)              => Left("not correctly formatted")
+      case other                  => Left(s"expected 2 lines, got ${other.size}")
     }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
@@ -86,7 +86,7 @@ trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
     *
     */
   private def validateDeclaration(contents: String): Either[String, Unit] =
-    contents.lines.toList match {
+    contents.linesIterator.toList match {
       case Seq(versionLine(), encodingLine()) => Right(())
       case Seq(versionLine(), encodingLinePrefix()) =>
         Left("encoding must be UTF-8")

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -233,7 +233,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
 
         verifySuccessCount(
           fixityListResult.locations,
-          expectedCount = 1
+          expectedCount = 4
         )
       }
     }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -183,23 +183,23 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           fetchObjects = Map(),
           bagObjects = Map(
             bagRoot.asLocation("data/README.txt") ->
-              "This is a file with Windows line endings.\\r\\n",
+              "This is a file with Windows line endings.\r\n",
             bagRoot.asLocation("bag-info.txt") -> (
-              "Bag-Software-Agent: bagit.py v1.7.0 <https://github.com/LibraryOfCongress/bagit-python>\\r\\n" +
-                "Bagging-Date: 2021-07-16\\r\\n" +
-                "External-Identifier: windows_line_endings_bag\\r\\n" + "" +
-                "Payload-Oxum: 43.1\\r\\n"
+              "Bag-Software-Agent: bagit.py v1.7.0 <https://github.com/LibraryOfCongress/bagit-python>\r\n" +
+                "Bagging-Date: 2021-07-16\r\n" +
+                "External-Identifier: windows_line_endings_bag\r\n" +
+                "Payload-Oxum: 43.1\r\n"
             ),
             bagRoot.asLocation("bagit.txt") -> (
-              "BagIt-Version: 0.97\\r\\n" +
-                "Tag-File-Character-Encoding: UTF-8\\r\\n"
+              "BagIt-Version: 0.97\r\n" +
+                "Tag-File-Character-Encoding: UTF-8\r\n"
             ),
             bagRoot.asLocation("manifest-sha256.txt") ->
-              "3145c4eacf0ff758f80ed68f6c6fa8d94ec3d31b1b7f421b8dc4a1f61973f4c8  data/README.txt\\r\\n",
-            bagRoot.asLocation("tagmanifest-sha256") -> (
-              "c2c8f2cf0726d04b0dab99d67f951d77a33ffe6eae2a46cee67dbb2bccb96b0d  bag-info.txt\\r\\n" +
-                "4ec18508e945726d1bdbdbdfef3e8973ede85fef1f4839bc166883dc958fbe93  bagit.txt\\r\\n" +
-                "d1d9d610ceeaee50b744d06731bdc7dffa5b24ea59987ab57ba46489550e9118  manifest-sha256.txt\\r\\n",
+              "3145c4eacf0ff758f80ed68f6c6fa8d94ec3d31b1b7f421b8dc4a1f61973f4c8  data/README.txt\r\n",
+            bagRoot.asLocation("tagmanifest-sha256.txt") -> (
+              "c2c8f2cf0726d04b0dab99d67f951d77a33ffe6eae2a46cee67dbb2bccb96b0d  bag-info.txt\r\n" +
+                "4ec18508e945726d1bdbdbdfef3e8973ede85fef1f4839bc166883dc958fbe93  bagit.txt\r\n" +
+                "d1d9d610ceeaee50b744d06731bdc7dffa5b24ea59987ab57ba46489550e9118  manifest-sha256.txt\r\n",
             )
           ),
           bagRoot = bagRoot,

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -206,8 +206,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           bagInfo = createBagInfoWith(externalIdentifier = externalIdentifier)
         )
 
-        println(bagContents)
-
         bagBuilder.storeBagContents(bagContents)
 
         val ingestStep =

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -182,21 +182,21 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val bagContents = bagBuilder.BagContents(
           fetchObjects = Map(),
           bagObjects = Map(
-            bagBuilder.createBagLocation(bagRoot, path = "data/README.txt") ->
+            bagRoot.asLocation("data/README.txt") ->
               "This is a file with Windows line endings.\\r\\n",
-            bagBuilder.createBagLocation(bagRoot, path = "bag-info.txt") -> (
+            bagRoot.asLocation("bag-info.txt") -> (
               "Bag-Software-Agent: bagit.py v1.7.0 <https://github.com/LibraryOfCongress/bagit-python>\\r\\n" +
                 "Bagging-Date: 2021-07-16\\r\\n" +
                 "External-Identifier: windows_line_endings_bag\\r\\n" + "" +
                 "Payload-Oxum: 43.1\\r\\n"
             ),
-            bagBuilder.createBagLocation(bagRoot, path = "bagit.txt") -> (
+            bagRoot.asLocation("bagit.txt") -> (
               "BagIt-Version: 0.97\\r\\n" +
                 "Tag-File-Character-Encoding: UTF-8\\r\\n"
             ),
-            bagBuilder.createBagLocation(bagRoot, path = "manifest-sha256.txt") ->
+            bagRoot.asLocation("manifest-sha256.txt") ->
               "3145c4eacf0ff758f80ed68f6c6fa8d94ec3d31b1b7f421b8dc4a1f61973f4c8  data/README.txt\\r\\n",
-            bagBuilder.createBagLocation(bagRoot, path = "tagmanifest-sha256.txt") -> (
+            bagRoot.asLocation("tagmanifest-sha256") -> (
               "c2c8f2cf0726d04b0dab99d67f951d77a33ffe6eae2a46cee67dbb2bccb96b0d  bag-info.txt\\r\\n" +
                 "4ec18508e945726d1bdbdbdfef3e8973ede85fef1f4839bc166883dc958fbe93  bagit.txt\\r\\n" +
                 "d1d9d610ceeaee50b744d06731bdc7dffa5b24ea59987ab57ba46489550e9118  manifest-sha256.txt\\r\\n",
@@ -205,6 +205,8 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
           bagRoot = bagRoot,
           bagInfo = createBagInfoWith(externalIdentifier = externalIdentifier)
         )
+
+        println(bagContents)
 
         bagBuilder.storeBagContents(bagContents)
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -41,6 +41,14 @@ class VerifyBagDeclarationTest
     }
   }
 
+  it("verifies a valid bagit.txt (Windows newlines)") {
+    implicit val root: MemoryLocationPrefix = createMemoryLocationPrefix
+
+    withVerifier("BagIt-Version: 1.0\r\nTag-File-Character-Encoding: UTF-8\r\n") {
+      _.verifyBagDeclaration(root) shouldBe Right(())
+    }
+  }
+
   it("fails if it can't find a bagit.txt") {
     val store = MemoryStreamStore[MemoryLocation]()
 
@@ -80,43 +88,54 @@ class VerifyBagDeclarationTest
   }
 
   it("fails if the bagit.txt has no BagIt-Version line") {
-    assertFails("Tag-File-Character-Encoding: UTF-8\n")
+    assertFails(
+      contents = "Tag-File-Character-Encoding: UTF-8\n",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1")
   }
 
   it("fails if the bagit.txt has no Tag-File-Character-Encoding line") {
-    assertFails("BagIt-Version: 0.97\n")
+    assertFails(
+      contents = "BagIt-Version: 0.97\n",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1")
   }
 
   it("fails if the bagit.txt has the wrong Tag-File-Character-Encoding") {
-    assertFails("BagIt-Version: 0.97\nTag-File-Character-Encoding: Latin-1")
+    assertFails(
+      contents = "BagIt-Version: 0.97\nTag-File-Character-Encoding: Latin-1",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): encoding must be UTF-8")
   }
 
   it("fails if the bagit.txt is empty") {
-    assertFails("")
+    assertFails(
+      contents = "",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 0")
   }
 
   it("fails if the bagit.txt is nonsense") {
     assertFails(
-      randomAlphanumeric(length = 2000),
+      contents = randomAlphanumeric(length = 2000),
       expectedMessage = "Error loading Bag Declaration (bagit.txt): too large"
     )
   }
 
   it("fails if the bagit.txt has an unwanted key") {
     assertFails(
-      "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key: ShouldNotBeHere"
+      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key: ShouldNotBeHere",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
     )
   }
 
   it("fails if the bagit.txt has unwanted keys") {
     assertFails(
-      "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key1: ShouldNotBeHere\nExtra-Key2: ShouldNotBeHere"
+      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key1: ShouldNotBeHere\nExtra-Key2: ShouldNotBeHere",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 4"
     )
   }
 
   it("fails if the bagit.txt has duplicate keys") {
     assertFails(
-      "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nBagIt-Version: 1.0"
+      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nBagIt-Version: 1.0",
+      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
     )
   }
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclarationTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclarationTest.scala
@@ -90,25 +90,33 @@ class VerifyBagDeclarationTest
   it("fails if the bagit.txt has no BagIt-Version line") {
     assertFails(
       contents = "Tag-File-Character-Encoding: UTF-8\n",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1")
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1"
+    )
   }
 
   it("fails if the bagit.txt has no Tag-File-Character-Encoding line") {
     assertFails(
       contents = "BagIt-Version: 0.97\n",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1")
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 1"
+    )
   }
 
   it("fails if the bagit.txt has the wrong Tag-File-Character-Encoding") {
     assertFails(
       contents = "BagIt-Version: 0.97\nTag-File-Character-Encoding: Latin-1",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): encoding must be UTF-8")
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): encoding must be UTF-8"
+    )
   }
 
   it("fails if the bagit.txt is empty") {
     assertFails(
       contents = "",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 0")
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 0"
+    )
   }
 
   it("fails if the bagit.txt is nonsense") {
@@ -120,22 +128,28 @@ class VerifyBagDeclarationTest
 
   it("fails if the bagit.txt has an unwanted key") {
     assertFails(
-      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key: ShouldNotBeHere",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
+      contents =
+        "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key: ShouldNotBeHere",
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
     )
   }
 
   it("fails if the bagit.txt has unwanted keys") {
     assertFails(
-      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key1: ShouldNotBeHere\nExtra-Key2: ShouldNotBeHere",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 4"
+      contents =
+        "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nExtra-Key1: ShouldNotBeHere\nExtra-Key2: ShouldNotBeHere",
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 4"
     )
   }
 
   it("fails if the bagit.txt has duplicate keys") {
     assertFails(
-      contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nBagIt-Version: 1.0",
-      expectedMessage = s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
+      contents =
+        "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\nBagIt-Version: 1.0",
+      expectedMessage =
+        s"Error loading Bag Declaration (bagit.txt): expected 2 lines, got 3"
     )
   }
 

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagInfoParserTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagInfoParserTest.scala
@@ -69,6 +69,37 @@ class BagInfoParserTest
         )
     }
 
+    it("a bag-info.txt with Windows line endings") {
+      val externalIdentifier = createExternalIdentifier
+      val payloadOxum = createPayloadOxum
+      val baggingDate = randomLocalDate
+      val sourceOrganisation = Some(randomSourceOrganisation)
+      val externalDescription = Some(randomExternalDescription)
+      val internalSenderIdentifier = Some(randomInternalSenderIdentifier)
+      val internalSenderDescription = Some(randomInternalSenderDescription)
+
+      val bagInfoString = Seq(
+        s"External-Identifier: $externalIdentifier",
+        s"Payload-Oxum: $payloadOxum",
+        s"Bagging-Date: $baggingDate",
+        s"Source-Organization: ${sourceOrganisation.get}",
+        s"External-Description: ${externalDescription.get}",
+        s"Internal-Sender-Identifier: ${internalSenderIdentifier.get}",
+        s"Internal-Sender-Description: ${internalSenderDescription.get}"
+      ).mkString("\r\n")
+
+      BagInfoParser.create(toInputStream(bagInfoString)).success.value shouldBe
+        BagInfo(
+          externalIdentifier,
+          payloadOxum,
+          baggingDate,
+          sourceOrganisation,
+          externalDescription,
+          internalSenderIdentifier,
+          internalSenderDescription
+        )
+    }
+
     it("it ignores other metadata fields in the bag-info.txt") {
       val bagInfoString =
         s"""|External-Identifier: $createExternalIdentifier

--- a/common/src/test/scala/weco/storage_service/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/weco/storage_service/fixtures/BagBuilder.scala
@@ -19,6 +19,12 @@ import scala.util.Random
 
 case class PayloadEntry(bagPath: BagPath, path: String, contents: String)
 
+/** This is used to build example bags for testing.
+  *
+  * It exposes a bunch of protected methods that control different bits of the
+  * bag creation process, so you can simulate different mistakes when creating
+  * the bag.  This is particularly useful for testing the bag verifier.
+  */
 trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Namespace]
     extends StorageSpaceGenerators
     with BagInfoGenerators

--- a/common/src/test/scala/weco/storage_service/fixtures/BagBuilder.scala
+++ b/common/src/test/scala/weco/storage_service/fixtures/BagBuilder.scala
@@ -38,7 +38,7 @@ trait BagBuilder[BagLocation <: Location, BagPrefix <: Prefix[BagLocation], Name
   def createBagRoot(
     space: StorageSpace,
     externalIdentifier: ExternalIdentifier,
-    version: BagVersion
+    version: BagVersion = createBagVersion
   )(namespace: Namespace): BagPrefix
 
   def createBagLocation(bagRoot: BagPrefix, path: String): BagLocation


### PR DESCRIPTION
For https://github.com/wellcomecollection/storage-service/issues/894

Previously we had an overly strict regex for matching the Bag Declaration (bagit.txt):

```scala
private val declaration = new Regex(
  "BagIt-Version: \\d\\.\\d+\nTag-File-Character-Encoding: UTF-8\n?"
)
```

Now we defer to Scala to split lines in bagit.txt for us (`String.lines`), so we don't have to worry about supporting different line endings.  This means we get support for Windows line endings for "free".

This approach also means we can provide slightly better error messages when we don't accept the Bag Declaration as supplied, e.g. "encoding must be UTF-8" or "not correctly formatted".

Once this patch is merged, I'll try a Windows bag in the staging environment and see if anything else breaks; if not, I'll close the ticket.