### PR TITLE
Use the new per-account SQS DLQ alarm topic

### DIFF
--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -43,7 +43,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.4"
 
   forward_port      = var.container_port
   log_configuration = module.base.log_configuration
@@ -54,7 +54,7 @@ module "nginx_container" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "app"
 
   image = var.api_container_image
@@ -65,7 +65,7 @@ module "app_container" {
 }
 
 module "tracker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "tracker"
 
   image = var.tracker_container_image

--- a/terraform/modules/service/base/main.tf
+++ b/terraform/modules/service/base/main.tf
@@ -1,5 +1,5 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.9.4"
   namespace = var.service_name
 
   container_registry = var.logging_container["container_registry"]
@@ -8,13 +8,13 @@ module "log_router_container" {
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.4"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.9.4"
 
   cpu    = var.cpu
   memory = var.memory
@@ -27,7 +27,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.9.4"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -48,7 +48,7 @@ module "base" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.9.4"
 
   forward_port      = var.external_api_container_port
   log_configuration = module.base.log_configuration
@@ -59,7 +59,7 @@ module "nginx_container" {
 }
 
 module "external_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "api"
 
   image = var.external_api_container_image
@@ -71,13 +71,13 @@ module "external_api_container" {
 }
 
 module "external_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.4"
   secrets   = var.external_api_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "worker_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "worker"
 
   image = var.worker_container_image
@@ -89,13 +89,13 @@ module "worker_container" {
 }
 
 module "worker_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.4"
   secrets   = var.worker_secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "internal_api_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "tracker"
 
   image = var.internal_api_container_image
@@ -107,7 +107,7 @@ module "internal_api_container" {
 }
 
 module "internal_api_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.4"
   secrets   = var.internal_api_secrets
   role_name = module.base.task_execution_role_name
 }

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -32,7 +32,7 @@ module "base" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.9.4"
   name   = "app"
 
   image = var.container_image
@@ -44,13 +44,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.9.4"
   secrets   = var.secrets
   role_name = module.base.task_execution_role_name
 }
 
 module "scaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.9.4"
 
   name = var.service_name
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -9,7 +9,7 @@ locals {
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 
-  dlq_alarm_arn = data.terraform_remote_state.infra_shared.outputs.dlq_alarm_arn
+  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.storage_dlq_alarm_topic_arn
 
   cognito_user_pool_arn          = data.terraform_remote_state.app_clients.outputs.cognito_user_pool_arn
   cognito_storage_api_identifier = data.terraform_remote_state.app_clients.outputs.cognito_storage_api_identifier

--- a/terraform/stack_prod/provider.tf
+++ b/terraform/stack_prod/provider.tf
@@ -1,6 +1,10 @@
 locals {
   default_tags = {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_prod"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Storage service"
+    Environment               = "Staging"
   }
 }
 

--- a/terraform/stack_prod/terraform.tf
+++ b/terraform/stack_prod/terraform.tf
@@ -35,6 +35,17 @@ data "terraform_remote_state" "infra_shared" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "app_clients" {
   backend = "s3"
 

--- a/terraform/stack_staging/.terraform.lock.hcl
+++ b/terraform/stack_staging/.terraform.lock.hcl
@@ -5,6 +5,17 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.42.0"
   hashes = [
     "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
   ]
 }
 

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -9,7 +9,7 @@ locals {
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 
-  dlq_alarm_arn = data.terraform_remote_state.infra_shared.outputs.dlq_alarm_arn
+  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.storage_dlq_alarm_topic_arn
 
   cognito_user_pool_arn          = data.terraform_remote_state.app_clients.outputs.cognito_user_pool_arn
   cognito_storage_api_identifier = data.terraform_remote_state.app_clients.outputs.cognito_storage_api_identifier

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -1,6 +1,10 @@
 locals {
   default_tags = {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/storage-service/tree/main/terraform/stack_staging"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Storage service"
+    Environment               = "Production"
   }
 }
 

--- a/terraform/stack_staging/terraform.tf
+++ b/terraform/stack_staging/terraform.tf
@@ -35,6 +35,17 @@ data "terraform_remote_state" "infra_shared" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "app_clients" {
   backend = "s3"
 


### PR DESCRIPTION
This uses the new SQS DLQ alerting infra from https://github.com/wellcomecollection/platform-infrastructure/pull/221

If/when another message ends up on a DLQ in the storage service, we should now get alerts about it in Slack.