### PR TITLE
Use the new API Gateway alarm topics

### DIFF
--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -809,7 +809,7 @@ module "api" {
 
   cognito_user_pool_arn = var.cognito_user_pool_arn
 
-  alarm_topic_arn = var.alarm_topic_arn
+  alarm_topic_arn = var.api_gateway_alarm_topic_arn
 
   auth_scopes = [
     "${var.cognito_storage_api_identifier}/ingests",

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -76,7 +76,7 @@ variable "cognito_user_pool_arn" {
   type = string
 }
 
-variable "alarm_topic_arn" {
+variable "api_gateway_alarm_topic_arn" {
   type = string
 }
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -9,14 +9,15 @@ locals {
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 
-  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.storage_dlq_alarm_topic_arn
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
+  dlq_alarm_arn               = local.monitoring_outputs["storage_dlq_alarm_topic_arn"]
+  api_gateway_alarm_topic_arn = local.monitoring_outputs["storage_api_gateway_alerts_topic_arn"]
 
   cognito_user_pool_arn          = data.terraform_remote_state.app_clients.outputs.cognito_user_pool_arn
   cognito_storage_api_identifier = data.terraform_remote_state.app_clients.outputs.cognito_storage_api_identifier
 
   nginx_image = "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx:95821b39e1683a0a7098cd67d82bc690415c1d5a"
-
-  gateway_server_error_alarm_arn = data.terraform_remote_state.infra_shared.outputs.gateway_server_error_alarm_arn
 
   # TODO: This value should be exported from the workflow-infra state, not hard-coded
   workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit"

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -41,7 +41,7 @@ module "stack_prod" {
   versioner_versions_table_name  = data.terraform_remote_state.critical_prod.outputs.versions_table_name
   versioner_versions_table_index = data.terraform_remote_state.critical_prod.outputs.versions_table_index
 
-  alarm_topic_arn = local.gateway_server_error_alarm_arn
+  api_gateway_alarm_topic_arn = local.api_gateway_alarm_topic_arn
 
   ingests_table_name = data.terraform_remote_state.critical_prod.outputs.ingests_table_name
   ingests_table_arn  = data.terraform_remote_state.critical_prod.outputs.ingests_table_arn

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -9,12 +9,13 @@ locals {
 
   cert_domain_name = "storage.api.wellcomecollection.org"
 
-  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.storage_dlq_alarm_topic_arn
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
+  dlq_alarm_arn               = local.monitoring_outputs["storage_dlq_alarm_topic_arn"]
+  api_gateway_alarm_topic_arn = local.monitoring_outputs["storage_api_gateway_alerts_topic_arn"]
 
   cognito_user_pool_arn          = data.terraform_remote_state.app_clients.outputs.cognito_user_pool_arn
   cognito_storage_api_identifier = data.terraform_remote_state.app_clients.outputs.cognito_storage_api_identifier
-
-  gateway_server_error_alarm_arn = data.terraform_remote_state.infra_shared.outputs.gateway_server_error_alarm_arn
 
   # TODO: This value should be exported from the workflow-infra state, not hard-coded
   workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit-stage"

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -41,7 +41,7 @@ module "stack_staging" {
   versioner_versions_table_name  = data.terraform_remote_state.critical_staging.outputs.versions_table_name
   versioner_versions_table_index = data.terraform_remote_state.critical_staging.outputs.versions_table_index
 
-  alarm_topic_arn = local.gateway_server_error_alarm_arn
+  api_gateway_alarm_topic_arn = local.api_gateway_alarm_topic_arn
 
   ingests_table_name = data.terraform_remote_state.critical_staging.outputs.ingests_table_name
   ingests_table_arn  = data.terraform_remote_state.critical_staging.outputs.ingests_table_arn


### PR DESCRIPTION
This means we'll get alerts of API Gateway errors for the storage service, which we haven't had before.

Requires https://github.com/wellcomecollection/platform-infrastructure/pull/232, part of wellcomecollection/platform#5245