### PR TITLE
Ensure API Gateway Deployments contain all resources

### DIFF
--- a/demo/terraform/README.md
+++ b/demo/terraform/README.md
@@ -23,7 +23,7 @@ It spins up real resources in your AWS account and you will be billed for them.
 
     ```hcl
     module "demo_stack" {
-      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
+      source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=5a61182"
 
       namespace       = "..."  # e.g. weco-dams-prototype
       short_namespace = "..."  # e.g. weco -- this should be 5 chars or less

--- a/demo/terraform/demo_stack/metadata_stores.tf
+++ b/demo/terraform/demo_stack/metadata_stores.tf
@@ -1,5 +1,5 @@
 module "metadata_stores" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=52e10ed"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/critical/metadata_stores?ref=2586bca81"
 
   namespace = var.namespace
 

--- a/demo/terraform/demo_stack/stack.tf
+++ b/demo/terraform/demo_stack/stack.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=52e10ed"
+  source = "github.com/wellcomecollection/storage-service.git//terraform/modules/stack?ref=2586bca81"
 
   namespace = var.short_namespace
 

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 
 
 module "us_demo_stack" {
-  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=b155543"
+  source = "github.com/wellcomecollection/storage-service.git//demo/terraform/demo_stack?ref=5a61182"
 
   namespace       = "weco-us-dams-prototype"
   short_namespace = "weco-us"

--- a/terraform/modules/resource/outputs.tf
+++ b/terraform/modules/resource/outputs.tf
@@ -4,3 +4,15 @@ output "integration_uris" {
     aws_api_gateway_integration.auth_resource.uri,
   ]
 }
+
+output "api_deployment_resource_fingerprint" {
+  description = "An opaque value which changes if the module's API Gateway resources change."
+  value = sha1(jsonencode([
+    aws_api_gateway_integration.auth_resource,
+    aws_api_gateway_integration.auth_subresource,
+    aws_api_gateway_method.auth_resource,
+    aws_api_gateway_method.auth_subresource,
+    aws_api_gateway_resource.auth_resource,
+    aws_api_gateway_resource.auth_subresource,
+  ]))
+}

--- a/terraform/modules/stack/api/gateway.tf
+++ b/terraform/modules/stack/api/gateway.tf
@@ -36,13 +36,6 @@ locals {
 
 resource "aws_api_gateway_deployment" "v1" {
   rest_api_id = aws_api_gateway_rest_api.api.id
-  stage_name  = "v1"
-
-  variables = {
-    bags_port        = local.bags_listener_port
-    ingests_port     = local.ingests_listener_port,
-    integration_uris = local.integration_uri_variable
-  }
 
   triggers = {
     # Re-deploy this deployment if any of the resources it contains are updated.
@@ -59,6 +52,18 @@ resource "aws_api_gateway_deployment" "v1" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "v1" {
+  stage_name    = "v1"
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  deployment_id = aws_api_gateway_deployment.v1.id
+
+  variables = {
+    bags_port        = local.bags_listener_port
+    ingests_port     = local.ingests_listener_port,
+    integration_uris = local.integration_uri_variable
   }
 }
 

--- a/terraform/modules/stack/api/gateway.tf
+++ b/terraform/modules/stack/api/gateway.tf
@@ -44,6 +44,19 @@ resource "aws_api_gateway_deployment" "v1" {
     integration_uris = local.integration_uri_variable
   }
 
+  triggers = {
+    # Re-deploy this deployment if any of the resources it contains are updated.
+    # This also orders the resources to ensure the deployment is created after
+    # all of its consitutent resources are created/updated. See the terraform
+    # docs for aws_api_gateway_deployment which suggests this pattern.
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_authorizer.cognito,
+      local.gateway_responses_resource_fingerprint,
+      module.bags.api_deployment_resource_fingerprint,
+      module.ingests.api_deployment_resource_fingerprint,
+    ]))
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/stack/api/gateway_responses.tf
+++ b/terraform/modules/stack/api/gateway_responses.tf
@@ -143,3 +143,21 @@ module "response_unsupported_media_type" {
 
   rest_api_id = aws_api_gateway_rest_api.api.id
 }
+
+locals {
+  gateway_responses_resource_fingerprint = sha1(jsonencode([
+    module.response_default_5xx.api_deployment_component_fingerprint,
+    module.response_default_4xx.api_deployment_component_fingerprint,
+    module.response_access_denied.api_deployment_component_fingerprint,
+    module.response_bad_request_parameters.api_deployment_component_fingerprint,
+    module.response_bad_request_body.api_deployment_component_fingerprint,
+    module.response_expired_token.api_deployment_component_fingerprint,
+    module.response_invalid_api_key.api_deployment_component_fingerprint,
+    module.response_invalid_signature.api_deployment_component_fingerprint,
+    module.response_missing_authentication_token.api_deployment_component_fingerprint,
+    module.response_quota_exceeded.api_deployment_component_fingerprint,
+    module.response_request_too_large.api_deployment_component_fingerprint,
+    module.response_unauthorized.api_deployment_component_fingerprint,
+    module.response_unsupported_media_type.api_deployment_component_fingerprint,
+  ]))
+}

--- a/terraform/modules/stack/api/outputs.tf
+++ b/terraform/modules/stack/api/outputs.tf
@@ -7,5 +7,5 @@ output "loadbalancer_arn" {
 }
 
 output "invoke_url" {
-  value = aws_api_gateway_deployment.v1.invoke_url
+  value = aws_api_gateway_stage.v1.invoke_url
 }

--- a/terraform/modules/stack/api/response_4xx/main.tf
+++ b/terraform/modules/stack/api/response_4xx/main.tf
@@ -34,3 +34,7 @@ resource "aws_api_gateway_gateway_response" "response" {
   }
 }
 
+output "api_deployment_component_fingerprint" {
+  description = "An opaque value which changes if the module's API Gateway resources change."
+  value       = sha1(jsonencode(aws_api_gateway_gateway_response.response))
+}

--- a/terraform/modules/stack/api/response_5xx/main.tf
+++ b/terraform/modules/stack/api/response_5xx/main.tf
@@ -30,3 +30,7 @@ resource "aws_api_gateway_gateway_response" "response" {
   }
 }
 
+output "api_deployment_component_fingerprint" {
+  description = "An opaque value which changes if the module's API Gateway resources change."
+  value       = sha1(jsonencode(aws_api_gateway_gateway_response.response))
+}


### PR DESCRIPTION
This PR fixes an intermittent issue that can occur on initial Terraform deployments — the API Gateway Deployment can be created before all of the API resources are defined, so things like authentication or API resources/methods may not be present in the Deployment. It also avoids a theoretical problem in that future changes to API resources currently don't trigger the creation of a new Deployment, so API changes wouldn't be visible without manual intervention to update the Deployment.

The fix is to make the relationship between API Gateway resources (`aws_api_gateway_method`,
`aws_api_gateway_resource`, etc) explicit, so that Terraform creates/updates them prior to `aws_api_gateway_deployment`, and also re-creates the Deployment if the resources it indirectly contains are modified. (Terraform doesn't know about these relationships by default as the sub-resources reference the `api_gateway_rest_api`, not the `aws_api_gateway_deployment`).

I've implemented this via the `triggers` argument of the Deployment, much like the example in the terraform docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment

---

Additionally, the "v1" Stage is now explicitly managed as a `api_gateway_stage` resource, rather than having the `aws_api_gateway_deployment` create one automatically via `stage_name`. This is the approach recommended in the `aws_api_gateway_deployment` docs linked above. 

**However, applying this change to an existing deployment re-trigger the original error seen on first apply**: 

> Error creating API Gateway Stage: ConflictException: Stage already exists

The commit message for the change describes why this occurs. To avoid it, the "v1" Stage needs to be manually deleted before the apply. After that the conflict will no longer occur. (I couldn't find a way to avoid this need for manual intervention, other than by renaming the stage, or renaming the `api_gateway_rest_api`, neither of which seemed desirable.)

This explicit Stage management is not required for the resource ordering/Deployment re-creation, so we could drop this aspect of the PR. The warning box in the `api_gateway_deployment` docs describe why it's recommended to explicitly manage the Stage (it avoids a brief period of downtime when the Deployment is re-created).