### PR TITLE
Add alarms for the Lambda functions in the storage account

### DIFF
--- a/terraform/modules/lambda/lambda_function.tf
+++ b/terraform/modules/lambda/lambda_function.tf
@@ -22,3 +22,21 @@ resource "aws_lambda_function" "lambda_function" {
     variables = var.environment
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "lambda" {
+  alarm_name          = "lambda-${var.name}-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+
+  dimensions = {
+    FunctionName = var.name
+  }
+
+  alarm_description = "This metric monitors Lambda errors in the function ${var.name}"
+  alarm_actions     = [var.lambda_error_alerts_topic_arn]
+}

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -43,3 +43,7 @@ variable "memory_size" {
   default = 128
   type    = number
 }
+
+variable "lambda_error_alerts_topic_arn" {
+  type = string
+}

--- a/terraform/monitoring/end_to_end_test_lambda/main.tf
+++ b/terraform/monitoring/end_to_end_test_lambda/main.tf
@@ -11,6 +11,8 @@ module "lambda" {
   s3_key    = "lambdas/monitoring/end_to_end_bag_test.zip"
 
   timeout = 15
+
+  lambda_error_alerts_topic_arn = var.lambda_error_alerts_topic_arn
 }
 
 output "function_name" {

--- a/terraform/monitoring/end_to_end_test_lambda/variables.tf
+++ b/terraform/monitoring/end_to_end_test_lambda/variables.tf
@@ -9,3 +9,7 @@ variable "description" {
 variable "environment" {
   type = map(string)
 }
+
+variable "lambda_error_alerts_topic_arn" {
+  type = string
+}

--- a/terraform/monitoring/lambda_daily_reporter.tf
+++ b/terraform/monitoring/lambda_daily_reporter.tf
@@ -8,6 +8,8 @@ module "daily_reporter_lambda" {
   s3_key    = "lambdas/monitoring/daily_reporter.zip"
 
   timeout = 300
+
+  lambda_error_alerts_topic_arn = local.lambda_error_alerts_topic_arn
 }
 
 data "aws_secretsmanager_secret_version" "storage_service_reporter_slack_webhook" {

--- a/terraform/monitoring/lambda_end_to_end_bag_test.tf
+++ b/terraform/monitoring/lambda_end_to_end_bag_test.tf
@@ -14,6 +14,8 @@ module "end_to_end_bag_tester_stage" {
 
     API_URL = "https://api-stage.wellcomecollection.org/storage/v1"
   }
+
+  lambda_error_alerts_topic_arn = local.lambda_error_alerts_topic_arn
 }
 
 module "end_to_end_bag_tester_prod" {
@@ -32,6 +34,8 @@ module "end_to_end_bag_tester_prod" {
 
     API_URL = "https://api.wellcomecollection.org/storage/v1"
   }
+
+  lambda_error_alerts_topic_arn = local.lambda_error_alerts_topic_arn
 }
 
 # Allow the CI agent running in BuildKite to trigger the Lambda after

--- a/terraform/monitoring/locals.tf
+++ b/terraform/monitoring/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  lambda_error_alerts_topic_arn = data.terraform_remote_state.monitoring.outputs.storage_lambda_error_alerts_topic_arn
+}

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -41,3 +41,14 @@ data "terraform_remote_state" "builds_infra" {
     region   = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+  }
+}


### PR DESCRIPTION
Builds on wellcomecollection/platform-infrastructure#233, for wellcomecollection/platform#5245

Previously we didn't have any alarms set up for these Lambdas.