### PR TITLE
Reduce the size of the "always on" tasks by half

### DIFF
--- a/terraform/modules/service/bags/main.tf
+++ b/terraform/modules/service/bags/main.tf
@@ -4,8 +4,8 @@ module "base" {
   service_name = var.service_name
   cluster_arn  = var.cluster_arn
 
-  cpu    = var.cpu
-  memory = var.memory
+  cpu    = 512
+  memory = 1024
 
   container_definitions = [
     module.nginx_container.container_definition,

--- a/terraform/modules/service/bags/variables.tf
+++ b/terraform/modules/service/bags/variables.tf
@@ -18,14 +18,6 @@ variable "tracker_environment" {
   type = map(string)
 }
 
-variable "cpu" {
-  type = number
-}
-
-variable "memory" {
-  type = number
-}
-
 variable "container_port" {
   type    = number
   default = 9001

--- a/terraform/modules/service/ingest/main.tf
+++ b/terraform/modules/service/ingest/main.tf
@@ -4,8 +4,8 @@ module "base" {
   service_name = var.service_name
   cluster_arn  = var.cluster_arn
 
-  cpu    = 1024
-  memory = 2048
+  cpu    = 512
+  memory = 1024
 
   container_definitions = [
     module.nginx_container.container_definition,

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -245,9 +245,6 @@ module "bags_api" {
     vhs_table_name  = var.vhs_manifests_table_name
   }
 
-  cpu    = 1024
-  memory = 2048
-
   load_balancer_arn           = module.api.loadbalancer_arn
   load_balancer_listener_port = local.bags_listener_port
 


### PR DESCRIPTION
I had a look at the CPU/memory metrics for the last 6 weeks, and they're mostly over-provisioned.  Cutting their size by half should save us ~$230 in compute costs per month, and our monitoring will notice if we do something that breaks them.