### PR TITLE
Allow writing fixity tags to soft-fail in the verifier

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FileFixityResult.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FileFixityResult.scala
@@ -33,9 +33,3 @@ case class FileFixityCouldNotGetChecksum[BagLocation](
   objectLocation: BagLocation,
   e: Throwable
 ) extends FileFixityError[BagLocation]
-
-case class FileFixityCouldNotWriteTag[BagLocation](
-  expectedFileFixity: ExpectedFileFixity,
-  objectLocation: BagLocation,
-  e: Throwable
-) extends FileFixityError[BagLocation]


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/storage-service/issues/932

## Context

A BagIt bag contains manifests with a list of files and their expected checksums, e.g. this is an MD5 manifest:

```
c40e6411794ca9f1fdb84729bf99c2a263fb54fa374bf403f24e1be70707a56a  data/README.txt
```

The bag verifier reads the manifest, and verifies that every object matches its checksum in the manifest.

The bag verifier adds a tag to the object after it's been successfully verified, recording the checksum. e.g. for this object we'd add the tag:

```
Content-MD5 => c40e6411794ca9f1fdb84729bf99c2a263fb54fa374bf403f24e1be70707a56a
```

There are two main reasons we do this:

- If the bag verifier gets interrupted midway through a bag with lots of files, it can look at the tag and see "I've already verified this object, I don't need to re-read it"
- We can send bag updates that only change a few files, then refer back to files in a previous version of a bag. e.g. "replace page 9 of 100, but keep all the other pages the same". If the bag verifier is looking at a file from the previous version, it can look at the tag and skip re-reading the object

But not every object in the storage service has fixity tags – we started tagging about a year or so after we starting using the storage service for real content, and we never backfilled the tags onto existing objects. That's fine, because the tags are a convenience rather than a requirement. The manifest is still a complete record of the checksums of every object in the bag.

## The problem

About a fortnight ago, S3 had a brief hiccup and failed to write tags on a couple of objects:

> WARN weco.storage.tags.s3.S3Tags - Tags on s3://bucket/key: error when trying to write: StoreWriteError(com.amazonaws.services.s3.model.AmazonS3Exception: We encountered an internal error. Please try again. (Service: Amazon S3; Status Code: 500; Error Code)

We do retry a 500 error from S3 when writing tags, but apparently three retries wasn't enough.

This failure caused the bag verifier to mark the entire bag as "failed", and prevent it from being stored successfully. If we're writing tags, we know the objects match the checksum in the manifest, so the content is "verified" – we just aren't able to record it.

## The solution

Because these tags are optional rather than required, allow tagging operations to soft-fail. We'll log a warning if something goes wrong so we'll see if there's a major tagging issue in the logs, but we won't fail bags if S3 is unhappy.