### PR TITLE
Use shared helpers to reduce repetition + cleanups in the unpacker tests

### DIFF
--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/Unpacker.scala
@@ -139,7 +139,9 @@ trait Unpacker[
           s"Error trying to unpack the archive at $srcLocation - is the gzip-compression correct?"
         )
 
-      case _ => None
+      case _ =>
+        warn(s"Unhandled error while reading $srcLocation: $error")
+        None
     }
 
   private def unpack(

--- a/bag_unpacker/src/test/scala/weco/storage_service/bag_unpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/weco/storage_service/bag_unpacker/services/UnpackerTestCases.scala
@@ -170,7 +170,7 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
 
   it("fails if the specified file is not in tar.gz format") {
     assertUnpackingFailsWith("/greeting.txt") {
-      case (_, userFacingMessage) =>
+      case (_, _, userFacingMessage) =>
         userFacingMessage should startWith(
           "Error trying to unpack the archive at"
         )
@@ -199,7 +199,7 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
     */
   it("fails if the archive has an EOF error") {
     assertUnpackingFailsWith("/truncated.tar.gz") {
-      case (_, userFacingMessage) =>
+      case (_, _, userFacingMessage) =>
         userFacingMessage should startWith(
           "Unexpected EOF while unpacking the archive"
         )
@@ -223,7 +223,7 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
     */
   it("fails if the uncompressed tarball has an EOF error") {
     assertUnpackingFailsWith("/truncated_tar.tar.gz") {
-      case (_, userFacingMessage) =>
+      case (_, _, userFacingMessage) =>
         userFacingMessage should startWith(
           "Unexpected EOF while unpacking the archive"
         )
@@ -242,7 +242,7 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
     */
   it("fails if the archive has repeated entries") {
     assertUnpackingFailsWith("/repetitive.tar.gz") {
-      case (srcLocation, userFacingMessage) =>
+      case (srcLocation, _, userFacingMessage) =>
         userFacingMessage shouldBe s"The archive at $srcLocation is malformed or has a duplicate entry (1.bin)"
     }
   }
@@ -264,7 +264,7 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
     */
   it("fails if the gzip-compressed data is corrupt") {
     assertUnpackingFailsWith("/truncated_crc32.tar.gz") {
-      case (_, userFacingMessage) =>
+      case (_, _, userFacingMessage) =>
         userFacingMessage should startWith(
           "Error trying to unpack the archive at"
         )
@@ -272,9 +272,9 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
     }
   }
 
-  private def assertUnpackingFailsWith[R](
+  protected def assertUnpackingFailsWith[R](
     filename: String
-  )(testWith: TestWith[(BagLocation, String), R]): R = {
+  )(testWith: TestWith[(BagLocation, Throwable, String), R]): R = {
     withNamespace { srcNamespace =>
       withStreamStore { implicit streamStore =>
         val srcLocation = createSrcLocationWith(namespace = srcNamespace)
@@ -294,8 +294,8 @@ trait UnpackerTestCases[BagLocation <: Location, BagPrefix <: Prefix[
             }
 
           assertIsError(result) {
-            case (_, maybeUserFacingMessage) =>
-              testWith((srcLocation, maybeUserFacingMessage.get))
+            case (err, maybeUserFacingMessage) =>
+              testWith((srcLocation, err, maybeUserFacingMessage.get))
           }
         }
       }

--- a/bag_unpacker/src/test/scala/weco/storage_service/bag_unpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/weco/storage_service/bag_unpacker/services/s3/S3UnpackerTest.scala
@@ -209,7 +209,9 @@ class S3UnpackerTest
       //
       assertUnpackingFailsWith("/truncated_header.tar.gz") {
         case (_, err, userFacingMessage) =>
-          userFacingMessage should startWith("Error trying to unpack the archive")
+          userFacingMessage should startWith(
+            "Error trying to unpack the archive"
+          )
 
           err shouldBe a[IOException]
           err.getMessage shouldBe "Error detected parsing the header"
@@ -255,7 +257,9 @@ class S3UnpackerTest
       //
       assertUnpackingFailsWith("/truncated_s3.tar.gz") {
         case (_, _, userFacingMessage) =>
-          userFacingMessage should startWith("Unexpected EOF while unpacking the archive at")
+          userFacingMessage should startWith(
+            "Unexpected EOF while unpacking the archive at"
+          )
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object WellcomeDependencies {
-  val defaultVersion = "30.11.1" // This is automatically bumped by the scala-libs release process, do not edit this line manually
+  val defaultVersion = "30.11.3" // This is automatically bumped by the scala-libs release process, do not edit this line manually
 
   lazy val versions = new {
     val fixtures = defaultVersion


### PR DESCRIPTION
Some preliminary refactoring ahead of https://github.com/wellcomecollection/platform/issues/5357; closes #959 and closes #960