### PR TITLE
Use multiple checksums in the BagMatcher

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
@@ -12,7 +12,6 @@ import weco.storage_service.bag_verifier.storage.{Locatable, Resolvable}
 import weco.storage_service.bag_verifier.storage.bag.BagLocatable
 import weco.storage_service.bagit.models._
 import weco.storage_service.bagit.services.BagMatcher
-import weco.storage_service.checksum._
 import weco.storage.{Location, Prefix}
 
 class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
@@ -55,21 +54,17 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
     matched: MatchedLocation
   ): Either[Throwable, ExpectedFileFixity] =
     matched match {
-      case MatchedLocation(
-          bagPath: BagPath,
-          checksum: Checksum,
-          Some(fetchEntry)
-          ) =>
+      case loc @ MatchedLocation(bagPath, _, _, Some(fetchEntry)) =>
         Right(
           FetchFileFixity(
             uri = fetchEntry.uri,
             path = bagPath,
-            checksum = checksum,
+            checksum = loc.checksum,
             length = fetchEntry.length
           )
         )
 
-      case MatchedLocation(bagPath: BagPath, checksum: Checksum, None) =>
+      case loc @ MatchedLocation(bagPath, _, _, None) =>
         bagPath.locateWith(root) match {
           case Left(e) => Left(CannotCreateExpectedFixity(e.msg))
           case Right(location) =>
@@ -77,7 +72,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
               DataDirectoryFileFixity(
                 uri = resolvable.resolve(location),
                 path = bagPath,
-                checksum = checksum
+                checksum = loc.checksum
               )
             )
         }

--- a/common/src/main/scala/weco/storage_service/bagit/models/MatchedLocation.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/MatchedLocation.scala
@@ -1,9 +1,23 @@
 package weco.storage_service.bagit.models
 
-import weco.storage_service.checksum.Checksum
+import weco.storage_service.checksum.{
+  Checksum,
+  ChecksumAlgorithm,
+  MultiManifestChecksum
+}
 
 case class MatchedLocation(
   bagPath: BagPath,
-  checksum: Checksum,
+  multiChecksum: MultiManifestChecksum,
+  algorithm: ChecksumAlgorithm,
   fetchMetadata: Option[BagFetchMetadata]
-)
+) {
+
+  // This is for backwards-compatibility purposes while we migrate to adding multi-checksum
+  // support to the storage service, but we'll remove it later.
+  def checksum: Checksum =
+    Checksum(
+      algorithm = algorithm,
+      value = multiChecksum.getValue(algorithm).get
+    )
+}

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
@@ -4,8 +4,16 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.storage_service.bagit.models.{MatchedLocation, NewPayloadManifest}
-import weco.storage_service.generators.{FetchMetadataGenerators, StorageRandomGenerators}
-import weco.storage_service.checksum.{Checksum, MD5, MultiManifestChecksum, SHA256}
+import weco.storage_service.generators.{
+  FetchMetadataGenerators,
+  StorageRandomGenerators
+}
+import weco.storage_service.checksum.{
+  Checksum,
+  MD5,
+  MultiManifestChecksum,
+  SHA256
+}
 
 class BagMatcherTest
     extends AnyFunSpec
@@ -63,7 +71,10 @@ class BagMatcherTest
       }
 
       result.value.foreach { loc =>
-        loc.checksum shouldBe Checksum(algorithm = SHA256, value = loc.multiChecksum.sha256.get)
+        loc.checksum shouldBe Checksum(
+          algorithm = SHA256,
+          value = loc.multiChecksum.sha256.get
+        )
       }
     }
 
@@ -81,7 +92,7 @@ class BagMatcherTest
       val result = BagMatcher.correlateFetchEntryToBagFile(
         manifest = NewPayloadManifest(
           entries = manifestEntries ++ Map(fetchPath -> fetchMultiChecksum),
-          algorithms = Set(MD5, SHA256),
+          algorithms = Set(MD5, SHA256)
         ),
         algorithm = SHA256,
         fetchEntries = Map(fetchPath -> fetchMetadata)


### PR DESCRIPTION
Another tiny step towards #900.

Currently the `MatchedLocation` case class only holds a single checksum; now it holds every checksum in the bag and has a back-compatibility shim to return just one checksum. In the next patch I'll update the bag verifier to read and use this multi-checksum, but I'm still keeping these patches small so they can be easily reviewed.