### PR TITLE
Allow Digirati to subscribe to notifications from the staging service

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,7 +7,7 @@ The storage service Terraform is organised as follows:
 *   `critical_{staging, prod}` – the permanent storage resources for the staging/prod service.
     This includes the S3 buckets and Blob containers that hold all the files.
 
-    **Modifying our stack can affect our permanent files, so changes in this stack should always be applied by two developers working together.**
+    **Modifying this configuration can affect our permanent files, so changes in critical_prod should always be applied by two developers working together.**
 
 *   `infra` – some generic infrastructure for the storage service that isn't tied to a particular stack, e.g. ECR repositories and VPC endpoints
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,16 @@
+# terraform
+
+The storage service Terraform is organised as follows:
+
+*   `app_clients` – credentials for different clients of the storage service.
+
+*   `critical_{staging, prod}` – the permanent storage resources for the staging/prod service.
+    This includes the S3 buckets and Blob containers that hold all the files.
+
+    **Modifying our stack can affect our permanent files, so changes in this stack should always be applied by two developers working together.**
+
+*   `infra` – some generic infrastructure for the storage service that isn't tied to a particular stack, e.g. ECR repositories and VPC endpoints
+
+*   `monitoring` – tools for monitoring the storage service, both staging and prod
+
+*   `stack_{staging, prod}` – the transient processing services for a particular instance of the storage service, e.g. the ECS tasks and SQS queues

--- a/terraform/modules/stack/iam_policy_document.tf
+++ b/terraform/modules/stack/iam_policy_document.tf
@@ -238,11 +238,11 @@ data "aws_iam_policy_document" "allow_bag_registration_notification_subscription
 
     principals {
       identifiers = [
-        for account_id in var.allow_cross_account_subscription_to_bag_register_output_from:
+        for account_id in var.allow_cross_account_subscription_to_bag_register_output_from :
         "arn:aws:iam::${account_id}:root"
       ]
 
-      type        = "AWS"
+      type = "AWS"
     }
   }
 }

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -346,7 +346,7 @@ module "registered_bag_notifications_topic" {
 resource "aws_sns_topic_policy" "registered_bag_notifications_topic_cross_account_subscription" {
   # We only need to create a policy that allows subscriptions to this topic
   # if there are other accounts that need access.
-  count = length(var.bag_register_output_subscribe_principals) > 0 ? 1 : 0
+  count = length(var.allow_cross_account_subscription_to_bag_register_output_from) > 0 ? 1 : 0
 
   arn    = module.registered_bag_notifications_topic.arn
   policy = data.aws_iam_policy_document.allow_bag_registration_notification_subscription.json

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -158,7 +158,9 @@ variable "max_capacity" {
   type = number
 }
 
-variable "bag_register_output_subscribe_principals" {
+variable "allow_cross_account_subscription_to_bag_register_output_from" {
+  description = "A list of account IDs that can subscribe to the bag register output topic"
+
   type = list(string)
 }
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -22,7 +22,5 @@ locals {
   # TODO: This value should be exported from the workflow-infra state, not hard-coded
   workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit"
   archivematica_ingests_bucket_arn = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
-
-  catalogue_pipeline_account_principal = "arn:aws:iam::760097843905:root"
 }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -14,6 +14,10 @@ module "stack_prod" {
   min_capacity = 0
   max_capacity = 10
 
+  allow_cross_account_subscription_to_bag_register_output_from = [
+    "760097843905",  # catalogue
+  ]
+
   azure_ssm_parameter_base = "azure/wecostorageprod/wellcomecollection-storage-replica-netherlands"
 
   vpc_id = local.vpc_id
@@ -80,8 +84,6 @@ module "stack_prod" {
     local.workflow_bucket_arn,
     local.archivematica_ingests_bucket_arn,
   ]
-
-  bag_register_output_subscribe_principals = [local.catalogue_pipeline_account_principal]
 
   logging_container = {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -15,7 +15,7 @@ module "stack_prod" {
   max_capacity = 10
 
   allow_cross_account_subscription_to_bag_register_output_from = [
-    "760097843905",  # catalogue
+    "760097843905", # catalogue
   ]
 
   azure_ssm_parameter_base = "azure/wecostorageprod/wellcomecollection-storage-replica-netherlands"

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -20,4 +20,6 @@ locals {
   # TODO: This value should be exported from the workflow-infra state, not hard-coded
   workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit-stage"
   archivematica_ingests_bucket_arn = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
+
+  digirati_account_principal = "arn:aws:iam::653428163053:root"
 }

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -20,6 +20,4 @@ locals {
   # TODO: This value should be exported from the workflow-infra state, not hard-coded
   workflow_bucket_arn              = "arn:aws:s3:::wellcomecollection-workflow-export-bagit-stage"
   archivematica_ingests_bucket_arn = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket_arn
-
-  digirati_account_principal = "arn:aws:iam::653428163053:root"
 }

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -81,7 +81,9 @@ module "stack_staging" {
     local.archivematica_ingests_bucket_arn,
   ]
 
-  bag_register_output_subscribe_principals = []
+  bag_register_output_subscribe_principals = [
+    local.digirati_account_principal,
+  ]
 
   # This means the staging service might be interrupted (unlikely), but the
   # staging service doesn't make the same guarantees of uptime and this

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -15,7 +15,7 @@ module "stack_staging" {
   max_capacity = 3
 
   allow_cross_account_subscription_to_bag_register_output_from = [
-    "653428163053",  # digirati
+    "653428163053", # digirati
   ]
 
   azure_ssm_parameter_base = "azure/wecostoragestage/wellcomecollection-storage-staging-replica-netherlands"

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -14,6 +14,10 @@ module "stack_staging" {
   min_capacity = 0
   max_capacity = 3
 
+  allow_cross_account_subscription_to_bag_register_output_from = [
+    "653428163053",  # digirati
+  ]
+
   azure_ssm_parameter_base = "azure/wecostoragestage/wellcomecollection-storage-staging-replica-netherlands"
 
   vpc_id = local.vpc_id
@@ -79,10 +83,6 @@ module "stack_staging" {
   upload_bucket_arns = [
     local.workflow_bucket_arn,
     local.archivematica_ingests_bucket_arn,
-  ]
-
-  bag_register_output_subscribe_principals = [
-    local.digirati_account_principal,
   ]
 
   # This means the staging service might be interrupted (unlikely), but the


### PR DESCRIPTION
~This change is already applied; this PR is just for visibility.~

Okay it wasn't, but now it is.

I've also added a few notes on how the storage service Terraform is organised, and tried to make the cross-account SNS subscriptions a bit more obvious.