### PR TITLE
Use multiple checksums in the bag register

### DIFF
--- a/bag_register/src/main/scala/weco/storage_service/bag_register/services/S3StorageManifestService.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/services/S3StorageManifestService.scala
@@ -162,11 +162,13 @@ class S3StorageManifestService(implicit s3Client: AmazonS3) extends Logging {
   ): Try[ChecksumAlgorithm] =
     ChecksumAlgorithms.algorithms
       .find { algorithm =>
-        manifest.algorithms.contains(algorithm) && tagManifest.algorithms.contains(algorithm)
+        manifest.algorithms.contains(algorithm) && tagManifest.algorithms
+          .contains(algorithm)
       } match {
-        case Some(algorithm) =>Success(algorithm)
-        case None => Failure(new Throwable("Unable to find common checksum algorithm!"))
-      }
+      case Some(algorithm) => Success(algorithm)
+      case None =>
+        Failure(new Throwable("Unable to find common checksum algorithm!"))
+    }
 
   private def getSizeAndLocation(
     matchedLocation: MatchedLocation,

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
@@ -3,7 +3,7 @@ package weco.storage_service.bag_register.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, TryValues}
-import weco.storage_service.bagit.models.{Bag, BagPath, BagVersion}
+import weco.storage_service.bagit.models.{Bag, BagPath, BagVersion, ExternalIdentifier}
 import weco.storage_service.bagit.services.s3.S3BagReader
 import weco.storage_service.fixtures.PayloadEntry
 import weco.storage_service.fixtures.s3.S3BagBuilder
@@ -16,6 +16,8 @@ import weco.storage.fixtures.S3Fixtures.Bucket
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.services.s3.S3SizeFinder
 import weco.fixtures.TimeAssertions
+import weco.storage.store.s3.S3TypedStore
+import weco.storage_service.checksum.SHA512
 
 import scala.util.Random
 
@@ -255,6 +257,71 @@ class StorageManifestServiceTest
           .map { case (bagPath, checksum) => bagPath.value -> checksum.value }
 
       tagManifestChecksums.filterKeys { _ != "tagmanifest-sha256.txt" } shouldBe tagChecksums
+    }
+  }
+
+  it("prefers SHA-512 checksums") {
+    val builder = new S3BagBuilder {}
+
+    val space = createStorageSpace
+    val externalIdentifier = ExternalIdentifier("multiple_manifests")
+    val version = createBagVersion
+
+    withLocalS3Bucket { bucket =>
+      val bagRoot = S3ObjectLocationPrefix(
+        bucket = bucket.name,
+        keyPrefix = s"$space/$externalIdentifier/$version"
+      )
+
+      val bagInfo = createBagInfoWith(externalIdentifier = externalIdentifier)
+
+      val bagContents = builder.BagContents(
+        fetchObjects = Map(),
+        bagObjects = Map(
+          bagRoot.asLocation("data/README.txt") -> "This is a file\n",
+          bagRoot.asLocation("bag-info.txt") -> (
+            "Bagging-Date: 2021-07-16\n" +
+              "External-Identifier: multiple_manifests\n" +
+              "Payload-Oxum: 15.1\n"
+            ),
+          bagRoot.asLocation("bagit.txt") -> (
+            "BagIt-Version: 0.97\n" +
+              "Tag-File-Character-Encoding: UTF-8\n"
+            ),
+          bagRoot
+            .asLocation("manifest-sha512.txt") -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8  data/README.txt\n",
+          bagRoot
+            .asLocation("manifest-md5.txt") -> "a86e2699931d4f3d1456e79383749e43  data/README.txt\n",
+          bagRoot.asLocation("tagmanifest-sha512.txt") -> (
+            "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa  bag-info.txt\n" +
+              "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6  bagit.txt\n" +
+              "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9  manifest-sha512.txt\n" +
+              "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6  manifest-md5.txt\n"
+            ),
+          bagRoot.asLocation("tagmanifest-md5.txt") -> (
+            "aa3c5e977224a9186dbb36ef1193be0d  bag-info.txt\n" +
+              "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
+              "d570da37be627c3955c165422e667245  manifest-sha512.txt\n" +
+              "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
+            )
+        ),
+        bagRoot = bagRoot,
+        bagInfo = bagInfo
+      )
+
+      implicit val typedStore: S3TypedStore[String] = S3TypedStore[String]
+
+      builder.storeBagContents(bagContents)
+
+      val manifest = createManifest(
+        bag = new S3BagReader().get(bagRoot).value,
+        space = space,
+        version = version,
+        location = PrimaryS3ReplicaLocation(bagRoot)
+      )
+
+      manifest.manifest.checksumAlgorithm shouldBe SHA512
+      manifest.tagManifest.checksumAlgorithm shouldBe SHA512
     }
   }
 
@@ -513,7 +580,7 @@ class StorageManifestServiceTest
     )
 
     if (result.isFailure) {
-      println(result)
+      throw result.failed.get
     }
 
     result.success.value

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
@@ -3,7 +3,12 @@ package weco.storage_service.bag_register.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, TryValues}
-import weco.storage_service.bagit.models.{Bag, BagPath, BagVersion, ExternalIdentifier}
+import weco.storage_service.bagit.models.{
+  Bag,
+  BagPath,
+  BagVersion,
+  ExternalIdentifier
+}
 import weco.storage_service.bagit.services.s3.S3BagReader
 import weco.storage_service.fixtures.PayloadEntry
 import weco.storage_service.fixtures.s3.S3BagBuilder
@@ -242,7 +247,10 @@ class StorageManifestServiceTest
 
       val bagChecksums =
         bag.newManifest.entries
-          .map { case (bagPath, multiChecksum) => bagPath.value -> multiChecksum.sha256.get.value }
+          .map {
+            case (bagPath, multiChecksum) =>
+              bagPath.value -> multiChecksum.sha256.get.value
+          }
 
       storageManifestChecksums shouldBe bagChecksums
 
@@ -254,7 +262,10 @@ class StorageManifestServiceTest
 
       val tagChecksums =
         bag.newTagManifest.entries
-          .map { case (bagPath, multiChecksum) => bagPath.value -> multiChecksum.sha256.get.value }
+          .map {
+            case (bagPath, multiChecksum) =>
+              bagPath.value -> multiChecksum.sha256.get.value
+          }
 
       tagManifestChecksums.filterKeys { _ != "tagmanifest-sha256.txt" } shouldBe tagChecksums
     }
@@ -283,11 +294,11 @@ class StorageManifestServiceTest
             "Bagging-Date: 2021-07-16\n" +
               "External-Identifier: multiple_manifests\n" +
               "Payload-Oxum: 15.1\n"
-            ),
+          ),
           bagRoot.asLocation("bagit.txt") -> (
             "BagIt-Version: 0.97\n" +
               "Tag-File-Character-Encoding: UTF-8\n"
-            ),
+          ),
           bagRoot
             .asLocation("manifest-sha512.txt") -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8  data/README.txt\n",
           bagRoot
@@ -297,13 +308,13 @@ class StorageManifestServiceTest
               "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6  bagit.txt\n" +
               "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9  manifest-sha512.txt\n" +
               "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6  manifest-md5.txt\n"
-            ),
+          ),
           bagRoot.asLocation("tagmanifest-md5.txt") -> (
             "aa3c5e977224a9186dbb36ef1193be0d  bag-info.txt\n" +
               "9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt\n" +
               "d570da37be627c3955c165422e667245  manifest-sha512.txt\n" +
               "7983626d0844789acfe8059b6730b9d1  manifest-md5.txt\n"
-            )
+          )
         ),
         bagRoot = bagRoot,
         bagInfo = bagInfo
@@ -321,12 +332,16 @@ class StorageManifestServiceTest
       )
 
       manifest.manifest.checksumAlgorithm shouldBe SHA512
-      manifest.manifest.files.map { f => f.path -> f.checksum.value }.toMap shouldBe Map(
+      manifest.manifest.files.map { f =>
+        f.path -> f.checksum.value
+      }.toMap shouldBe Map(
         s"$version/data/README.txt" -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8"
       )
 
       manifest.tagManifest.checksumAlgorithm shouldBe SHA512
-      manifest.tagManifest.files.map { f => f.path -> f.checksum.value }.toMap shouldBe Map(
+      manifest.tagManifest.files.map { f =>
+        f.path -> f.checksum.value
+      }.toMap shouldBe Map(
         s"$version/bag-info.txt" -> "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa",
         s"$version/bagit.txt" -> "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6",
         s"$version/manifest-sha512.txt" -> "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9",

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
@@ -241,8 +241,8 @@ class StorageManifestServiceTest
         }.toMap
 
       val bagChecksums =
-        bag.manifest.entries
-          .map { case (bagPath, checksum) => bagPath.value -> checksum.value }
+        bag.newManifest.entries
+          .map { case (bagPath, multiChecksum) => bagPath.value -> multiChecksum.sha256.get.value }
 
       storageManifestChecksums shouldBe bagChecksums
 

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
@@ -321,7 +321,19 @@ class StorageManifestServiceTest
       )
 
       manifest.manifest.checksumAlgorithm shouldBe SHA512
+      manifest.manifest.files.map { f => f.path -> f.checksum.value }.toMap shouldBe Map(
+        s"$version/data/README.txt" -> "7cd31c95fc5a40e5be7bf46e84df52c6d8d50e9003dfb7e3b85ac9c704b90a63ac220147645ff22d410166356133d241a7346e452c863601ce68b82d075031f8"
+      )
+
       manifest.tagManifest.checksumAlgorithm shouldBe SHA512
+      manifest.tagManifest.files.map { f => f.path -> f.checksum.value }.toMap shouldBe Map(
+        s"$version/bag-info.txt" -> "b7112a34f6892c1d3bfb6054dc4977c2ffd32bd7e4d8b686d08f68d1ef407c35857ad3cf552543318238701afb390faad20ac7a0a22b1cf43cd916dfb5d97efa",
+        s"$version/bagit.txt" -> "418dcfbe17d5f4b454b18630be795462cf7da4ceb6313afa49451aa2568e41f7ca3d34cf0280c7d056dc5681a70c37586aa1755620520b9198eede905ba2d0f6",
+        s"$version/manifest-sha512.txt" -> "bfbd969850673f65d14917bcbe42e86df867e4e383702a4471eb0776f2f1cfa48ec102489416741dcf278344bc0229ac2a9011080ffe2a4e55a64540ed0291d9",
+        s"$version/manifest-md5.txt" -> "f8036c779eba074e72101458d675c287b731f5bec4cbe744d59565ce4cc26f96d5259d8f7b1cc55f3999d4db34eba59d99dc131200f1bdf8ddc89912ed23afe6",
+        s"$version/tagmanifest-sha512.txt" -> "70da96851f53a30e64c3246ae9b03d0cbe25342a5b3c4700e4e358e6c549a1e9a1802cdb63054945520ef710e904c67b93380c8ce169fb6066d359383220c717",
+        s"$version/tagmanifest-md5.txt" -> "b4a337392375f0b84b6555462718ef524562ab9d146b0dc8eb12a169c5fe4c4beda78f73006f2ac57424b7b254851b7115d9d0de9bb980c1f32b7fa485d0fec3"
+      )
     }
   }
 

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/services/StorageManifestServiceTest.scala
@@ -253,8 +253,8 @@ class StorageManifestServiceTest
         }.toMap
 
       val tagChecksums =
-        bag.tagManifest.entries
-          .map { case (bagPath, checksum) => bagPath.value -> checksum.value }
+        bag.newTagManifest.entries
+          .map { case (bagPath, multiChecksum) => bagPath.value -> multiChecksum.sha256.get.value }
 
       tagManifestChecksums.filterKeys { _ != "tagmanifest-sha256.txt" } shouldBe tagChecksums
     }
@@ -451,7 +451,7 @@ class StorageManifestServiceTest
 
         val storageManifest = createManifest(
           bag = bag.copy(
-            tagManifest = bag.tagManifest.copy(entries = Map.empty)
+            newTagManifest = bag.newTagManifest.copy(entries = Map())
           ),
           location = location,
           version = version,
@@ -509,7 +509,7 @@ class StorageManifestServiceTest
 
         val storageManifest = createManifest(
           bag = bag.copy(
-            tagManifest = bag.tagManifest.copy(entries = Map.empty)
+            newTagManifest = bag.newTagManifest.copy(entries = Map())
           ),
           location = location,
           version = version,

--- a/common/src/main/scala/weco/storage_service/bagit/models/Bag.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/Bag.scala
@@ -26,14 +26,6 @@ case class Bag(
       }
     )
 
-  def copy(tagManifest: TagManifest): Bag =
-    Bag(
-      info = info,
-      manifest = manifest,
-      tagManifest = tagManifest,
-      fetch = fetch
-    )
-
   // Quoting RFC 8493 § 2.2.1 (https://datatracker.ietf.org/doc/html/rfc8493#section-2.2.1):
   //
   //      Tag manifests SHOULD use the same algorithms as the payload manifests

--- a/common/src/main/scala/weco/storage_service/bagit/models/UnreferencedFiles.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/UnreferencedFiles.scala
@@ -36,5 +36,5 @@ object UnreferencedFiles {
   val tagManifestFiles: Seq[String] =
     ChecksumAlgorithms.algorithms.map { h =>
       s"tagmanifest-${h.pathRepr}.txt"
-    }.toSeq
+    }
 }

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
@@ -69,7 +69,10 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
         require(
-          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(SHA256, SHA512)
+          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(
+            SHA256,
+            SHA512
+          )
         )
         Left(
           BagUnavailable(
@@ -102,7 +105,10 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
         require(
-          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(SHA256, SHA512)
+          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(
+            SHA256,
+            SHA512
+          )
         )
         Left(
           BagUnavailable(

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
@@ -69,7 +69,7 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
         require(
-          ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512)
+          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(SHA256, SHA512)
         )
         Left(
           BagUnavailable(
@@ -102,7 +102,7 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
         // A runtime assertion is meant to draw our attention to it, rather than introducing the
         // unnecessary complexity of creating this message dynamically.
         require(
-          ChecksumAlgorithms.nonDeprecatedAlgorithms == Set(SHA256, SHA512)
+          ChecksumAlgorithms.nonDeprecatedAlgorithms.toSet == Set(SHA256, SHA512)
         )
         Left(
           BagUnavailable(

--- a/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
@@ -36,9 +36,14 @@ sealed trait ChecksumAlgorithm {
 }
 
 case object ChecksumAlgorithms {
-  val algorithms: Set[ChecksumAlgorithm] = Set(SHA512, SHA256, SHA1, MD5)
 
-  val nonDeprecatedAlgorithms: Set[ChecksumAlgorithm] =
+  // A list of all checksum algorithms, in order of decreasing preference.
+  //
+  // i.e. SHA512 is preferable to SHA256, SHA256 to SHA1, and so on.
+  //
+  val algorithms: Seq[ChecksumAlgorithm] = Seq(SHA512, SHA256, SHA1, MD5)
+
+  val nonDeprecatedAlgorithms: Seq[ChecksumAlgorithm] =
     algorithms
       .filterNot(_.isForBackwardsCompatibilityOnly)
 }

--- a/common/src/test/scala/weco/storage_service/generators/StorageRandomGenerators.scala
+++ b/common/src/test/scala/weco/storage_service/generators/StorageRandomGenerators.scala
@@ -131,7 +131,7 @@ trait StorageRandomGenerators extends RandomGenerators {
     BagVersion(randomInt(from = 1, to = 100000))
 
   def randomChecksumAlgorithm: ChecksumAlgorithm =
-    chooseFrom(ChecksumAlgorithms.algorithms.toSeq: _*)
+    chooseFrom(ChecksumAlgorithms.algorithms: _*)
 
   def createBagPath: BagPath = BagPath(randomAlphanumeric())
 


### PR DESCRIPTION
For #900. This updates the bag register to be aware of multiple checksums, and it picks the best available checksum – so we'll start seeing SHA-512 instead of SHA-256 in storage manifests returned by Goobi.

There's a reasonable argument that we should be tracking all the checksums within the storage manifests (and consequently the reporting cluster), but that means migrating all the existing storage manifests. We might tack it onto the process of verifying the SHA-512 checksums in the Goobi manifests, if we choose to do that.

I think this is the last feature change – the final patch will be clearing out all the backward compatibility code.