### PR TITLE
Read multiple checksums in the BagReader

### DIFF
--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -351,7 +351,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     }
   }
 
-  it("fails a bag if the file manifest does not exist") {
+  it("fails a bag if there are no payload manifests") {
     val badBuilder = new BagBuilderImpl {
       override protected def createPayloadManifest(
         entries: Seq[PayloadEntry]
@@ -364,13 +364,13 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val error = summary.e
 
         error shouldBe a[BagUnavailable]
-        error.getMessage should include("Error loading manifest-sha256.txt")
+        error.getMessage should include("Could not find any payload manifests in the bag")
 
-        ingestFailed.maybeUserFacingMessage.get shouldBe "Error loading manifest-sha256.txt: no such file!"
+        ingestFailed.maybeUserFacingMessage.get shouldBe "Could not find any payload manifests in the bag"
     }
   }
 
-  it("fails a bag if the tag manifest does not exist") {
+  it("fails a bag if there are no tag manifests") {
     val badBuilder = new BagBuilderImpl {
       override protected def createTagManifest(
         entries: Seq[ManifestFile]
@@ -383,9 +383,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val error = summary.e
 
         error shouldBe a[BagUnavailable]
-        error.getMessage should include("Error loading tagmanifest-sha256.txt")
+        error.getMessage should include("Could not find any tag manifests in the bag")
 
-        ingestFailed.maybeUserFacingMessage.get shouldBe "Error loading tagmanifest-sha256.txt: no such file!"
+        ingestFailed.maybeUserFacingMessage.get shouldBe "Could not find any tag manifests in the bag"
     }
   }
 
@@ -725,34 +725,6 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
             "Files referred to in the fetch.txt also appear in the bag:"
           )
       }
-    }
-
-    it("passes a bag that includes an extra manifest/tag manifest") {
-      val space = createStorageSpace
-      val externalIdentifier = createExternalIdentifier
-
-      withNamespace { implicit namespace =>
-        withBag(space, externalIdentifier) {
-          case (primaryBucket, bagRoot) =>
-            val location = bagRoot.asLocation("tagmanifest-sha512.txt")
-            writeFile(location)
-
-            val ingestStep =
-              withBagContext(bagRoot) { bagContext =>
-                withVerifier(primaryBucket) {
-                  _.verify(
-                    ingestId = createIngestID,
-                    bagContext = bagContext,
-                    space = space,
-                    externalIdentifier = externalIdentifier
-                  )
-                }
-              }
-
-            ingestStep.success.get shouldBe a[IngestStepSucceeded[_]]
-        }
-      }
-
     }
   }
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -364,7 +364,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val error = summary.e
 
         error shouldBe a[BagUnavailable]
-        error.getMessage should include("Could not find any payload manifests in the bag")
+        error.getMessage should include(
+          "Could not find any payload manifests in the bag"
+        )
 
         ingestFailed.maybeUserFacingMessage.get shouldBe "Could not find any payload manifests in the bag"
     }
@@ -383,7 +385,9 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val error = summary.e
 
         error shouldBe a[BagUnavailable]
-        error.getMessage should include("Could not find any tag manifests in the bag")
+        error.getMessage should include(
+          "Could not find any tag manifests in the bag"
+        )
 
         ingestFailed.maybeUserFacingMessage.get shouldBe "Could not find any tag manifests in the bag"
     }

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
@@ -1,9 +1,8 @@
 package weco.storage_service.bagit.services
 
 import java.io.InputStream
-
 import weco.storage_service.bagit.models._
-import weco.storage_service.checksum.{ChecksumAlgorithm, SHA256}
+import weco.storage_service.checksum.{ChecksumAlgorithm, ChecksumAlgorithms, ChecksumValue, MD5, MultiManifestChecksum, MultiManifestChecksumException, SHA1, SHA256, SHA512}
 import weco.storage._
 import weco.storage.store.Readable
 import weco.storage.streaming.InputStreamWithLength
@@ -37,27 +36,182 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
 
   private def loadPayloadManifest(
     bagRoot: BagPrefix
-  ): Either[BagUnavailable, PayloadManifest] =
-    loadRequired[PayloadManifest](bagRoot)(fileManifest(SHA256))(
-      (inputStream: InputStream) =>
-        BagManifestParser.parse(inputStream).map { entries =>
-          PayloadManifest(
-            checksumAlgorithm = SHA256,
-            entries = entries
+  ): Either[BagUnavailable, NewPayloadManifest] =
+    loadManifestEntries(bagRoot)(fileManifest) match {
+      case Right((algorithms, entries)) =>
+        Right(NewPayloadManifest(algorithms, entries))
+      case Left(ManifestError.CannotBeLoaded(err)) => Left(err)
+      case Left(ManifestError.NoManifestsFound) =>
+        Left(
+          BagUnavailable("Could not find any payload manifests in the bag")
+        )
+      case Left(ManifestError.InconsistentFilenames) =>
+        Left(
+          BagUnavailable(
+            "Payload manifests are inconsistent: every payload file must be listed in every payload manifest"
           )
-        }
-    )
+        )
+
+      case Left(ManifestError.OnlyDeprecatedChecksums) =>
+        // We'll need to update this error message if we add support for other checksum algorithms.
+        // A runtime assertion is meant to draw our attention to it, rather than introducing the
+        // unnecessary complexity of creating this message dynamically.
+        require(ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512))
+        Left(
+          BagUnavailable(
+            "Payload manifests only use deprecated checksums: add a payload manifest using SHA-256 or SHA-512"
+          )
+        )
+
+      case Left(_) =>
+        Left(
+          BagUnavailable("Unknown error while trying to read payload manifests")
+        )
+    }
 
   private def loadTagManifest(bagRoot: BagPrefix) =
-    loadRequired[TagManifest](bagRoot)(tagManifest(SHA256))(
-      (inputStream: InputStream) =>
-        BagManifestParser.parse(inputStream).map { entries =>
-          TagManifest(
-            checksumAlgorithm = SHA256,
-            entries = entries
+    loadManifestEntries(bagRoot)(tagManifest) match {
+      case Right((algorithms, entries)) =>
+        Right(NewTagManifest(algorithms, entries))
+      case Left(ManifestError.CannotBeLoaded(err)) => Left(err)
+      case Left(ManifestError.NoManifestsFound) =>
+        Left(BagUnavailable("Could not find any tag manifests in the bag"))
+      case Left(ManifestError.InconsistentFilenames) =>
+        Left(
+          BagUnavailable(
+            "Tag manifests are inconsistent: each tag manifest should list the same set of tag files"
           )
-        }
-    )
+        )
+
+      case Left(ManifestError.OnlyDeprecatedChecksums) =>
+        // We'll need to update this error message if we add support for other checksum algorithms.
+        // A runtime assertion is meant to draw our attention to it, rather than introducing the
+        // unnecessary complexity of creating this message dynamically.
+        require(ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512))
+        Left(
+          BagUnavailable(
+            "Tag manifests only use weak checksums: add a tag manifest using SHA-256 or SHA-512"
+          )
+        )
+
+      case Left(_) =>
+        Left(
+          BagUnavailable("Unknown error while trying to read tag manifests")
+        )
+    }
+
+  private sealed trait ManifestError
+  private object ManifestError {
+    case class CannotBeLoaded(err: BagUnavailable) extends ManifestError
+    case object NoManifestsFound extends ManifestError
+    case object InconsistentFilenames extends ManifestError
+    case object OnlyDeprecatedChecksums extends ManifestError
+    case class UnknownError(t: Throwable) extends ManifestError
+  }
+
+  /** Loads all the entries for every instance of a type of manifest.
+    *
+    * i.e. loads manifest-{algorithm}.txt or tagmanifest-{algorithm}.txt for
+    * every supported checksum algorithm
+    *
+    * Returns a list of checksum algorithms for which the manifest files are defined
+    * in the bag, and a list of entries correlated across the manifests.  These are
+    * returned separately because the list of entries may be empty (if there's nothing
+    * in the payload manifests).
+    *
+    * This function is responsible for checking consistency within a type of manifest,
+    * e.g. does every manifest list the same filenames.  Callers may assume the manifest
+    * data is consistent, although we can't easily enforce that in the type system.
+    *
+    */
+  private def loadManifestEntries(root: BagPrefix)(filename: ChecksumAlgorithm => BagPath): Either[
+    ManifestError,
+    (Set[ChecksumAlgorithm], Map[BagPath, MultiManifestChecksum])
+  ] =
+
+    for {
+      md5 <- loadSingleManifest(root, filename(MD5))
+      sha1 <- loadSingleManifest(root, filename(SHA1))
+      sha256 <- loadSingleManifest(root, filename(SHA256))
+      sha512 <- loadSingleManifest(root, filename(SHA512))
+
+      presentManifests <- {
+        val readValues = Map(
+          MD5 -> md5,
+          SHA1 -> sha1,
+          SHA256 -> sha256,
+          SHA512 -> sha512
+        )
+
+        // This assertion is meant to remind us that we need to change this code
+        // when we add new checksum algorithms.
+        //
+        // I did try writing this code in a dynamic way that automatically picks up
+        // new checksum algorithms, but I couldn't find a way that doesn't make
+        // the code much more complicated.  Given we don't even know if we'll ever
+        // add new checksum algorithms, a single runtime assertion feels like
+        // better than adding substantial complexity here.
+        require(readValues.size == ChecksumAlgorithms.algorithms.size)
+
+        val extantValues: Map[ChecksumAlgorithm, Map[BagPath, ChecksumValue]] =
+          readValues
+            .collect { case (algorithm, Some(entries)) => (algorithm, entries)}
+
+        Either.cond(
+          extantValues.nonEmpty,
+          extantValues,
+          ManifestError.NoManifestsFound
+        )
+      }
+
+      algorithms = presentManifests.keys.toSet
+      manifests = presentManifests.values.toSeq
+
+      // RFC 8493 § 3 (https://datatracker.ietf.org/doc/html/rfc8493#section-3):
+      //
+      //      For BagIt 1.0, every payload file MUST be listed in every payload
+      //      manifest.  Note that older versions of BagIt allowed payload
+      //      files to be listed in just one of the manifests.
+      //
+      filenames <- manifests.map(_.keys.toSeq).distinct match {
+        case Seq(names) => Right(names)
+        case _          => Left(ManifestError.InconsistentFilenames)
+      }
+
+      entries <- Try {
+        filenames.map { bagPath =>
+          bagPath -> MultiManifestChecksum(
+            md5 = md5.map(_(bagPath)),
+            sha1 = sha1.map(_(bagPath)),
+            sha256 = sha256.map(_(bagPath)),
+            sha512 = sha512.map(_(bagPath))
+          )
+        }.toMap
+      } match {
+        case Success(entries) => Right(entries)
+        case Failure(MultiManifestChecksumException.OnlyDeprecatedChecksums) =>
+          Left(ManifestError.OnlyDeprecatedChecksums)
+        case Failure(t) => Left(ManifestError.UnknownError(t))
+      }
+
+      // If this isn't the case, we should have caught it with one of the checks above --
+      // this is just to catch a programmer error.
+      _ = require(
+        entries.values.forall(_.definedAlgorithms == algorithms)
+      )
+
+    } yield (algorithms, entries)
+
+
+  private def loadSingleManifest(
+    root: BagPrefix,
+    path: BagPath
+  ): Either[ManifestError.CannotBeLoaded, Option[Map[BagPath, ChecksumValue]]] =
+    loadOptional[Map[BagPath, ChecksumValue]](root)(path)(BagManifestParser.parse) match {
+      case Right(entries) => Right(entries)
+      case Left(bagUnavailable) =>
+        Left(ManifestError.CannotBeLoaded(bagUnavailable))
+    }
 
   private def loadFetch(
     bagRoot: BagPrefix

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
@@ -2,7 +2,17 @@ package weco.storage_service.bagit.services
 
 import java.io.InputStream
 import weco.storage_service.bagit.models._
-import weco.storage_service.checksum.{ChecksumAlgorithm, ChecksumAlgorithms, ChecksumValue, MD5, MultiManifestChecksum, MultiManifestChecksumException, SHA1, SHA256, SHA512}
+import weco.storage_service.checksum.{
+  ChecksumAlgorithm,
+  ChecksumAlgorithms,
+  ChecksumValue,
+  MD5,
+  MultiManifestChecksum,
+  MultiManifestChecksumException,
+  SHA1,
+  SHA256,
+  SHA512
+}
 import weco.storage._
 import weco.storage.store.Readable
 import weco.storage.streaming.InputStreamWithLength
@@ -58,7 +68,9 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // We'll need to update this error message if we add support for other checksum algorithms.
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
-        require(ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512))
+        require(
+          ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512)
+        )
         Left(
           BagUnavailable(
             "Payload manifests only use deprecated checksums: add a payload manifest using SHA-256 or SHA-512"
@@ -89,7 +101,9 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // We'll need to update this error message if we add support for other checksum algorithms.
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
-        require(ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512))
+        require(
+          ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512)
+        )
         Left(
           BagUnavailable(
             "Tag manifests only use weak checksums: add a tag manifest using SHA-256 or SHA-512"
@@ -110,11 +124,16 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
   // We're already stricter than the spec by requiring tag manifests be present (which are
   // optional in the spec); similarly here we treat this SHOULD as a MUST.
   //
-  private def compareAlgorithms(payloadManifest: NewPayloadManifest, tagManifest: NewTagManifest): Either[BagUnavailable, Unit] =
+  private def compareAlgorithms(
+    payloadManifest: NewPayloadManifest,
+    tagManifest: NewTagManifest
+  ): Either[BagUnavailable, Unit] =
     Either.cond(
       payloadManifest.algorithms == tagManifest.algorithms,
       (),
-      BagUnavailable("Manifests are inconsistent: tag manifests should use the same algorithms as the payload manifests in the bag")
+      BagUnavailable(
+        "Manifests are inconsistent: tag manifests should use the same algorithms as the payload manifests in the bag"
+      )
     )
 
   private sealed trait ManifestError
@@ -141,11 +160,12 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
     * data is consistent, although we can't easily enforce that in the type system.
     *
     */
-  private def loadManifestEntries(root: BagPrefix)(filename: ChecksumAlgorithm => BagPath): Either[
+  private def loadManifestEntries(
+    root: BagPrefix
+  )(filename: ChecksumAlgorithm => BagPath): Either[
     ManifestError,
     (Set[ChecksumAlgorithm], Map[BagPath, MultiManifestChecksum])
   ] =
-
     for {
       md5 <- loadSingleManifest(root, filename(MD5))
       sha1 <- loadSingleManifest(root, filename(SHA1))
@@ -172,7 +192,7 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
 
         val extantValues: Map[ChecksumAlgorithm, Map[BagPath, ChecksumValue]] =
           readValues
-            .collect { case (algorithm, Some(entries)) => (algorithm, entries)}
+            .collect { case (algorithm, Some(entries)) => (algorithm, entries) }
 
         Either.cond(
           extantValues.nonEmpty,
@@ -219,12 +239,13 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
 
     } yield (algorithms, entries)
 
-
   private def loadSingleManifest(
     root: BagPrefix,
     path: BagPath
   ): Either[ManifestError.CannotBeLoaded, Option[Map[BagPath, ChecksumValue]]] =
-    loadOptional[Map[BagPath, ChecksumValue]](root)(path)(BagManifestParser.parse) match {
+    loadOptional[Map[BagPath, ChecksumValue]](root)(path)(
+      BagManifestParser.parse
+    ) match {
       case Right(entries) => Right(entries)
       case Left(bagUnavailable) =>
         Left(ManifestError.CannotBeLoaded(bagUnavailable))

--- a/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
@@ -37,6 +37,10 @@ sealed trait ChecksumAlgorithm {
 
 case object ChecksumAlgorithms {
   val algorithms: Set[ChecksumAlgorithm] = Set(SHA512, SHA256, SHA1, MD5)
+
+  val nonDeprecatedAlgorithms: Set[ChecksumAlgorithm] =
+    algorithms
+      .filterNot(_.isForBackwardsCompatibilityOnly)
 }
 
 case object SHA512 extends ChecksumAlgorithm {

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
@@ -172,14 +172,6 @@ trait BagReaderTestCases[
     }
   }
 
-  private def createMultiManifestChecksumWith(md5: String, sha512: String): MultiManifestChecksum =
-    MultiManifestChecksum(
-      md5 = Some(ChecksumValue(md5)),
-      sha1 = None,
-      sha256 = None,
-      sha512 = Some(ChecksumValue(sha512))
-    )
-
   it("errors if the bag-info.txt file does not exist") {
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace, bucket) = fixtures
@@ -535,4 +527,12 @@ trait BagReaderTestCases[
 
     (bagContents.bagRoot, bagContents.bagInfo)
   }
+
+  private def createMultiManifestChecksumWith(md5: String, sha512: String): MultiManifestChecksum =
+    MultiManifestChecksum(
+      md5 = Some(ChecksumValue(md5)),
+      sha1 = None,
+      sha256 = None,
+      sha512 = Some(ChecksumValue(sha512))
+    )
 }

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
@@ -117,7 +117,7 @@ trait BagReaderTestCases[
 
       withBagReader {
         _.get(bagRoot).left.value.msg should startWith(
-          "Error loading manifest-sha256.txt"
+          "Could not find any payload manifests in the bag"
         )
       }
     }
@@ -147,7 +147,7 @@ trait BagReaderTestCases[
 
       withBagReader {
         _.get(bagRoot).left.value.msg should startWith(
-          "Error loading tagmanifest-sha256.txt"
+          "Could not find any tag manifests in the bag"
         )
       }
     }

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagReaderTestCases.scala
@@ -4,14 +4,26 @@ import org.scalatest.{Assertion, EitherValues}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.fixtures.TestWith
-import weco.storage_service.bagit.models.{BagInfo, BagPath, ExternalIdentifier, NewPayloadManifest, NewTagManifest, PayloadOxum}
+import weco.storage_service.bagit.models.{
+  BagInfo,
+  BagPath,
+  ExternalIdentifier,
+  NewPayloadManifest,
+  NewTagManifest,
+  PayloadOxum
+}
 import weco.storage_service.fixtures.BagBuilder
 import weco.storage_service.generators.StorageRandomGenerators
 import weco.storage.fixtures.S3Fixtures
 import weco.storage.fixtures.S3Fixtures.Bucket
 import weco.storage.{Location, Prefix}
 import weco.storage.store.TypedStore
-import weco.storage_service.checksum.{ChecksumValue, MD5, MultiManifestChecksum, SHA512}
+import weco.storage_service.checksum.{
+  ChecksumValue,
+  MD5,
+  MultiManifestChecksum,
+  SHA512
+}
 
 import java.time.LocalDate
 
@@ -106,11 +118,11 @@ trait BagReaderTestCases[
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: multiple_manifests\n" +
               "Payload-Oxum: 15.1\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-sha512.txt") -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8  data/README.txt\n",
           bagRoot
@@ -120,13 +132,13 @@ trait BagReaderTestCases[
               "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6  bagit.txt\n" +
               "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9  manifest-sha512.txt\n" +
               "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6  manifest-md5.txt\n"
-            ),
+          ),
           bagRoot.asLocation("tagmanifest-md5.txt") -> (
             "aa3c5e977224a9186dbb36ef1193be0d  bag-info.txt\n" +
               "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
               "d570da37be627c3955c165422e667245  manifest-sha512.txt\n" +
               "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -143,7 +155,8 @@ trait BagReaderTestCases[
         entries = Map(
           BagPath("data/README.txt") -> createMultiManifestChecksumWith(
             md5 = "a86e2699931d4f3d1456e79383749e43",
-            sha512 = "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8"
+            sha512 =
+              "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8"
           )
         )
       )
@@ -153,19 +166,23 @@ trait BagReaderTestCases[
         entries = Map(
           BagPath("bag-info.txt") -> createMultiManifestChecksumWith(
             md5 = "aa3c5e977224a9186dbb36ef1193be0d",
-            sha512 = "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa"
+            sha512 =
+              "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa"
           ),
           BagPath("bagit.txt") -> createMultiManifestChecksumWith(
             md5 = "9e5ad981e0d29adc278f6a294b8c2aca",
-            sha512 = "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6"
+            sha512 =
+              "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6"
           ),
           BagPath("manifest-sha512.txt") -> createMultiManifestChecksumWith(
             md5 = "d570da37be627c3955c165422e667245",
-            sha512 = "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9"
+            sha512 =
+              "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9"
           ),
           BagPath("manifest-md5.txt") -> createMultiManifestChecksumWith(
             md5 = "7983626d0844789acfe8059b6730b9d1",
-            sha512 = "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6"
+            sha512 =
+              "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6"
           )
         )
       )
@@ -232,7 +249,7 @@ trait BagReaderTestCases[
     }
   }
 
-  it("errors if different payload manifests have different files")  {
+  it("errors if different payload manifests have different files") {
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace, bucket) = fixtures
 
@@ -258,11 +275,11 @@ trait BagReaderTestCases[
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: mismatched_files\n" +
               "Payload-Oxum: 35.2\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-sha1.txt") -> "897589b7c274b17a1d02a74cf0b1128ad286d94e  data/ANOTHER.txt\n",
           bagRoot
@@ -272,13 +289,13 @@ trait BagReaderTestCases[
               "e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt\n" +
               "620cf3a28d891c8e27e3f8b79fb9b87eec0b9543  manifest-sha1.txt\n" +
               "e0f93804f40bbeae4c5440ce197d3856e1367d77  manifest-md5.txt\n"
-            ),
+          ),
           bagRoot.asLocation("tagmanifest-md5.txt") -> (
             "139536a64db2ac0373fcfd83a379718b  bag-info.txt\n" +
               "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
               "a1e301444f5e48cebfb0480e6ded97ec  manifest-sha1.txt\n" +
               "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -349,11 +366,11 @@ trait BagReaderTestCases[
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: multiple_manifests\n" +
               "Payload-Oxum: 15.1\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-sha512.txt") -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8  data/README.txt\n",
           bagRoot
@@ -362,12 +379,12 @@ trait BagReaderTestCases[
             "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa  bag-info.txt\n" +
               "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6  bagit.txt\n" +
               "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9  manifest-sha512.txt\n"
-            ),
+          ),
           bagRoot.asLocation("tagmanifest-md5.txt") -> (
             "aa3c5e977224a9186dbb36ef1193be0d  bag-info.txt\n" +
               "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
               "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -408,11 +425,11 @@ trait BagReaderTestCases[
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: weak_algorithms\n" +
               "Payload-Oxum: 15.1\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-md5.txt") -> "a86e2699931d4f3d1456e79383749e43  data/README.txt\n",
           bagRoot.asLocation("tagmanifest-md5.txt") -> (
@@ -420,7 +437,7 @@ trait BagReaderTestCases[
               "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
               "d570da37be627c3955c165422e667245  manifest-sha512.txt\n" +
               "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -461,18 +478,18 @@ trait BagReaderTestCases[
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: different_checksums\n" +
               "Payload-Oxum: 15.1\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-sha512.txt") -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8  data/README.txt\n",
           bagRoot.asLocation("tagmanifest-sha256.txt") -> (
             "1ad8750c4a30a82cff48049c6aa65d60dfef7d54bc7f5f54055d2c60a5bba851  bag-info.txt\n" +
               "e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689  bagit.txt\n" +
               "33f48fd5df3bb188f874c033adab20e39b8e24c823e32fae99ee539317e8badf  manifest-sha512.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -528,7 +545,10 @@ trait BagReaderTestCases[
     (bagContents.bagRoot, bagContents.bagInfo)
   }
 
-  private def createMultiManifestChecksumWith(md5: String, sha512: String): MultiManifestChecksum =
+  private def createMultiManifestChecksumWith(
+    md5: String,
+    sha512: String
+  ): MultiManifestChecksum =
     MultiManifestChecksum(
       md5 = Some(ChecksumValue(md5)),
       sha1 = None,


### PR DESCRIPTION
For #900, follows #909.

This patch means that whenever we read a bag from S3 or Azure, we'll read all the available manifests and check they're consistent. The applications will only look at the SHA256 manifest, but the other manifests will be sitting in-memory waiting to be used.

In places we're taking a stricter reading of the BagIt spec in a way that I think is mostly fine – e.g. the BagIt spec says you SHOULD use the same algorithms for payload and tag manifests, but doesn't actually require it. This code does require they're the same.

(The BagIt spec also lists tag manifests as an optional element, but we require them.)