### PR TITLE
Inline two uses of the withApp HTTP fixture

### DIFF
--- a/bags_api/src/test/scala/weco/storage_service/bags_api/fixtures/BagsApiFixture.scala
+++ b/bags_api/src/test/scala/weco/storage_service/bags_api/fixtures/BagsApiFixture.scala
@@ -58,7 +58,7 @@ trait BagsApiFixture
             metrics = metrics
           )
 
-          lazy val router: BagsApi = new BagsApi {
+          lazy val bagsApi: BagsApi = new BagsApi {
             override val httpServerConfig: HTTPServerConfig =
               httpServerConfigTest
             override implicit val ec: ExecutionContext = global
@@ -73,9 +73,16 @@ trait BagsApiFixture
             override val maximumResponseByteLength: Long = maxResponseByteLength
           }
 
-          withApp(router.bags, Some(httpMetrics), Some(actorSystem)) { app =>
-            testWith(app)
-          }
+          val app = new WellcomeHttpApp(
+            routes = bagsApi.bags,
+            httpMetrics = httpMetrics,
+            httpServerConfig = httpServerConfigTest,
+            appName = "bags.test"
+          )
+
+          app.run()
+
+          testWith(app)
         }
       }
     }

--- a/ingests/ingests_api/src/test/scala/weco/storage_service/ingests_api/fixtures/IngestsApiFixture.scala
+++ b/ingests/ingests_api/src/test/scala/weco/storage_service/ingests_api/fixtures/IngestsApiFixture.scala
@@ -65,9 +65,16 @@ trait IngestsApiFixture
           ingestCreatorInstance
       }
 
-      withApp(ingestsApi.ingests, Some(httpMetrics), Some(actorSystem)) { app =>
-        testWith(app)
-      }
+      val app = new WellcomeHttpApp(
+        routes = ingestsApi.ingests,
+        httpMetrics = httpMetrics,
+        httpServerConfig = httpServerConfigTest,
+        appName = "ingests.test"
+      )
+
+      app.run()
+
+      testWith(app)
     }
 
   def withBrokenApp[R](


### PR DESCRIPTION
This will let us simplify the upstream fixture by no longer having to pass the metrics/actor system.