### PR TITLE
Give the replicators List* permissions

### DIFF
--- a/terraform/modules/stack/replifier/iam_replicator.tf
+++ b/terraform/modules/stack/replifier/iam_replicator.tf
@@ -9,6 +9,17 @@ data "aws_iam_policy_document" "bucket_readwrite" {
       "arn:aws:s3:::${var.destination_namespace}/*",
     ]
   }
+
+  statement {
+    actions = [
+      "s3:List*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.destination_namespace}",
+      "arn:aws:s3:::${var.destination_namespace}/*",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "bag_replicator_read_write" {

--- a/terraform/stack_prod/.terraform.lock.hcl
+++ b/terraform/stack_prod/.terraform.lock.hcl
@@ -5,6 +5,17 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.42.0"
   hashes = [
     "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
   ]
 }
 


### PR DESCRIPTION
The replicator is a service that does bulk copying of objects from one S3 bucket to another.  But we don't want to overwrite/replace objects in the destination bucket if they already exist.

* if they're the same we can save ourselves a write
* if they're different then something has gone extremely wrong

So the replicator queries for the destination object before it starts the copy.

What happens if there's no existing object?  If you call GetObject on a non-existent object, one of two things can happen:

*   If you have List* permissions, S3 returns a 404 Not Found
*   If you don't have List* permissions, S3 returns a 401 Not Authorized (to avoid leaking information about bucket contents in 404s)

It turns out we'd given the replicator Get* and Put* permissions on the destination bucket, but not List*, so all these requests for non-existent objects were 401'ing.  Adding the right permissions means they'll 404, which is more correct.

Note: we do have some code to reduce the number of unnecessary requests here, but it's a fairly conservative check (better to check than not), and the cost of a few extra requests hasn't been unwieldy so far.

Closes https://github.com/wellcomecollection/platform/issues/5355