### PR TITLE
Reduce the Azure replicator concurrency to avoid intermittent issues

### DIFF
--- a/bag_replicator/src/main/resources/application.conf
+++ b/bag_replicator/src/main/resources/application.conf
@@ -8,4 +8,5 @@ aws.metrics.namespace=${?metrics_namespace}
 operation.name=${?operation_name}
 aws.locking.dynamo.tableName=${?locking_table_name}
 aws.locking.dynamo.tableIndex=${?locking_table_index}
+aws.locking.dynamo.lockExpiryTime=${?locking_expiry_time}
 azure.endpoint=${?azure_endpoint}

--- a/scripts/ss_retry_unpacking.py
+++ b/scripts/ss_retry_unpacking.py
@@ -52,10 +52,10 @@ if __name__ == "__main__":
     }
 
     if name == "prod":
-        topic_arn = "arn:aws:sns:eu-west-1:975596993436:storage_prod_bag_unpacker_input"
+        topic_arn = "arn:aws:sns:eu-west-1:975596993436:storage-prod_bag_unpacker_input"
     elif name == "stage":
         topic_arn = (
-            "arn:aws:sns:eu-west-1:975596993436:storage_staging_bag_unpacker_input"
+            "arn:aws:sns:eu-west-1:975596993436:storage-staging_bag_unpacker_input"
         )
     else:
         assert False, f"Unrecognised API name: {name}"

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -697,7 +697,7 @@ module "replica_aggregator" {
   subnets      = var.private_subnets
   service_name = "${var.namespace}-replica_aggregator"
 
-environment = {
+  environment = {
     replicas_table_name    = var.replicas_table_name
     queue_url              = module.replica_aggregator_input_queue.url
     outgoing_topic_arn     = module.replica_aggregator_output_topic.arn

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -633,7 +633,7 @@ module "replicator_verifier_azure" {
   }
 
   verifier_secrets = {
-    azure_endpoint = "${var.azure_ssm_parameter_base}/read_write_sas_url"
+    azure_endpoint = "${var.azure_ssm_parameter_base}/read_only_sas_url"
   }
 
   replicator_secrets = {

--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -133,6 +133,10 @@ module "bag_unpacker_queue" {
   # avoid messages appearing to time out and fail.
   visibility_timeout_seconds = 60 * 60 * 5
 
+  # We want to make sure the bag unpacker doesn't get interrupted mid-work,
+  # so we increase the cooldown period to avoid premature scaling down.
+  cooldown_period = "15m"
+
   queue_high_actions = [
     module.bag_unpacker.scale_up_arn,
   ]

--- a/terraform/modules/stack/replifier/main.tf
+++ b/terraform/modules/stack/replifier/main.tf
@@ -22,11 +22,18 @@ module "bag_replicator" {
     outgoing_topic_arn    = module.bag_replicator_output_topic.arn
     metrics_namespace     = local.bag_replicator_service_name
     operation_name        = "replicating to ${var.replica_display_name}"
-    locking_table_name    = var.replicator_lock_table_name
-    locking_table_index   = var.replicator_lock_table_index
     storage_provider      = var.storage_provider
     replica_type          = var.replica_type
     JAVA_OPTS             = local.java_opts_heap_size
+
+    # This expiry time is for processing the entire bag, because we
+    # lock over the destination prefix.
+    #
+    # We'll need to reduce this expiry time when we switch to per-object
+    # locks; see https://github.com/wellcomecollection/storage-service/issues/993
+    locking_table_name  = var.replicator_lock_table_name
+    locking_table_index = var.replicator_lock_table_index
+    locking_expiry_time = "${var.replicator_visibility_timeout_seconds - 30}s"
   }
 
   secrets = var.replicator_secrets

--- a/terraform/modules/stack/replifier/messaging.tf
+++ b/terraform/modules/stack/replifier/messaging.tf
@@ -9,10 +9,7 @@ module "bag_replicator_input_queue" {
 
   role_names = [module.bag_replicator.task_role_name]
 
-  # Because these operations take a long time (potentially copying thousands
-  # of S3 objects for a single message), we keep a high visibility timeout to
-  # avoid messages appearing to time out and fail.
-  visibility_timeout_seconds = 60 * 60 * 5
+  visibility_timeout_seconds = var.replicator_visibility_timeout_seconds
 
   # We want to make sure the bag replicator doesn't get interrupted mid-work,
   # so we increase the cooldown period to avoid premature scaling down.
@@ -50,9 +47,7 @@ module "bag_verifier_queue" {
 
   role_names = [module.bag_verifier.task_role_name]
 
-  # We keep a high visibility timeout to
-  # avoid messages appearing to time out and fail.
-  visibility_timeout_seconds = 60 * 60 * 5
+  visibility_timeout_seconds = var.verifier_visibility_timeout_seconds
 
   # We want to make sure the bag verifier doesn't get interrupted mid-work,
   # so we increase the cooldown period to avoid premature scaling down.

--- a/terraform/modules/stack/replifier/variables.tf
+++ b/terraform/modules/stack/replifier/variables.tf
@@ -131,3 +131,24 @@ variable "logging_container" {
     container_tag      = string
   })
 }
+
+# Because these operations take a long time (potentially copying thousands
+# of S3 objects for a single message), we keep a high visibility timeout to
+# avoid messages appearing to time out and fail.
+#
+# Also, we current lock over the entire destination prefix, and there are
+# issues if the lock expires before the message is retried.
+#
+# See https://github.com/wellcomecollection/storage-service/issues/993
+#
+variable "replicator_visibility_timeout_seconds" {
+  description = "Visibility timeout of the SQS queue for the replicator"
+  type        = number
+  default     = 60 * 60 * 5
+}
+
+variable "verifier_visibility_timeout_seconds" {
+  description = "Visibility timeout of the SQS queue for the verifier"
+  type        = number
+  default     = 60 * 60 * 5
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/storage-service/issues/993

This reduces the max tasks in the Azure replicator in prod from 10 to 8, plus makes sure we actually configure replicator locks properly (i.e. not the default of 3 minutes). We'll probably want to back out these changes again later, but I hope they'll stave off any more intermittent failures.