### PR TITLE
Use a Localstack container for S3 instead of zenko/cloudserver

### DIFF
--- a/bag_register/docker-compose.yml
+++ b/bag_register/docker-compose.yml
@@ -5,8 +5,8 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"

--- a/bag_register/docker-compose.yml
+++ b/bag_register/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_register/docker-compose.yml
+++ b/bag_register/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -5,11 +5,11 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"
 azurite:
   image: "mcr.microsoft.com/azure-storage/azurite"
   ports:

--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_root_finder/docker-compose.yml
+++ b/bag_root_finder/docker-compose.yml
@@ -5,8 +5,8 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"

--- a/bag_root_finder/docker-compose.yml
+++ b/bag_root_finder/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_root_finder/docker-compose.yml
+++ b/bag_root_finder/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_tagger/docker-compose.yml
+++ b/bag_tagger/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_tagger/docker-compose.yml
+++ b/bag_tagger/docker-compose.yml
@@ -5,11 +5,11 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"
 azurite:
   image: "mcr.microsoft.com/azure-storage/azurite"
   ports:

--- a/bag_tagger/docker-compose.yml
+++ b/bag_tagger/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_tracker/docker-compose.yml
+++ b/bag_tracker/docker-compose.yml
@@ -3,7 +3,7 @@ dynamodb:
   ports:
     - "45678:8000"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_tracker/docker-compose.yml
+++ b/bag_tracker/docker-compose.yml
@@ -3,8 +3,8 @@ dynamodb:
   ports:
     - "45678:8000"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"

--- a/bag_tracker/docker-compose.yml
+++ b/bag_tracker/docker-compose.yml
@@ -3,7 +3,7 @@ dynamodb:
   ports:
     - "45678:8000"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_unpacker/docker-compose.yml
+++ b/bag_unpacker/docker-compose.yml
@@ -5,8 +5,8 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"

--- a/bag_unpacker/docker-compose.yml
+++ b/bag_unpacker/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_unpacker/docker-compose.yml
+++ b/bag_unpacker/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_verifier/docker-compose.yml
+++ b/bag_verifier/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_verifier/docker-compose.yml
+++ b/bag_verifier/docker-compose.yml
@@ -5,11 +5,11 @@ localstack:
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"
 azurite:
   image: "mcr.microsoft.com/azure-storage/azurite"
   ports:

--- a/bag_verifier/docker-compose.yml
+++ b/bag_verifier/docker-compose.yml
@@ -1,11 +1,11 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:
     - "4566:4566"
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bag_versioner/docker-compose.yml
+++ b/bag_versioner/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/bag_versioner/docker-compose.yml
+++ b/bag_versioner/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/bags_api/docker-compose.yml
+++ b/bags_api/docker-compose.yml
@@ -1,5 +1,5 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/bags_api/docker-compose.yml
+++ b/bags_api/docker-compose.yml
@@ -1,5 +1,5 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/bags_api/docker-compose.yml
+++ b/bags_api/docker-compose.yml
@@ -1,6 +1,6 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ def setupProject(
   externalDependencies: Seq[ModuleID] = Seq(),
   description: String
 ): Project = {
-
   Metadata.write(project, folder, localDependencies, description)
 
   val dependsOn = localDependencies

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -6,7 +6,8 @@ set -o verbose
 
 ECR_REGISTRY="760097843905.dkr.ecr.eu-west-1.amazonaws.com"
 
-ROOT=$(git rev-parse --show-toplevel)
+ROOT="$(git rev-parse --show-toplevel)"
+ROOT="$(cd "$(dirname "$ROOT")"; pwd)/$(basename "$ROOT")"
 
 # Coursier cache location is platform-dependent
 # https://get-coursier.io/docs/cache.html#default-location
@@ -24,8 +25,10 @@ docker run --tty --rm \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "$DOCKER_CONFIG:/root/.docker" \
+  --volume "${DOCKER_CONFIG:-$HOME/.docker}":/root/.docker \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
+  --env "BUILDKITE_BUILD_NUMBER" \
+  --env "ROOT" \
   "$ECR_REGISTRY/wellcome/sbt_wrapper" "$@"

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,9 +1,9 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
   environment:
-    - "S3BACKEND=mem"
+    - SERVICES=s3
   ports:
-    - "33333:8000"
+    - "33333:4566"
 azurite:
   image: "mcr.microsoft.com/azure-storage/azurite"
   ports:

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,5 +1,5 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=s3
   ports:

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,5 +1,5 @@
 s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=s3
   ports:

--- a/indexer/bag_indexer/docker-compose.yml
+++ b/indexer/bag_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/bag_indexer/docker-compose.yml
+++ b/indexer/bag_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/file_finder/docker-compose.yml
+++ b/indexer/file_finder/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/file_finder/docker-compose.yml
+++ b/indexer/file_finder/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/file_indexer/docker-compose.yml
+++ b/indexer/file_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/file_indexer/docker-compose.yml
+++ b/indexer/file_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/ingests_indexer/docker-compose.yml
+++ b/indexer/ingests_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/indexer/ingests_indexer/docker-compose.yml
+++ b/indexer/ingests_indexer/docker-compose.yml
@@ -10,7 +10,7 @@ elasticsearch:
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/ingests/ingests_worker/docker-compose.yml
+++ b/ingests/ingests_worker/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/notifier/docker-compose.yml
+++ b/notifier/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
   environment:
     - SERVICES=sqs
   ports:

--- a/notifier/docker-compose.yml
+++ b/notifier/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:

--- a/notifier/docker-compose.yml
+++ b/notifier/docker-compose.yml
@@ -1,5 +1,5 @@
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.2"
   environment:
     - SERVICES=sqs
   ports:

--- a/replica_aggregator/docker-compose.yml
+++ b/replica_aggregator/docker-compose.yml
@@ -3,7 +3,7 @@ dynamodb:
   ports:
     - "45678:8000"
 localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.14.3"
   environment:
     - SERVICES=sqs
   ports:


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5547

Note: I don't plan to merge this as-is; I'm using it to prove these tests can pass with localstack. Our localstack container runs on port 4566; our existing S3 container uses port 33333. I'd like to collapse it all into 4566, but that's defined in the S3Fixtures trait – I'll have to patch scala-libs to use the new port, then use the new version of the library here, then remove the overrides. This will also allow me to consolidate containers in some tests; if we have SQS+S3 in the same test, we can do them both in a single localstack container.