### PR TITLE
Continue inching towards a multi-checksum bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FailedChecksum.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FailedChecksum.scala
@@ -1,5 +1,6 @@
 package weco.storage_service.bag_verifier.fixity
-import weco.storage_service.checksum.{Checksum, ChecksumAlgorithm}
+
+import weco.storage_service.checksum.{ChecksumAlgorithm, MismatchedChecksum}
 
 sealed trait FailedChecksum
 
@@ -7,9 +8,9 @@ case class FailedChecksumCreation(algorithm: ChecksumAlgorithm, e: Throwable)
     extends Throwable(s"Could not create checksum: ${e.getMessage}")
     with FailedChecksum
 
-case class FailedChecksumNoMatch(actual: Checksum, expected: Checksum)
+case class FailedChecksumNoMatch(mismatches: Seq[MismatchedChecksum])
     extends Throwable(
-      s"Checksum values do not match! Expected: $expected, saw: $actual"
+      s"Checksum values do not match: ${mismatches.map(_.description).mkString("; ")}."
     )
     with FailedChecksum
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FailedChecksum.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FailedChecksum.scala
@@ -1,10 +1,10 @@
 package weco.storage_service.bag_verifier.fixity
 
-import weco.storage_service.checksum.{ChecksumAlgorithm, MismatchedChecksum}
+import weco.storage_service.checksum.MismatchedChecksum
 
 sealed trait FailedChecksum
 
-case class FailedChecksumCreation(algorithm: ChecksumAlgorithm, e: Throwable)
+case class FailedChecksumCreation(e: Throwable)
     extends Throwable(s"Could not create checksum: ${e.getMessage}")
     with FailedChecksum
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -233,14 +233,19 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
             )
           )
 
-        case Success(value) =>
+        case Success(actualChecksum) =>
           Left(
             FileFixityMismatch(
               expectedFileFixity = expectedFileFixity,
               objectLocation = location,
               e = FailedChecksumNoMatch(
-                actual = Checksum(algorithm, value),
-                expected = expectedFileFixity.checksum
+                mismatches = Seq(
+                  MismatchedChecksum(
+                    algorithm = algorithm,
+                    expected = expectedFileFixity.checksum.value,
+                    actual = actualChecksum
+                  )
+                )
               )
             )
           )

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -146,9 +146,9 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
     algorithm: ChecksumAlgorithm,
     size: Long
   ): Either[FileFixityError[BagLocation], FileFixityCorrect[BagLocation]] =
-    existingTags.get(fixityTagName(expectedFileFixity)) match {
+    existingTags.get(fixityTagName(expectedFileFixity.checksum.algorithm)) match {
       case Some(cachedFixityValue)
-          if cachedFixityValue == fixityTagValue(expectedFileFixity) =>
+          if cachedFixityValue == fixityTagValue(expectedFileFixity.checksum.value) =>
         Right(
           FileFixityCorrect(
             expectedFileFixity = expectedFileFixity,
@@ -260,8 +260,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
   ): Either[FileFixityCouldNotWriteTag[BagLocation], Unit] =
     tags
       .update(location) { existingTags =>
-        val tagName = fixityTagName(expectedFileFixity)
-        val tagValue = fixityTagValue(expectedFileFixity)
+        val tagName = fixityTagName(expectedFileFixity.checksum.algorithm)
+        val tagValue = fixityTagValue(expectedFileFixity.checksum.value)
 
         val fixityTags = Map(tagName -> tagValue)
 
@@ -291,11 +291,11 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
     }
 
   // e.g. Content-MD5, Content-SHA256
-  protected def fixityTagName(expectedFileFixity: ExpectedFileFixity): String =
-    s"Content-${expectedFileFixity.checksum.algorithm.pathRepr.toUpperCase}"
+  protected def fixityTagName(algorithm: ChecksumAlgorithm): String =
+    s"Content-${algorithm.pathRepr.toUpperCase}"
 
-  private def fixityTagValue(expectedFileFixity: ExpectedFileFixity): String =
-    expectedFileFixity.checksum.value.toString
+  private def fixityTagValue(value: ChecksumValue): String =
+    value.toString
 
   private def handleReadErrors[T](
     t: Either[ReadError, T],

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -157,12 +157,14 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         )
 
       case _ if expectedFileFixity.conflictsWithExistingTags(existingTags) =>
+        val mismatches = expectedFileFixity.mismatchesWith(existingTags)
+        // TODO: Add a test for the message when there are multiple mismatches
         Left(
           FileFixityMismatch(
             expectedFileFixity = expectedFileFixity,
             objectLocation = location,
             e = new Throwable(
-              s"Cached verification tag doesn't match expected checksum for $location: $existingTags (${expectedFileFixity.checksum})"
+              s"Cached verification tag doesn't match expected checksum for $location: ${mismatches.map(_.message).mkString("; ")}"
             )
           )
         )

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success}
   *
   */
 trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
-    extends Logging {
+    extends FixityTagChecker with Logging {
   protected val streamReader: Readable[BagLocation, InputStreamWithLength]
   protected val sizeFinder: SizeFinder[BagLocation]
   val tags: Tags[BagLocation]
@@ -294,13 +294,6 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           )
         )
     }
-
-  // e.g. Content-MD5, Content-SHA256
-  protected def fixityTagName(algorithm: ChecksumAlgorithm): String =
-    s"Content-${algorithm.pathRepr.toUpperCase}"
-
-  private def fixityTagValue(value: ChecksumValue): String =
-    value.toString
 
   private def handleReadErrors[T](
     t: Either[ReadError, T],

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -146,9 +146,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
     algorithm: ChecksumAlgorithm,
     size: Long
   ): Either[FileFixityError[BagLocation], FileFixityCorrect[BagLocation]] =
-    existingTags.get(fixityTagName(expectedFileFixity.checksum.algorithm)) match {
-      case Some(cachedFixityValue)
-          if cachedFixityValue == fixityTagValue(expectedFileFixity.checksum.value) =>
+    existingTags match {
+      case _ if expectedFileFixity.matchesAllExistingTags(existingTags) =>
         Right(
           FileFixityCorrect(
             expectedFileFixity = expectedFileFixity,
@@ -157,7 +156,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           )
         )
 
-      case Some(_) =>
+      case _ if expectedFileFixity.conflictsWithExistingTags(existingTags) =>
         Left(
           FileFixityMismatch(
             expectedFileFixity = expectedFileFixity,
@@ -168,7 +167,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           )
         )
 
-      case None =>
+      case _ =>
         // Note: it is possible for something to go wrong *after* we open
         // the input stream, e.g. if the stream gets interrupted.
         //

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -219,7 +219,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
             FileFixityCouldNotGetChecksum(
               expectedFileFixity = expectedFileFixity,
               objectLocation = location,
-              e = FailedChecksumCreation(algorithm, e)
+              e = FailedChecksumCreation(e)
             )
           )
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -23,7 +23,8 @@ import scala.util.{Failure, Success}
   *
   */
 trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
-    extends FixityTagChecker with Logging {
+    extends FixityTagChecker
+    with Logging {
   protected val streamReader: Readable[BagLocation, InputStreamWithLength]
   protected val sizeFinder: SizeFinder[BagLocation]
   val tags: Tags[BagLocation]

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -1,0 +1,13 @@
+package weco.storage_service.bag_verifier.fixity
+
+import weco.storage_service.checksum.{ChecksumAlgorithm, ChecksumValue}
+
+trait FixityTagChecker {
+
+  // e.g. Content-MD5, Content-SHA256
+  protected def fixityTagName(algorithm: ChecksumAlgorithm): String =
+    s"Content-${algorithm.pathRepr.toUpperCase}"
+
+  protected def fixityTagValue(value: ChecksumValue): String =
+    value.toString
+}

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -1,6 +1,6 @@
 package weco.storage_service.bag_verifier.fixity
 
-import weco.storage_service.checksum.{ChecksumAlgorithm, ChecksumValue}
+import weco.storage_service.checksum.{ChecksumAlgorithm, ChecksumValue, MismatchedChecksum}
 
 trait FixityTagChecker {
 
@@ -10,4 +10,27 @@ trait FixityTagChecker {
 
   protected def fixityTagValue(value: ChecksumValue): String =
     value.toString
+
+  implicit class ExpectedFileFixityOps(e: ExpectedFileFixity) {
+    def fixityTags: Map[String, String] =
+      Map(
+        fixityTagName(e.checksum.algorithm) -> fixityTagValue(e.checksum.value)
+      )
+
+    def matchesAllExistingTags(existingTags: Map[String, String]): Boolean =
+      fixityTags.toSet.subsetOf(existingTags.toSet)
+
+    def conflictsWithExistingTags(existingTags: Map[String, String]): Boolean =
+      e.findMismatches(existingTags).nonEmpty
+
+    def findMismatches(existingTags: Map[String, String]): Set[MismatchedChecksum] =
+      Seq((e.checksum.algorithm, e.checksum.value))
+        .map { case (algorithm, expected) =>
+          (algorithm, expected, existingTags.get(fixityTagName(algorithm)).map(ChecksumValue(_)))
+        }
+        .collect { case (algorithm, expected, Some(actual)) if expected != actual =>
+          MismatchedChecksum(algorithm = algorithm, expected = expected, actual = actual)
+        }
+        .toSet
+  }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -34,20 +34,29 @@ trait FixityTagChecker {
 
     def mismatchesWith(existingTags: Map[String, String]): Seq[MismatchedTag] =
       fixityTags
-        .map { case (name, expectedValue) =>
-          (name, expectedValue, existingTags.get(name))
+        .map {
+          case (name, expectedValue) =>
+            (name, expectedValue, existingTags.get(name))
         }
-        .collect { case (name, expectedValue, Some(actualValue)) if expectedValue != actualValue =>
-          MismatchedTag(name, expectedValue, actualValue)
+        .collect {
+          case (name, expectedValue, Some(actualValue))
+              if expectedValue != actualValue =>
+            MismatchedTag(name, expectedValue, actualValue)
         }
         .toSeq
   }
 
   implicit class MapOps[K, V](m: Map[K, V]) {
     def isCompatibleWith(other: Map[K, V]): Boolean =
-      m.keySet.intersect(other.keySet)
-        .map { key => (m(key), other(key)) }
-        .collect { case (mValue, otherValue) if mValue != otherValue => (mValue, otherValue) }
+      m.keySet
+        .intersect(other.keySet)
+        .map { key =>
+          (m(key), other(key))
+        }
+        .collect {
+          case (mValue, otherValue) if mValue != otherValue =>
+            (mValue, otherValue)
+        }
         .isEmpty
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -42,4 +42,12 @@ trait FixityTagChecker {
         }
         .toSeq
   }
+
+  implicit class MapOps[K, V](m: Map[K, V]) {
+    def isCompatibleWith(other: Map[K, V]): Boolean =
+      m.keySet.intersect(other.keySet)
+        .map { key => (m(key), other(key)) }
+        .collect { case (mValue, otherValue) if mValue != otherValue => (mValue, otherValue) }
+        .isEmpty
+  }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/azure/AzureFixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/azure/AzureFixityChecker.scala
@@ -4,10 +4,7 @@ import java.net.URI
 import com.azure.storage.blob.BlobServiceClient
 import org.apache.commons.io.FileUtils
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import weco.storage_service.bag_verifier.fixity.{
-  ExpectedFileFixity,
-  FixityChecker
-}
+import weco.storage_service.bag_verifier.fixity.FixityChecker
 import weco.storage_service.bag_verifier.storage.Locatable
 import weco.storage_service.bag_verifier.storage.azure.AzureLocatable
 import weco.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
@@ -17,6 +14,7 @@ import weco.storage.services.azure.{AzureLargeStreamReader, AzureSizeFinder}
 import weco.storage.store.Readable
 import weco.storage.streaming.InputStreamWithLength
 import weco.storage.tags.Tags
+import weco.storage_service.checksum.ChecksumAlgorithm
 
 class AzureFixityChecker(
   val streamReader: Readable[AzureBlobLocation, InputStreamWithLength],
@@ -29,10 +27,8 @@ class AzureFixityChecker(
   // We can't include a hyphen in the name because Azure metadata names have to be
   // valid C# identifiers.
   // See https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources#Subheading1
-  override protected def fixityTagName(
-    expectedFileFixity: ExpectedFileFixity
-  ): String =
-    s"Content${expectedFileFixity.checksum.algorithm.pathRepr.toUpperCase}"
+  override protected def fixityTagName(algorithm: ChecksumAlgorithm): String =
+    s"Content${algorithm.pathRepr.toUpperCase}"
 }
 
 object AzureFixityChecker {

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
@@ -149,7 +149,7 @@ trait FixityCheckerTestCases[
         fixityMismatch.expectedFileFixity shouldBe expectedFileFixity
         fixityMismatch.e shouldBe a[FailedChecksumNoMatch]
         fixityMismatch.e.getMessage should startWith(
-          s"Checksum values do not match! Expected: $checksum"
+          s"Checksum values do not match: expected $checksum"
         )
       }
     }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -293,7 +293,7 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
         val error = fixityError.e
 
         error shouldBe a[FailedChecksumNoMatch]
-        error.getMessage should include("Checksum values do not match!")
+        error.getMessage should include("Checksum values do not match:")
     }
   }
 

--- a/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MismatchedChecksum.scala
@@ -8,5 +8,5 @@ case class MismatchedChecksum(
   require(expected != actual)
 
   def description: String =
-    s"Expected ${algorithm.pathRepr}:$expected, saw ${algorithm.pathRepr}:$actual"
+    s"expected ${algorithm.pathRepr}:$expected, saw ${algorithm.pathRepr}:$actual"
 }


### PR DESCRIPTION
Another small step towards #900. The key here is changing how we do tags – right now we only write a single fixity tag for every object, but in future we'll write multiple tags – one per manifest. This PR rearranges some of the tag-related pieces to deal with multiple tags, where right now it's just the degenerate case of a single-item list. This should make adding multiple tags a smaller change.