### PR TITLE
Verify every checksum in the bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/ExpectedFileFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/ExpectedFileFixity.scala
@@ -1,27 +1,28 @@
 package weco.storage_service.bag_verifier.fixity
-import java.net.URI
 
 import weco.storage_service.bagit.models.BagPath
-import weco.storage_service.checksum.Checksum
+import weco.storage_service.checksum.MultiManifestChecksum
+
+import java.net.URI
 
 sealed trait ExpectedFileFixity {
   val uri: URI
   val path: BagPath
-  val checksum: Checksum
+  val multiChecksum: MultiManifestChecksum
   val length: Option[Long]
 }
 
 case class FetchFileFixity(
   uri: URI,
   path: BagPath,
-  checksum: Checksum,
+  multiChecksum: MultiManifestChecksum,
   length: Option[Long]
 ) extends ExpectedFileFixity
 
 case class DataDirectoryFileFixity(
   uri: URI,
   path: BagPath,
-  checksum: Checksum
+  multiChecksum: MultiManifestChecksum
 ) extends ExpectedFileFixity {
   val length: Option[Long] = None
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -10,7 +10,7 @@ import weco.storage_service.bag_verifier.storage.{
   LocationNotFound,
   LocationParsingError
 }
-import weco.storage_service.checksum._
+import weco.storage_service.checksum.MultiChecksum
 import weco.storage.services.SizeFinder
 import weco.storage.store.Readable
 import weco.storage.streaming.InputStreamWithLength
@@ -208,10 +208,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
         s"The size of $location has changed!  Before: $size, after: ${inputStream.length}"
     )
 
-    val algorithm = expectedFileFixity.checksum.algorithm
-
     val fixityResult =
-      MultiChecksum.create(inputStream).map(_.getValue(algorithm)) match {
+      MultiChecksum.create(inputStream) match {
         case Failure(e) =>
           Left(
             FileFixityCouldNotGetChecksum(
@@ -221,8 +219,7 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
             )
           )
 
-        case Success(value)
-            if Checksum(algorithm, value) == expectedFileFixity.checksum =>
+        case Success(actualChecksum) if actualChecksum.compare(expectedFileFixity.multiChecksum).isRight =>
           Right(
             FileFixityCorrect(
               expectedFileFixity = expectedFileFixity,
@@ -232,19 +229,16 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           )
 
         case Success(actualChecksum) =>
+          val mismatches =
+            actualChecksum
+              .compare(expectedFileFixity.multiChecksum)
+              .left.get
+
           Left(
             FileFixityMismatch(
               expectedFileFixity = expectedFileFixity,
               objectLocation = location,
-              e = FailedChecksumNoMatch(
-                mismatches = Seq(
-                  MismatchedChecksum(
-                    algorithm = algorithm,
-                    expected = expectedFileFixity.checksum.value,
-                    actual = actualChecksum
-                  )
-                )
-              )
+              e = FailedChecksumNoMatch(mismatches = mismatches)
             )
           )
       }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -219,7 +219,10 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
             )
           )
 
-        case Success(actualChecksum) if actualChecksum.compare(expectedFileFixity.multiChecksum).isRight =>
+        case Success(actualChecksum)
+            if actualChecksum
+              .compare(expectedFileFixity.multiChecksum)
+              .isRight =>
           Right(
             FileFixityCorrect(
               expectedFileFixity = expectedFileFixity,
@@ -232,7 +235,8 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
           val mismatches =
             actualChecksum
               .compare(expectedFileFixity.multiChecksum)
-              .left.get
+              .left
+              .get
 
           Left(
             FileFixityMismatch(

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -22,9 +22,11 @@ trait FixityTagChecker {
 
   implicit class ExpectedFileFixityOps(e: ExpectedFileFixity) {
     def fixityTags: Map[String, String] =
-      Map(
-        fixityTagName(e.checksum.algorithm) -> fixityTagValue(e.checksum.value)
-      )
+      e.multiChecksum.definedChecksums
+        .map { case (algorithm, value) =>
+          fixityTagName(algorithm) -> fixityTagValue(value)
+        }
+        .toMap
 
     def matchesAllExistingTags(existingTags: Map[String, String]): Boolean =
       fixityTags.toSet.subsetOf(existingTags.toSet)

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -22,11 +22,10 @@ trait FixityTagChecker {
 
   implicit class ExpectedFileFixityOps(e: ExpectedFileFixity) {
     def fixityTags: Map[String, String] =
-      e.multiChecksum.definedChecksums
-        .map { case (algorithm, value) =>
+      e.multiChecksum.definedChecksums.map {
+        case (algorithm, value) =>
           fixityTagName(algorithm) -> fixityTagValue(value)
-        }
-        .toMap
+      }.toMap
 
     def matchesAllExistingTags(existingTags: Map[String, String]): Boolean =
       fixityTags.toSet.subsetOf(existingTags.toSet)

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
@@ -54,17 +54,17 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
     matched: MatchedLocation
   ): Either[Throwable, ExpectedFileFixity] =
     matched match {
-      case loc @ MatchedLocation(bagPath, _, _, Some(fetchEntry)) =>
+      case MatchedLocation(bagPath, multiChecksum, _, Some(fetchEntry)) =>
         Right(
           FetchFileFixity(
             uri = fetchEntry.uri,
             path = bagPath,
-            checksum = loc.checksum,
+            multiChecksum = multiChecksum,
             length = fetchEntry.length
           )
         )
 
-      case loc @ MatchedLocation(bagPath, _, _, None) =>
+      case MatchedLocation(bagPath, multiChecksum, _, None) =>
         bagPath.locateWith(root) match {
           case Left(e) => Left(CannotCreateExpectedFixity(e.msg))
           case Right(location) =>
@@ -72,7 +72,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
               DataDirectoryFileFixity(
                 uri = resolvable.resolve(location),
                 path = bagPath,
-                checksum = loc.checksum
+                multiChecksum = multiChecksum
               )
             )
         }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
@@ -54,7 +54,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
     matched: MatchedLocation
   ): Either[Throwable, ExpectedFileFixity] =
     matched match {
-      case MatchedLocation(bagPath, multiChecksum, _, Some(fetchEntry)) =>
+      case MatchedLocation(bagPath, multiChecksum, Some(fetchEntry)) =>
         Right(
           FetchFileFixity(
             uri = fetchEntry.uri,
@@ -64,7 +64,7 @@ class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
           )
         )
 
-      case MatchedLocation(bagPath, multiChecksum, _, None) =>
+      case MatchedLocation(bagPath, multiChecksum, None) =>
         bagPath.locateWith(root) match {
           case Left(e) => Left(CannotCreateExpectedFixity(e.msg))
           case Right(location) =>

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTagsTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTagsTestCases.scala
@@ -20,10 +20,6 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
       StreamReaderImpl
     ] {
 
-  val contentString = "HelloWorld"
-  val checksumString = "68e109f0f40ca72a15e05cc22786f8e6"
-  val checksum = Checksum(MD5, ChecksumValue(checksumString))
-
   def tagName(algorithm: ChecksumAlgorithm): String =
     algorithm match {
       case MD5    => "Content-MD5"
@@ -40,7 +36,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
 
         val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
-          checksum = checksum
+          multiChecksum = multiChecksum
         )
 
         withFixityChecker() { fixityChecker =>
@@ -50,7 +46,8 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
           fixityChecker.tags.get(location).value shouldBe Identified(
             location,
             Map(
-              tagName(checksum.algorithm) -> checksumString
+              tagName(MD5) -> "68e109f0f40ca72a15e05cc22786f8e6",
+              tagName(SHA256) -> "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
             )
           )
         }
@@ -66,7 +63,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
 
         val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
-          checksum = checksum
+          multiChecksum = multiChecksum
         )
 
         withStreamReader { streamReader =>
@@ -101,12 +98,12 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
 
         val expectedFileFixity = createDataDirectoryFileFixityWith(
           location = location,
-          checksum = checksum
+          multiChecksum = multiChecksum
         )
 
         val badExpectedFixity = expectedFileFixity.copy(
-          checksum = checksum.copy(
-            value = randomChecksumValue
+          multiChecksum = multiChecksum.copy(
+            sha256 = Some(randomChecksumValue)
           )
         )
 
@@ -147,7 +144,7 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
 
         val expectedFileFixity = createFetchFileFixityWith(
           location = location,
-          checksum = checksum
+          multiChecksum = multiChecksum
         )
 
         val badExpectedFixity = expectedFileFixity.copy(
@@ -203,53 +200,5 @@ trait FixityCheckerTagsTestCases[BagLocation <: Location, BagPrefix <: Prefix[
         }
       }
     }
-  }
-
-  it("adds one tag per checksum algorithm") {
-    val contentString = "HelloWorld"
-
-    val allChecksums = Seq(
-      Checksum(MD5, ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")),
-      Checksum(
-        SHA1,
-        ChecksumValue("db8ac1c259eb89d4a131b253bacfca5f319d54f2")
-      ),
-      Checksum(
-        SHA256,
-        ChecksumValue(
-          "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
-        )
-      )
-    )
-
-    withContext { implicit context =>
-      withNamespace { implicit namespace =>
-        val location = createLocationWith(namespace)
-        putString(location, contentString)
-
-        withFixityChecker() { fixityChecker =>
-          allChecksums.foreach { checksum =>
-            val expectedFileFixity = createDataDirectoryFileFixityWith(
-              location = location,
-              checksum = checksum
-            )
-
-            fixityChecker.check(expectedFileFixity) shouldBe a[
-              FileFixityCorrect[_]
-            ]
-          }
-
-          fixityChecker.tags.get(location).value shouldBe Identified(
-            location,
-            Map(
-              tagName(MD5) -> "68e109f0f40ca72a15e05cc22786f8e6",
-              tagName(SHA1) -> "db8ac1c259eb89d4a131b253bacfca5f319d54f2",
-              tagName(SHA256) -> "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
-            )
-          )
-        }
-      }
-    }
-
   }
 }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTestCases.scala
@@ -63,7 +63,11 @@ trait FixityCheckerTestCases[
   val multiChecksum = MultiManifestChecksum(
     md5 = Some(ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")),
     sha1 = None,
-    sha256 = Some(ChecksumValue("872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4")),
+    sha256 = Some(
+      ChecksumValue(
+        "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
+      )
+    ),
     sha512 = None
   )
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTests.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/FixityCheckerTests.scala
@@ -39,7 +39,11 @@ class FixityCheckerTests
   val multiChecksum = MultiManifestChecksum(
     md5 = Some(ChecksumValue("68e109f0f40ca72a15e05cc22786f8e6")),
     sha1 = None,
-    sha256 = Some(ChecksumValue("872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4")),
+    sha256 = Some(
+      ChecksumValue(
+        "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
+      )
+    ),
     sha512 = None
   )
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixityTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixityTest.scala
@@ -165,7 +165,9 @@ class BagExpectedFixityTest
     }
   }
 
-  def getExpectedLocations(manifestEntries: Map[BagPath, MultiManifestChecksum]): Seq[ExpectedFileFixity] =
+  def getExpectedLocations(
+    manifestEntries: Map[BagPath, MultiManifestChecksum]
+  ): Seq[ExpectedFileFixity] =
     manifestEntries.map {
       case (bagPath, multiChecksum) =>
         DataDirectoryFileFixity(

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/generators/FixityGenerators.scala
@@ -1,25 +1,18 @@
 package weco.storage_service.bag_verifier.generators
 
-import java.net.URI
+import weco.storage.Location
 import weco.storage_service.bag_verifier.fixity.{
   DataDirectoryFileFixity,
   ExpectedFileFixity,
   FetchFileFixity
 }
+import weco.storage_service.checksum.MultiManifestChecksum
 import weco.storage_service.generators.StorageRandomGenerators
-import weco.storage_service.checksum.{
-  Checksum,
-  MD5,
-  MultiManifestChecksum,
-  SHA256
-}
-import weco.storage.Location
+
+import java.net.URI
 
 trait FixityGenerators[BagLocation <: Location]
     extends StorageRandomGenerators {
-
-  def randomChecksum = Checksum(SHA256, randomChecksumValue)
-  def badChecksum = Checksum(MD5, randomChecksumValue)
 
   def resolve(location: BagLocation): URI
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/generators/FixityGenerators.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/generators/FixityGenerators.scala
@@ -1,18 +1,23 @@
 package weco.storage_service.bag_verifier.generators
 
 import java.net.URI
-
 import weco.storage_service.bag_verifier.fixity.{
   DataDirectoryFileFixity,
   ExpectedFileFixity,
   FetchFileFixity
 }
 import weco.storage_service.generators.StorageRandomGenerators
-import weco.storage_service.checksum.{Checksum, MD5, SHA256}
+import weco.storage_service.checksum.{
+  Checksum,
+  MD5,
+  MultiManifestChecksum,
+  SHA256
+}
 import weco.storage.Location
 
 trait FixityGenerators[BagLocation <: Location]
     extends StorageRandomGenerators {
+
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
 
@@ -25,24 +30,24 @@ trait FixityGenerators[BagLocation <: Location]
 
   def createFetchFileFixityWith(
     location: BagLocation = createLocation,
-    checksum: Checksum = randomChecksum,
+    multiChecksum: MultiManifestChecksum = randomMultiChecksum,
     length: Option[Long] = None
   ): FetchFileFixity =
     FetchFileFixity(
       uri = resolve(location),
       path = createBagPath,
-      checksum = checksum,
+      multiChecksum = multiChecksum,
       length = length
     )
 
   def createDataDirectoryFileFixityWith(
     location: BagLocation = createLocation,
-    checksum: Checksum = randomChecksum
+    multiChecksum: MultiManifestChecksum = randomMultiChecksum
   ): DataDirectoryFileFixity =
     DataDirectoryFileFixity(
       uri = resolve(location),
       path = createBagPath,
-      checksum = checksum
+      multiChecksum = multiChecksum
     )
 
   def createDataDirectoryFileFixity: DataDirectoryFileFixity =

--- a/common/src/main/scala/weco/storage_service/bagit/models/MatchedLocation.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/MatchedLocation.scala
@@ -1,23 +1,9 @@
 package weco.storage_service.bagit.models
 
-import weco.storage_service.checksum.{
-  Checksum,
-  ChecksumAlgorithm,
-  MultiManifestChecksum
-}
+import weco.storage_service.checksum.MultiManifestChecksum
 
 case class MatchedLocation(
   bagPath: BagPath,
   multiChecksum: MultiManifestChecksum,
-  algorithm: ChecksumAlgorithm,
   fetchMetadata: Option[BagFetchMetadata]
-) {
-
-  // This is for backwards-compatibility purposes while we migrate to adding multi-checksum
-  // support to the storage service, but we'll remove it later.
-  def checksum: Checksum =
-    Checksum(
-      algorithm = algorithm,
-      value = multiChecksum.getValue(algorithm).get
-    )
-}
+)

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagMatcher.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagMatcher.scala
@@ -7,7 +7,6 @@ import weco.storage_service.bagit.models.{
   MatchedLocation,
   NewBagManifest
 }
-import weco.storage_service.checksum.ChecksumAlgorithm
 
 /** A bag can contain concrete files or refer to files stored elsewhere
   * in the fetch file.  This object takes a list of files referenced in
@@ -23,7 +22,6 @@ object BagMatcher {
     for {
       payloadMatchedLocations <- correlateFetchEntryToBagFile(
         manifest = bag.newManifest,
-        algorithm = bag.manifest.checksumAlgorithm,
         fetchEntries = bag.fetch match {
           case Some(fetchEntry) => fetchEntry.entries
           case None             => Map.empty
@@ -33,14 +31,12 @@ object BagMatcher {
       // The fetch.txt should never refer to tag files
       tagMatchedLocations <- correlateFetchEntryToBagFile(
         manifest = bag.newTagManifest,
-        algorithm = bag.manifest.checksumAlgorithm,
         fetchEntries = Map.empty
       )
     } yield payloadMatchedLocations ++ tagMatchedLocations
 
   def correlateFetchEntryToBagFile(
     manifest: NewBagManifest,
-    algorithm: ChecksumAlgorithm,
     fetchEntries: Map[BagPath, BagFetchMetadata]
   ): Either[Throwable, Seq[MatchedLocation]] = {
     // First construct the list of matched locations -- for every file in the bag,
@@ -52,7 +48,6 @@ object BagMatcher {
             MatchedLocation(
               bagPath = bagPath,
               multiChecksum = multiChecksum,
-              algorithm = algorithm,
               fetchMetadata = fetchEntries.get(bagPath)
             )
         }

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
@@ -8,11 +8,7 @@ import weco.storage_service.generators.{
   FetchMetadataGenerators,
   StorageRandomGenerators
 }
-import weco.storage_service.checksum.{
-  MD5,
-  MultiManifestChecksum,
-  SHA256
-}
+import weco.storage_service.checksum.{MD5, MultiManifestChecksum, SHA256}
 
 class BagMatcherTest
     extends AnyFunSpec

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
@@ -21,7 +21,7 @@ class BagMatcherTest
     with FetchMetadataGenerators
     with StorageRandomGenerators {
 
-  def randomMultiChecksum: MultiManifestChecksum =
+  override def randomMultiChecksum: MultiManifestChecksum =
     MultiManifestChecksum(
       md5 = Some(randomChecksumValue),
       sha1 = None,

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagMatcherTest.scala
@@ -9,7 +9,6 @@ import weco.storage_service.generators.{
   StorageRandomGenerators
 }
 import weco.storage_service.checksum.{
-  Checksum,
   MD5,
   MultiManifestChecksum,
   SHA256
@@ -38,7 +37,6 @@ class BagMatcherTest
             entries = Map.empty,
             algorithms = Set(SHA256)
           ),
-          algorithm = SHA256,
           fetchEntries = Map.empty
         )
         .value shouldBe Seq.empty
@@ -56,7 +54,6 @@ class BagMatcherTest
           entries = manifestEntries,
           algorithms = Set(MD5, SHA256)
         ),
-        algorithm = SHA256,
         fetchEntries = Map.empty
       )
 
@@ -65,16 +62,8 @@ class BagMatcherTest
           MatchedLocation(
             bagPath = bagPath,
             multiChecksum = multiChecksum,
-            algorithm = SHA256,
             fetchMetadata = None
           )
-      }
-
-      result.value.foreach { loc =>
-        loc.checksum shouldBe Checksum(
-          algorithm = SHA256,
-          value = loc.multiChecksum.sha256.get
-        )
       }
     }
 
@@ -94,7 +83,6 @@ class BagMatcherTest
           entries = manifestEntries ++ Map(fetchPath -> fetchMultiChecksum),
           algorithms = Set(MD5, SHA256)
         ),
-        algorithm = SHA256,
         fetchEntries = Map(fetchPath -> fetchMetadata)
       )
 
@@ -103,13 +91,11 @@ class BagMatcherTest
           MatchedLocation(
             bagPath = bagPath,
             multiChecksum = multiChecksum,
-            algorithm = SHA256,
             fetchMetadata = None
           )
       }.toSeq :+ MatchedLocation(
         bagPath = fetchPath,
         multiChecksum = fetchMultiChecksum,
-        algorithm = SHA256,
         fetchMetadata = Some(fetchMetadata)
       )
 
@@ -127,7 +113,6 @@ class BagMatcherTest
           entries = Map.empty,
           algorithms = Set(SHA256)
         ),
-        algorithm = SHA256,
         fetchEntries = fetchEntries
       )
 
@@ -145,7 +130,6 @@ class BagMatcherTest
           entries = Map.empty,
           algorithms = Set(SHA256)
         ),
-        algorithm = SHA256,
         fetchEntries = fetchEntries
       )
 

--- a/common/src/test/scala/weco/storage_service/generators/BagGenerators.scala
+++ b/common/src/test/scala/weco/storage_service/generators/BagGenerators.scala
@@ -5,6 +5,8 @@ import weco.storage_service.bagit.models.{
   BagFetch,
   BagFetchMetadata,
   BagPath,
+  NewPayloadManifest,
+  NewTagManifest,
   PayloadManifest,
   TagManifest
 }
@@ -26,6 +28,26 @@ trait BagGenerators extends BagInfoGenerators {
       ),
       tagManifest = TagManifest(
         checksumAlgorithm = tagManifestChecksumAlgorithm,
+        entries = tagManifestEntries
+      ),
+      fetch = if (fetchEntries.isEmpty) None else Some(BagFetch(fetchEntries))
+    )
+
+  def createNewBagWith(
+    manifestEntries: Map[BagPath, MultiManifestChecksum] = Map.empty,
+    manifestAlgorithms: Set[ChecksumAlgorithm] = Set(SHA256),
+    tagManifestEntries: Map[BagPath, MultiManifestChecksum] = Map.empty,
+    tagManifestAlgorithms: Set[ChecksumAlgorithm] = Set(SHA256),
+    fetchEntries: Map[BagPath, BagFetchMetadata] = Map.empty
+  ): Bag =
+    Bag(
+      info = createBagInfo,
+      newManifest = NewPayloadManifest(
+        algorithms = manifestAlgorithms,
+        entries = manifestEntries
+      ),
+      newTagManifest = NewTagManifest(
+        algorithms = tagManifestAlgorithms,
         entries = tagManifestEntries
       ),
       fetch = if (fetchEntries.isEmpty) None else Some(BagFetch(fetchEntries))

--- a/common/src/test/scala/weco/storage_service/generators/StorageRandomGenerators.scala
+++ b/common/src/test/scala/weco/storage_service/generators/StorageRandomGenerators.scala
@@ -17,6 +17,14 @@ trait StorageRandomGenerators extends RandomGenerators {
 
   def randomChecksumValue = ChecksumValue(randomAlphanumeric())
 
+  def randomMultiChecksum: MultiManifestChecksum =
+    MultiManifestChecksum(
+      md5 = None,
+      sha1 = None,
+      sha256 = Some(randomChecksumValue),
+      sha512 = None
+    )
+
   val dummyQueue: Queue = Queue(
     url = "test://test-q",
     arn = "arn::sqs::test",


### PR DESCRIPTION
For #900. This patch changes the behaviour of the bag verifier (specifically, the FixityChecker trait) so it now looks at every checksum on a file, rather than just the SHA-256 checksum.

I've tried to keep this patch as small as I can so it can be reviewed carefully, but it's a pretty core piece of the verifier. 😅 