### PR TITLE
Use eclipse-temurin:11-jre-alpine for applications

### DIFF
--- a/bag_register/Dockerfile
+++ b/bag_register/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_replicator/Dockerfile
+++ b/bag_replicator/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_root_finder/Dockerfile
+++ b/bag_root_finder/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_tagger/Dockerfile
+++ b/bag_tagger/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_tracker/Dockerfile
+++ b/bag_tracker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_unpacker/Dockerfile
+++ b/bag_unpacker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_verifier/Dockerfile
+++ b/bag_verifier/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bag_versioner/Dockerfile
+++ b/bag_versioner/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/bags_api/Dockerfile
+++ b/bags_api/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/indexer/bag_indexer/Dockerfile
+++ b/indexer/bag_indexer/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/indexer/file_finder/Dockerfile
+++ b/indexer/file_finder/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/indexer/file_indexer/Dockerfile
+++ b/indexer/file_indexer/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/indexer/ingests_indexer/Dockerfile
+++ b/indexer/ingests_indexer/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/ingests/ingests_api/Dockerfile
+++ b/ingests/ingests_api/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/ingests/ingests_tracker/Dockerfile
+++ b/ingests/ingests_tracker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/ingests/ingests_worker/Dockerfile
+++ b/ingests/ingests_worker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/notifier/Dockerfile
+++ b/notifier/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/replica_aggregator/Dockerfile
+++ b/replica_aggregator/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 


### PR DESCRIPTION
Following on from https://github.com/wellcomecollection/platform-infrastructure/pull/313, using the same (smaller and non-deprecated) image for running our applications as we do for compiling them. This being the JVM I don't expect to see any of the potential oddities of Alpine that occur with compiled code, but will keep an eye on things of course.