### PR TITLE
Improve our handling of URI encoding in fetch.txt

### DIFF
--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableTest.scala
@@ -1,0 +1,17 @@
+package weco.storage_service.bag_verifier.storage.s3
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.storage.s3.S3ObjectLocation
+
+import java.net.URI
+
+class S3LocatableTest extends AnyFunSpec with Matchers {
+  it("decodes a percent-encoded space in a URI") {
+    val uri = new URI("s3://example-bucket/key%20with%20spaces.txt")
+
+    S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None) shouldBe Right(
+      S3ObjectLocation(bucket = "example-bucket", key = "key with spaces.txt")
+    )
+  }
+}

--- a/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
@@ -117,7 +117,7 @@ object BagFetch {
   private def decodeUri(line: String, lineNo: Int, u: String): URI =
     Try { new URI(u) } match {
       case Failure(_: URISyntaxException) if u.contains(" ") =>
-        throw new RuntimeException(s"URI is incorrectly formatted on line $lineNo. Spaces should be URL-encoded: $line")
+        throw new RuntimeException(s"URI is incorrectly formatted on line $lineNo. Spaces should be URI-encoded: $line")
 
       case Failure(e: URISyntaxException) =>
         val wrappedExc = new URISyntaxException(line, e.getReason, e.getIndex)

--- a/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
@@ -130,8 +130,14 @@ object BagFetch {
   private def decodeLength(ls: String): Option[Long] =
     if (ls == "-") None else Some(ls.toLong)
 
+  // Quoting RFC 8493 § 2.2.3 (https://datatracker.ietf.org/doc/html/rfc8493#section-2.2.3):
+  //
+  //      If _filename_ includes an LF, a CR, a CRLF, or a percent sign (%), those
+  //      characters (and only those) MUST be percent-encoded as described in [RFC3986].
+  //
   private def decodeFilepath(path: String): String =
     path
       .replaceAll("%0A", "\n")
       .replaceAll("%0D", "\r")
+      .replaceAll("%25", "%")
 }

--- a/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
@@ -106,7 +106,7 @@ class BagFetchTest
 
       val exc = BagFetch.create(contents).failed.get
       exc shouldBe a[RuntimeException]
-      exc.getMessage shouldBe s"URI is incorrectly formatted on line 1. Spaces should be URL-encoded: $line"
+      exc.getMessage shouldBe s"URI is incorrectly formatted on line 1. Spaces should be URI-encoded: $line"
     }
 
     it("throws an exception for an illegal URI") {

--- a/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
@@ -1,11 +1,12 @@
 package weco.storage_service.bagit.models
 
 import java.io.InputStream
-
 import org.apache.commons.io.IOUtils
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.storage_service.generators.FetchMetadataGenerators
+
+import java.net.URI
 
 class BagFetchTest
     extends AnyFunSpec
@@ -80,6 +81,38 @@ class BagFetchTest
         "data/example\n2\n.txt",
         "data/example\r\n3\r\n.txt"
       )
+    }
+
+    it("correctly decodes a percent-encoded space in the URI") {
+      val lines = "http://example.org/abc%20def - data/example 1.txt"
+
+      val contents = toInputStream(lines)
+
+      BagFetch.create(contents).get shouldBe BagFetch(
+        entries = Map(
+          BagPath("data/example 1.txt") -> BagFetchMetadata(
+            uri = new URI("http://example.org/abc%20def"),
+            length = None
+          )
+        )
+      )
+    }
+
+    it("returns a helpful error for spaces in the URI") {
+      val line = "http://example.org/abc def - data/example.txt"
+      val contents = toInputStream(line)
+
+      val exc = BagFetch.create(contents).failed.get
+      exc shouldBe a[RuntimeException]
+      exc.getMessage shouldBe s"URI is incorrectly formatted on line 1. Spaces should be URL-encoded: $line"
+    }
+
+    it("throws an exception for an illegal URI") {
+      val line = "{uri} - data/example.txt"
+      val contents = toInputStream(line)
+
+      val exc = BagFetch.create(contents).failed.get
+      exc.getMessage shouldBe s"URI is incorrectly formatted on line 1. Illegal character in path at index 0: {uri} - data/example.txt"
     }
 
     it("throws an exception if a line is incorrectly formatted") {

--- a/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
@@ -69,7 +69,9 @@ class BagFetchTest
       BagFetch.create(contents).get.entries shouldBe expected
     }
 
-    it("correctly decodes a percent-encoded CR/LF/CRLF or percentage in the file path") {
+    it(
+      "correctly decodes a percent-encoded CR/LF/CRLF or percentage in the file path"
+    ) {
       val contents = toInputStream(s"""
                                       |http://example.org/abc - data/example%0D1%0D.txt
                                       |http://example.org/abc - data/example%0A2%0A.txt
@@ -81,7 +83,7 @@ class BagFetchTest
         "data/example\r1\r.txt",
         "data/example\n2\n.txt",
         "data/example\r\n3\r\n.txt",
-        "data/example%4%.txt",
+        "data/example%4%.txt"
       )
     }
 

--- a/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/BagFetchTest.scala
@@ -69,17 +69,19 @@ class BagFetchTest
       BagFetch.create(contents).get.entries shouldBe expected
     }
 
-    it("correctly decodes a percent-encoded CR/LF/CRLF in the file path") {
+    it("correctly decodes a percent-encoded CR/LF/CRLF or percentage in the file path") {
       val contents = toInputStream(s"""
                                       |http://example.org/abc - data/example%0D1%0D.txt
                                       |http://example.org/abc - data/example%0A2%0A.txt
                                       |http://example.org/abc - data/example%0D%0A3%0D%0A.txt
+                                      |http://example.org/abc - data/example%254%25.txt
        """.stripMargin)
 
       BagFetch.create(contents).get.paths.map { _.toString } shouldBe Seq(
         "data/example\r1\r.txt",
         "data/example\n2\n.txt",
-        "data/example\r\n3\r\n.txt"
+        "data/example\r\n3\r\n.txt",
+        "data/example%4%.txt",
       )
     }
 


### PR DESCRIPTION
This slightly improves the error if you have a space in the URI

    Error loading fetch.txt: URI is incorrectly formatted on line 1.
    Spaces should be URI-encoded: http://example.org/abc def - data/example.txt

We also include the line number for other URI parsing errors, e.g.

    Error loading fetch.txt: URI is incorrectly formatted on line 1.
    Illegal character in path at index 0: {uri} - data/example.txt

Plus handling percent characters in the URI to properly adhere to the BagIt RFC.