### PR TITLE
Make bag register idempotent

### DIFF
--- a/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
@@ -1,17 +1,23 @@
 package weco.storage_service.bag_register
 
 import java.time.Instant
-
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.JsonUtil._
 import weco.messaging.fixtures.SQS.QueuePair
 import weco.messaging.memory.MemoryMessageSender
+import weco.storage.Version
+import weco.storage.maxima.memory.MemoryMaxima
+import weco.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 import weco.storage_service.bag_register.fixtures.BagRegisterFixtures
+import weco.storage_service.bag_tracker.storage.memory.MemoryStorageManifestDao
 import weco.storage_service.bagit.models.BagId
 import weco.storage_service.generators.PayloadGenerators
+import weco.storage_service.ingests.models.{Ingest, IngestStatusUpdate, IngestUpdate}
 import weco.storage_service.storage.models._
+
+import scala.concurrent.duration._
 
 class BagRegisterFeatureTest
     extends AnyFunSpec
@@ -90,6 +96,64 @@ class BagRegisterFeatureTest
             assertBagRegisterSucceeded(ingests)
 
             assertQueueEmpty(queue)
+          }
+        }
+      }
+    }
+  }
+
+  it("can receive the same update twice") {
+    val ingests = new MemoryMessageSender()
+
+    val store = new MemoryStore[Version[BagId, Int], StorageManifest](initialEntries = Map())
+      with MemoryMaxima[BagId, StorageManifest]
+
+    val storageManifestDao =
+      new MemoryStorageManifestDao(
+        new MemoryVersionedStore[BagId, StorageManifest](store)
+      )
+
+    val space = createStorageSpace
+    val version = createBagVersion
+
+    withLocalS3Bucket { implicit bucket =>
+      val (bagRoot, _) = storeS3BagWith(
+        space = space,
+        version = version
+      )
+
+      val knownReplicas = KnownReplicas(
+        location = PrimaryS3ReplicaLocation(prefix = bagRoot),
+        replicas = List.empty
+      )
+
+      val payload = createKnownReplicasPayloadWith(
+        context = createPipelineContextWith(
+          storageSpace = space
+        ),
+        version = version,
+        knownReplicas = knownReplicas
+      )
+
+      withLocalSqsQueuePair(visibilityTimeout = 1 second) { case QueuePair(queue, dlq) =>
+        withBagRegisterWorker(
+          queue = queue,
+          ingests = ingests,
+          storageManifestDao = storageManifestDao
+        ) { _ =>
+          sendNotificationToSQS(queue, payload)
+          sendNotificationToSQS(queue, payload)
+
+          eventually {
+            store.entries should have size 1
+
+            // (started + succeeded) × 2 = 4 events
+            ingests.messages should have size 4
+            ingests.getMessages[IngestUpdate]
+              .collect { case IngestStatusUpdate(_, status, _) => status} shouldBe List(Ingest.Succeeded, Ingest.Succeeded)
+
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
           }
         }
       }

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
@@ -148,6 +148,11 @@ class BagRegisterFeatureTest
             storageManifestDao = storageManifestDao
           ) { _ =>
             sendNotificationToSQS(queue, payload)
+
+            // The sleep here is very deliberate: it means the two storage manifests will
+            // have slightly different creation times.  We should still recognise them as
+            // "equivalent" and allow the idempotent-ish write.
+            Thread.sleep(1000)
             sendNotificationToSQS(queue, payload)
 
             eventually {

--- a/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/weco/storage_service/bag_register/BagRegisterFeatureTest.scala
@@ -147,13 +147,13 @@ class BagRegisterFeatureTest
           eventually {
             store.entries should have size 1
 
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+
             // (started + succeeded) × 2 = 4 events
             ingests.messages should have size 4
             ingests.getMessages[IngestUpdate]
               .collect { case IngestStatusUpdate(_, status, _) => status} shouldBe List(Ingest.Succeeded, Ingest.Succeeded)
-
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
           }
         }
       }

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/client/BagTrackerClient.scala
@@ -40,7 +40,7 @@ trait BagTrackerClient extends Logging {
           Future(Right(()))
 
         case status =>
-          val err = new Exception(s"$status for POST to IngestsTracker")
+          val err = new Exception(s"$status for POST to bag tracker")
           error(
             f"Unexpected status for POST to /bags with ${storageManifest.idWithVersion}",
             err

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/client/BagTrackerClient.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/client/BagTrackerClient.scala
@@ -45,7 +45,7 @@ trait BagTrackerClient extends Logging {
             f"Unexpected status for POST to /bags with ${storageManifest.idWithVersion}",
             err
           )
-          Future(Left(BagTrackerCreateError(err)))
+          Future(Left(new BagTrackerCreateError(err) with RetryableError))
       }
     } yield result
 

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/StorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/StorageManifestDao.scala
@@ -48,14 +48,18 @@ trait StorageManifestDao {
       // manifests include their creation time.  Two manifests created at different
       // times are not _equal_, but they may be _equivalent_.  The latter is sufficient
       // for our purposes.
-      case Left(_: VersionAlreadyExistsError) if equivalentManifestIsAlreadyStored(id, storageManifest) =>
+      case Left(_: VersionAlreadyExistsError)
+          if equivalentManifestIsAlreadyStored(id, storageManifest) =>
         Right(storageManifest)
 
       case result => result
     }
   }
 
-  private def equivalentManifestIsAlreadyStored(id: Version[BagId, Int], manifest: StorageManifest): Boolean =
+  private def equivalentManifestIsAlreadyStored(
+    id: Version[BagId, Int],
+    manifest: StorageManifest
+  ): Boolean =
     vhs.get(id) match {
       // Two manifests are equivalent if they are the same modulo createdDate.
       case Right(Identified(_, storedManifest)) =>

--- a/bag_tracker/src/test/scala/weco/storage_service/bag_tracker/storage/StorageManifestDaoTestCases.scala
+++ b/bag_tracker/src/test/scala/weco/storage_service/bag_tracker/storage/StorageManifestDaoTestCases.scala
@@ -85,14 +85,30 @@ trait StorageManifestDaoTestCases[Context]
       }
     }
 
-    it("blocks putting two manifests with the same version") {
+    it("allows writing the same manifest to the same version twice") {
       val storageManifest = createStorageManifest
 
       withContext { implicit context =>
         withDao { dao =>
           dao.put(storageManifest).value shouldBe storageManifest
+          dao.put(storageManifest).value shouldBe storageManifest
+        }
+      }
+    }
+
+    it("blocks putting two different manifests with the same id and version") {
+      val storageManifest1 = createStorageManifestWith(version = BagVersion(1))
+      val storageManifest2 = createStorageManifestWith(
+        space = storageManifest1.space,
+        externalIdentifier = storageManifest1.info.externalIdentifier,
+        version = BagVersion(1)
+      )
+
+      withContext { implicit context =>
+        withDao { dao =>
+          dao.put(storageManifest1).value shouldBe storageManifest1
           dao
-            .put(storageManifest)
+            .put(storageManifest2)
             .left
             .value shouldBe a[VersionAlreadyExistsError]
         }

--- a/common/src/test/scala/weco/storage_service/generators/IngestGenerators.scala
+++ b/common/src/test/scala/weco/storage_service/generators/IngestGenerators.scala
@@ -19,7 +19,7 @@ trait IngestGenerators extends BagIdGenerators with S3Fixtures {
   val testCallbackUri =
     new URI("http://www.wellcomecollection.org/callback/ok")
 
-  private def maybeVersion: Option[BagVersion] =
+  protected def maybeVersion: Option[BagVersion] =
     chooseFrom(Some(createBagVersion), None)
 
   def createIngestWith(

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/IngestsTrackerApiFeatureTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/IngestsTrackerApiFeatureTest.scala
@@ -91,7 +91,12 @@ class IngestsTrackerApiFeatureTest
     describe("with an existing Ingest") {
       withIngestsTrackerApi(Seq(ingest)) {
         case (callbackSender, ingestsSender, ingestTracker) =>
-          whenAbsolutePostRequestReady(path, ingestEntity) { response =>
+          val otherIngestEntity = HttpEntity(
+            ContentTypes.`application/json`,
+            createIngestWith(id = ingest.id).asJson.noSpaces
+          )
+
+          whenAbsolutePostRequestReady(path, otherIngestEntity) { response =>
             it("responds Conflict") {
               response.status shouldBe StatusCodes.Conflict
             }

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
@@ -90,7 +90,7 @@ trait IngestTrackerTestCases[Context]
         val retrievedResult = tracker.get(ingest.id).value
 
         retrievedResult.id shouldBe Version(ingest.id, 0)
-        assertIngestsEqual(retrievedResult.identifiedT, ingest)
+        retrievedResult.identifiedT shouldBe ingest
       }
     }
 
@@ -128,16 +128,10 @@ trait IngestTrackerTestCases[Context]
 
         withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
           val result = tracker.update(update)
-          assertIngestEventSeqEqual(
-            result.value.identifiedT.events,
-            Seq(event)
-          )
+          result.value.identifiedT.events shouldBe Seq(event)
 
           val storedIngest = tracker.get(ingest.id).value.identifiedT
-          assertIngestEventSeqEqual(
-            storedIngest.events,
-            Seq(event)
-          )
+          storedIngest.events shouldBe Seq(event)
         }
       }
 
@@ -153,16 +147,10 @@ trait IngestTrackerTestCases[Context]
 
         withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
           val result = tracker.update(update)
-          assertIngestEventSeqEqual(
-            result.value.identifiedT.events,
-            events
-          )
+          result.value.identifiedT.events shouldBe events
 
           val storedIngest = tracker.get(ingest.id).value.identifiedT
-          assertIngestEventSeqEqual(
-            storedIngest.events,
-            events
-          )
+          storedIngest.events shouldBe events
         }
       }
 
@@ -178,16 +166,10 @@ trait IngestTrackerTestCases[Context]
 
         withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
           val result = tracker.update(update)
-          assertIngestEventSeqEqual(
-            result.value.identifiedT.events,
-            existingEvents ++ newEvents
-          )
+          result.value.identifiedT.events shouldBe existingEvents ++ newEvents
 
           val storedIngest = tracker.get(ingest.id).value.identifiedT
-          assertIngestEventSeqEqual(
-            storedIngest.events,
-            existingEvents ++ newEvents
-          )
+          storedIngest.events shouldBe existingEvents ++ newEvents
         }
       }
 
@@ -216,16 +198,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              Seq(event)
-            )
+            result.value.identifiedT.events shouldBe Seq(event)
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              Seq(event)
-            )
+            storedIngest.events shouldBe Seq(event)
           }
         }
 
@@ -241,16 +217,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              events
-            )
+            result.value.identifiedT.events shouldBe events
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              events
-            )
+            storedIngest.events shouldBe events
           }
         }
 
@@ -266,16 +236,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              existingEvents ++ newEvents
-            )
+            result.value.identifiedT.events shouldBe existingEvents ++ newEvents
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              existingEvents ++ newEvents
-            )
+            storedIngest.events shouldBe existingEvents ++ newEvents
           }
         }
       }
@@ -365,16 +329,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              Seq(event)
-            )
+            result.value.identifiedT.events shouldBe Seq(event)
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              Seq(event)
-            )
+            storedIngest.events shouldBe Seq(event)
           }
         }
 
@@ -390,16 +348,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              events
-            )
+            result.value.identifiedT.events shouldBe events
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              events
-            )
+            storedIngest.events shouldBe events
           }
         }
 
@@ -415,16 +367,10 @@ trait IngestTrackerTestCases[Context]
 
           withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
             val result = tracker.update(update)
-            assertIngestEventSeqEqual(
-              result.value.identifiedT.events,
-              existingEvents ++ newEvents
-            )
+            result.value.identifiedT.events shouldBe existingEvents ++ newEvents
 
             val storedIngest = tracker.get(ingest.id).value.identifiedT
-            assertIngestEventSeqEqual(
-              storedIngest.events,
-              existingEvents ++ newEvents
-            )
+            storedIngest.events shouldBe existingEvents ++ newEvents
           }
         }
       }
@@ -542,42 +488,6 @@ trait IngestTrackerTestCases[Context]
           tracker.update(update).left.value shouldBe a[IngestStoreError]
         }
       }
-    }
-  }
-
-  protected def assertIngestsEqual(
-    ingest1: Ingest,
-    ingest2: Ingest
-  ): Assertion =
-    ingest1 shouldBe ingest2
-
-  def assertIngestSeqEqual(
-    seq1: Seq[Ingest],
-    seq2: Seq[Ingest]
-  ): Seq[Assertion] = {
-    seq1.size shouldBe seq2.size
-
-    seq1.zip(seq2).map {
-      case (ingest1, ingest2) =>
-        assertIngestsEqual(ingest1, ingest2)
-    }
-  }
-
-  protected def assertIngestEventsEqual(
-    event1: IngestEvent,
-    event2: IngestEvent
-  ): Assertion =
-    event1 shouldBe event2
-
-  def assertIngestEventSeqEqual(
-    seq1: Seq[IngestEvent],
-    seq2: Seq[IngestEvent]
-  ): Seq[Assertion] = {
-    seq1.size shouldBe seq2.size
-
-    seq1.zip(seq2).map {
-      case (event1, event2) =>
-        assertIngestEventsEqual(event1, event2)
     }
   }
 }

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
@@ -3,12 +3,12 @@ package weco.storage_service.ingests_tracker.tracker
 import java.net.URI
 
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{Assertion, EitherValues}
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.fixtures.TestWith
 import weco.storage_service.generators.IngestGenerators
-import weco.storage_service.ingests.models.{Callback, Ingest, IngestEvent}
+import weco.storage_service.ingests.models.{Callback, Ingest}
 import weco.storage._
 
 trait IngestTrackerTestCases[Context]

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/IngestTrackerTestCases.scala
@@ -53,20 +53,20 @@ trait IngestTrackerTestCases[Context]
       }
     }
 
-    it("only allows calling init() once") {
+    it("allows calling init() twice with the same value") {
       withIngestTrackerFixtures() { tracker =>
         val ingest = createIngest
-        tracker.init(ingest)
-
-        tracker.init(ingest).left.value shouldBe a[IngestAlreadyExistsError]
+        tracker.init(ingest) shouldBe a[Right[_, _]]
+        tracker.init(ingest) shouldBe a[Right[_, _]]
       }
     }
 
-    it("blocks calling init() on a pre-existing ingest") {
-      val ingest = createIngest
-
-      withIngestTrackerFixtures(initialIngests = Seq(ingest)) { tracker =>
-        tracker.init(ingest).left.value shouldBe a[IngestAlreadyExistsError]
+    it("doesn't allow calling init() twice with different values") {
+      withIngestTrackerFixtures() { tracker =>
+        val ingest1 = createIngest
+        val ingest2 = createIngestWith(id = ingest1.id)
+        tracker.init(ingest1) shouldBe a[Right[_, _]]
+        tracker.init(ingest2).left.value shouldBe a[IngestAlreadyExistsError]
       }
     }
 

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -16,7 +16,11 @@ import weco.storage.dynamo._
 import weco.storage.fixtures.DynamoFixtures
 import weco.storage.fixtures.DynamoFixtures.{Table => DynamoTable}
 import weco.storage.store.VersionedStore
-import weco.storage.store.dynamo.DynamoHashStore
+import weco.storage.store.dynamo.{
+  ConsistencyMode,
+  DynamoHashStore,
+  StronglyConsistent
+}
 
 import scala.language.higherKinds
 
@@ -73,6 +77,8 @@ class DynamoIngestTrackerTest
               id: Version[IngestID, Int]
             )(t: Ingest): WriteEither =
               Left(StoreWriteError(new Throwable("BOOM!")))
+
+            override implicit val consistencyMode: ConsistencyMode = StronglyConsistent
           }
         )
       }

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -78,7 +78,8 @@ class DynamoIngestTrackerTest
             )(t: Ingest): WriteEither =
               Left(StoreWriteError(new Throwable("BOOM!")))
 
-            override implicit val consistencyMode: ConsistencyMode = StronglyConsistent
+            override implicit val consistencyMode: ConsistencyMode =
+              StronglyConsistent
           }
         )
       }

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -1,7 +1,6 @@
 package weco.storage_service.ingests_tracker.tracker.dynamo
 
 import java.time.temporal.ChronoUnit
-import org.scalatest.Assertion
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import weco.fixtures.TestWith

--- a/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests/ingests_tracker/src/test/scala/weco/storage_service/ingests_tracker/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -147,7 +147,7 @@ class DynamoIngestTrackerTest
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: Option[BagVersion] = maybeVersion,
     createdDate: Instant =
-    Instant.now().plusSeconds(randomInt(from = 0, to = 30)),
+      Instant.now().plusSeconds(randomInt(from = 0, to = 30)),
     events: Seq[IngestEvent] = Seq.empty
   ): Ingest =
     Ingest(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  val defaultVersion = "30.6.1" // This is automatically bumped by the scala-libs release process, do not edit this line manually
+  val defaultVersion = "30.6.2" // This is automatically bumped by the scala-libs release process, do not edit this line manually
 
   lazy val versions = new {
     val fixtures = defaultVersion

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -741,6 +741,9 @@ module "bag_register" {
     JAVA_OPTS               = local.java_opts_heap_size
   }
 
+  cpu    = 1024
+  memory = 2048
+
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
 

--- a/terraform/stack_prod/provider.tf
+++ b/terraform/stack_prod/provider.tf
@@ -4,7 +4,7 @@ locals {
     Department                = "Digital Platform"
     Division                  = "Culture and Society"
     Use                       = "Storage service"
-    Environment               = "Staging"
+    Environment               = "Production"
   }
 }
 

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -4,7 +4,7 @@ locals {
     Department                = "Digital Platform"
     Division                  = "Culture and Society"
     Use                       = "Storage service"
-    Environment               = "Production"
+    Environment               = "Staging"
   }
 }
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5287, closes https://github.com/wellcomecollection/storage-service/pull/939

## Context

The final step in storing a bag is the "bag register". This gets a notification about a fully replicated and verified bag, then it constructs a "storage manifest" which it stores in the VHS. The manifest is a JSON description of:

* the bag
* the files it contains, their size and checksum
* the replica locations (S3 buckets, Blob containers)

A bag can have multiple versions, so the DynamoDB table looks something like this:

```
id              | version | location
----------------+---------+------------------------------------------
digitised/b1234 | v1      | s3://storage-manifests-vhs/b1234/v1.json
digitised/b1234 | v2      | s3://storage-manifests-vhs/b1234/v2.json
digitised/b1234 | v3      | s3://storage-manifests-vhs/b1234/v3.json
digitised/b1235 | v1      | s3://storage-manifests-vhs/b1235/v1.json
…
```

## The problem

The underlying VersionedStore implementation isn't idempotent. If you call:

```
VersionedStore.put(Version(id, 1))(manifest)
VersionedStore.put(Version(id, 1))(manifest)
```

the second call will fail, even though you're writing the same value.

We recently saw the bag register receive the same notification twice. It stored the manifest successfully on the first try, but didn't manage to delete the message from SQS. One the second try, the failed call to VersionedStore.put failed the entire bag.

(This occurs through a wrapper class called StorageManifestDao.)

## The solution

These are the key changes:

* VersionedStore.put is now idempotent. This was added in scala-libs v30.6.2; see https://github.com/wellcomecollection/scala-libs/pull/136
* The bag register probably fell over because it ran out of CPU power; this doubles it from 0.5 vCPUs to 1 vCPU

Then I've also fixed a log message and added a few tests that the bag register can get the same notification twice.