### PR TITLE
Minor tweaks stepping towards a multi-checksum verifier

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyPayloadOxum.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyPayloadOxum.scala
@@ -7,7 +7,7 @@ import weco.storage_service.bagit.models.Bag
 trait VerifyPayloadOxum {
   def verifyPayloadOxumFileCount(bag: Bag): Either[BagVerifierError, Unit] = {
     val payloadOxumCount = bag.info.payloadOxum.numberOfPayloadFiles
-    val manifestCount = bag.manifest.entries.size
+    val manifestCount = bag.newManifest.entries.size
 
     if (payloadOxumCount != manifestCount) {
       Left(
@@ -27,12 +27,12 @@ trait VerifyPayloadOxum {
     // The Payload-Oxum octetstream sum only counts the size of files in the payload,
     // not manifest files such as the bag-info.txt file.
     // We need to filter those out.
-    val dataFilePaths = bag.manifest.paths
+    val payloadPaths = bag.newManifest.entries.keys.toSet
 
     val actualSize =
       locations
         .filter { loc =>
-          dataFilePaths.contains(loc.expectedFileFixity.path)
+          payloadPaths.contains(loc.expectedFileFixity.path)
         }
         .map { _.size }
         .sum

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTagsTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTagsTestCases.scala
@@ -43,7 +43,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
           checksum = checksum
         )
 
-        withFixityChecker { fixityChecker =>
+        withFixityChecker() { fixityChecker =>
           fixityChecker.check(expectedFileFixity) shouldBe a[
             FileFixityCorrect[_]
           ]
@@ -191,7 +191,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
           location = location
         )
 
-        withFixityChecker { fixityChecker =>
+        withFixityChecker() { fixityChecker =>
           fixityChecker.check(expectedFileFixity) shouldBe a[
             FileFixityMismatch[_]
           ]
@@ -227,7 +227,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
         val location = createLocationWith(namespace)
         putString(location, contentString)
 
-        withFixityChecker { fixityChecker =>
+        withFixityChecker() { fixityChecker =>
           allChecksums.foreach { checksum =>
             val expectedFileFixity = createDataDirectoryFileFixityWith(
               location = location,

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
@@ -48,7 +48,7 @@ trait FixityCheckerTestCases[
     implicit context: Context
   ): R
 
-  def withFixityChecker[R](
+  def withFixityChecker[R]()(
     testWith: TestWith[FixityChecker[BagLocation, BagPrefix], R]
   )(
     implicit context: Context
@@ -79,7 +79,7 @@ trait FixityCheckerTestCases[
         )
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 
@@ -105,7 +105,7 @@ trait FixityCheckerTestCases[
         )
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 
@@ -137,7 +137,7 @@ trait FixityCheckerTestCases[
         )
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 
@@ -177,7 +177,7 @@ trait FixityCheckerTestCases[
         putString(location, contentString)
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 
@@ -216,7 +216,7 @@ trait FixityCheckerTestCases[
         putString(location, contentString)
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 
@@ -250,7 +250,7 @@ trait FixityCheckerTestCases[
         putString(location, contentString)
 
         val result =
-          withFixityChecker {
+          withFixityChecker() {
             _.check(expectedFileFixity)
           }
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/s3/S3FixityCheckerTest.scala
@@ -88,7 +88,7 @@ class S3FixityCheckerTest
     )
 
     val result =
-      withFixityChecker {
+      withFixityChecker() {
         _.check(expectedFileFixity)
       }
 
@@ -112,7 +112,7 @@ class S3FixityCheckerTest
     )
 
     val result =
-      withFixityChecker {
+      withFixityChecker() {
         _.check(expectedFileFixity)
       }
 
@@ -137,7 +137,7 @@ class S3FixityCheckerTest
       )
 
       val result =
-        withFixityChecker {
+        withFixityChecker() {
           _.check(expectedFileFixity)
         }
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
@@ -54,7 +54,7 @@ trait S3BagVerifierTests[Verifier <: BagVerifier[
     new S3BagReader()
 
   override val bagBuilder
-  : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
     new S3BagBuilder {}
 }
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
@@ -52,6 +52,10 @@ trait S3BagVerifierTests[Verifier <: BagVerifier[
   override def createBagReader
     : BagReader[S3ObjectLocation, S3ObjectLocationPrefix] =
     new S3BagReader()
+
+  override val bagBuilder
+  : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
+    new S3BagBuilder {}
 }
 
 class S3ReplicatedBagVerifierTest
@@ -79,11 +83,6 @@ class S3ReplicatedBagVerifierTest
     testWith(
       S3BagVerifier.replicated(primaryBucket = primaryBucket.name)
     )
-
-  override val bagBuilder
-    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
-    new S3BagBuilder {}
-
 }
 
 class S3StandaloneBagVerifierTest
@@ -104,10 +103,6 @@ class S3StandaloneBagVerifierTest
     testWith(
       S3BagVerifier.standalone(primaryBucket = primaryBucket.name)
     )
-
-  override val bagBuilder
-    : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
-    new S3BagBuilder {}
 
   override def withBagContext[R](bagRoot: S3ObjectLocationPrefix)(
     testWith: TestWith[StandaloneBagVerifyContext, R]

--- a/common/src/main/scala/weco/storage_service/bagit/models/BagManifest.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/BagManifest.scala
@@ -9,8 +9,6 @@ import weco.storage_service.checksum.{
 sealed trait BagManifest {
   val checksumAlgorithm: ChecksumAlgorithm
   val entries: Map[BagPath, ChecksumValue]
-
-  def paths: Seq[BagPath] = entries.keys.toSeq
 }
 
 case class PayloadManifest(
@@ -26,8 +24,6 @@ case class TagManifest(
 sealed trait NewBagManifest {
   val algorithms: Set[ChecksumAlgorithm]
   val entries: Map[BagPath, MultiManifestChecksum]
-
-  def paths: Seq[BagPath] = entries.keys.toSeq
 
   // Check that every file is using the same set of algorithms.  It would be
   // an error if, say, one file had an MD5 and SHA-256 checksum and another file

--- a/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
@@ -1,0 +1,7 @@
+package weco.storage_service.checksum
+
+case class MismatchedChecksum(
+  algorithm: ChecksumAlgorithm,
+  expected: ChecksumValue,
+  actual: ChecksumValue
+)

--- a/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
@@ -4,4 +4,9 @@ case class MismatchedChecksum(
   algorithm: ChecksumAlgorithm,
   expected: ChecksumValue,
   actual: ChecksumValue
-)
+) {
+  require(expected != actual)
+
+  def description: String =
+    s"Expected ${algorithm.pathRepr}:$expected, saw ${algorithm.pathRepr}:$actual"
+}

--- a/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
@@ -29,23 +29,26 @@ case class MultiChecksum(
     * expected checksum, or are they different?
     *
     */
-  def compare(manifestChecksum: MultiManifestChecksum): Either[Seq[MismatchedChecksum], Unit] = {
+  def compare(
+    manifestChecksum: MultiManifestChecksum
+  ): Either[Seq[MismatchedChecksum], Unit] = {
     val mismatches =
       manifestChecksum.definedChecksums
-        .flatMap { case (algorithm, expectedValue) =>
-          val actualValue = getValue(algorithm)
+        .flatMap {
+          case (algorithm, expectedValue) =>
+            val actualValue = getValue(algorithm)
 
-          if (expectedValue == actualValue) {
-            None
-          } else {
-            Some(
-              MismatchedChecksum(
-                algorithm = algorithm,
-                expected = expectedValue,
-                actual = actualValue
+            if (expectedValue == actualValue) {
+              None
+            } else {
+              Some(
+                MismatchedChecksum(
+                  algorithm = algorithm,
+                  expected = expectedValue,
+                  actual = actualValue
+                )
               )
-            )
-          }
+            }
         }
         .toSeq
         .sortBy { _.algorithm.value }

--- a/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
@@ -30,12 +30,9 @@ case class MultiChecksum(
     *
     */
   def matches(manifestChecksum: MultiManifestChecksum): Boolean =
-    manifestChecksum.definedAlgorithms
-      .forall { a =>
-        val expected = manifestChecksum.getValue(a)
-        val actual = getValue(a)
-
-        expected.contains(actual)
+    manifestChecksum.definedChecksums
+      .forall { case (algorithm, expectedValue) =>
+        expectedValue == getValue(algorithm)
       }
 }
 

--- a/common/src/main/scala/weco/storage_service/checksum/MultiManifestChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MultiManifestChecksum.scala
@@ -30,6 +30,12 @@ case class MultiManifestChecksum(
       sha512.map(_ => SHA512)
     ).flatten
 
+  def definedChecksums: Set[(ChecksumAlgorithm, ChecksumValue)] =
+    definedAlgorithms
+      .map { algorithm =>
+        algorithm -> getValue(algorithm).get
+      }
+
   def getValue(algorithm: ChecksumAlgorithm): Option[ChecksumValue] =
     algorithm match {
       case MD5    => md5

--- a/common/src/test/scala/weco/storage_service/checksum/MultiChecksumTest.scala
+++ b/common/src/test/scala/weco/storage_service/checksum/MultiChecksumTest.scala
@@ -84,7 +84,7 @@ class MultiChecksumTest
         sha512 = ChecksumValue("ddddddd")
       )
 
-      actual.matches(expected) shouldBe true
+      actual.compare(expected) shouldBe Right(())
     }
 
     it("isn't a match if one of the checksums is difference") {
@@ -96,13 +96,21 @@ class MultiChecksumTest
       )
 
       val actual = MultiChecksum(
-        md5 = ChecksumValue("aaaaaab"),
+        md5 = ChecksumValue("aaaaaaa"),
         sha1 = ChecksumValue("bbbbbbb"),
         sha256 = ChecksumValue("ccccccc"),
         sha512 = ChecksumValue("ddddddd")
       )
 
-      actual.matches(expected) shouldBe false
+      actual.compare(expected) shouldBe Left(
+        Seq(
+          MismatchedChecksum(
+            algorithm = SHA256,
+            expected = ChecksumValue("aaaaaaa"),
+            actual = ChecksumValue("ccccccc")
+          )
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
For #900.

I'm continuing to write this in small pieces, because the bag verifier is such a critical service and I don't want to muck it up. This PR continues to rearrange some pieces to prepare for doing verification of multiple checksums.

Most of it is just refactoring or clean-ups; the one big change is:

```diff
 case class MultiChecksum(md5, sha1, sha256, sha512: ChecksumValue) {
-  def compare(manifestChecksum: MultiManifestChecksum): Boolean
+  def compare(manifestChecksum: MultiManifestChecksum): Either[Seq[MismatchedChecksum], Unit]
   ...
 }
```

This is to enable better error reporting in a subsequent patch: rather than saying "some of the checksums were different", we can say *which* checksums were different.