### PR TITLE
Don't trigger infinite prod deploys

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -26,17 +26,3 @@ steps:
       python3 .buildkite/scripts/send_and_wait_for_test_bag.py prod
     agents:
       queue: nano
-
-  - wait
-
-  - label: trigger prod deploy
-    trigger: "storage-service-deploy-prod"
-    async: true
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
-      env:
-        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
-        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"


### PR DESCRIPTION
This step runs as part of the "deploy prod" pipeline… and triggers another "deploy prod" pipeline.

This is obviously wrong.