### PR TITLE
Always check for existing objects in the prefix when replicating

### DIFF
--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
@@ -9,7 +9,6 @@ import weco.storage_service.ingests.models.IngestID
 import weco.storage_service.storage.models.{EnsureTrailingSlash, StorageSpace}
 import weco.storage_service.storage.services.DestinationBuilder
 import weco.storage._
-import weco.storage.listing.Listing
 import weco.storage.s3.S3ObjectLocationPrefix
 import weco.storage.transfer.{PrefixTransfer, PrefixTransferFailure}
 
@@ -30,8 +29,6 @@ trait Replicator[SrcLocation, DstLocation <: Location, DstPrefix <: Prefix[
     DstPrefix,
     DstLocation
   ]
-
-  implicit val dstListing: Listing[DstPrefix, DstLocation]
 
   def buildDestination(
     namespace: String,

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
@@ -75,7 +75,6 @@ trait Replicator[SrcLocation, DstLocation <: Location, DstPrefix <: Prefix[
     prefixTransfer.transferPrefix(
       srcPrefix = replicaSrcPrefix,
       dstPrefix = request.dstPrefix,
-
       // We used to condition this on whether there were any existing objects in
       // the prefix; if there weren't, we skip checking to avoid getting eventual
       // consistency from S3.  We no longer need to do so.

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/azure/AzureReplicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/azure/AzureReplicator.scala
@@ -2,25 +2,19 @@ package weco.storage_service.bag_replicator.replicator.azure
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.S3ObjectSummary
-import com.azure.storage.blob.BlobServiceClient
 import weco.storage_service.bag_replicator.replicator.Replicator
 import weco.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
-import weco.storage.listing.azure.AzureBlobLocationListing
 import weco.storage.transfer.azure.{AzurePrefixTransfer, AzureTransfer}
 
 class AzureReplicator(
   transfer: AzureTransfer[_]
 )(
-  implicit s3Client: AmazonS3,
-  blobClient: BlobServiceClient
+  implicit s3Client: AmazonS3
 ) extends Replicator[
       S3ObjectSummary,
       AzureBlobLocation,
       AzureBlobLocationPrefix
     ] {
-
-  override implicit val dstListing: AzureBlobLocationListing =
-    AzureBlobLocationListing()
 
   override implicit val prefixTransfer: AzurePrefixTransfer =
     new AzurePrefixTransfer()(s3Client, transfer)

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/s3/S3Replicator.scala
@@ -2,7 +2,6 @@ package weco.storage_service.bag_replicator.replicator.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import weco.storage_service.bag_replicator.replicator.Replicator
-import weco.storage.listing.s3.S3ObjectLocationListing
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.transfer.s3.S3PrefixTransfer
 
@@ -24,9 +23,6 @@ class S3Replicator(implicit s3Client: AmazonS3)
   // to store them as Standard-IA than Standard.
   //
   implicit val prefixTransfer: S3PrefixTransfer = S3PrefixTransfer()
-
-  override implicit val dstListing: S3ObjectLocationListing =
-    S3ObjectLocationListing()
 
   override protected def buildDestinationFromParts(
     bucket: String,


### PR DESCRIPTION
For #993. This change doesn't affect much code, but it requires quite a lot of context to understand.

---

The bag replicator copies bags around, or more specifically prefixes. For example, it might get a request

> copy bag `s3://temporary-storage/b1234/v1` to `s3://permanent-storage/b1234/v1`

We don't want the replicator to overwrite existing objects, and we can't enforce this in S3 itself. If you call PutObject twice for the same key, S3 will happily write both versions of the object. We do have the bag verifier to check the bag after it's been written, but we'd rather not have multiple versions of individual objects. If each object has exactly one version, everything gets easier to reason about.

(Or rather, we can using S3 Object Lock and write-once-read-many (WORM), but we don't have those enabled.)

We do two things to reduce the risk of this happening:

1. The replicator will lock around the destination prefix, and in theory only one replicator is writing to a prefix at a time.
2. If the replicator is about to write to a key that already has an object, it compares the already-present object and the object it's about to write. If they're the same, the write is a no-op. If they're different, it throws an error.

These work, mostly.

## Problem 1: S3 consistency

But when we initially tried this approach in September 2019 (https://github.com/wellcomecollection/platform/issues/3897), we hit an issue with S3 consistency. Quoting the S3 documentation at the time:

> Amazon S3 provides read-after-write consistency for PUTS of new objects in your S3 bucket in all Regions with one caveat. The caveat is that if you make a HEAD or GET request to a key name before the object is created, then create the object shortly after that, a subsequent GET might not return the object due to eventual consistency.

This caused failures where:

1. The replicator would go to write an object
2. It would make a GET request for the key (which didn't exist), forcing the object into eventual consistency
3. Finding nothing, it would make a PUT to replicate the object
4. Later, the verifier would make a GET to retrieve the object and check its contents, but due to eventual consistency, it would get a 404 and fail

So we introduced a new rule: the replicator would skip looking for existing object if the prefix was empty when it started. This meant it was usually making a PUT for a brand new object, and give us read-after-write consistency. Hooray!

In December 2020, Amazon [announced strong read-after-write consistency](https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-s3-now-delivers-strong-read-after-write-consistency-automatically-for-all-applications/) for all objects in S3, making this workaround unnecessary. We didn't remove it at the time because everything was working fine; why change what's not broken?

## Azure replication

In September 2020, we added replication to Azure. Here we did enable some of the WORM features; if you try to write the same Azure blob twice, you get an error:

> Error while trying to Put Block to azure://wellcomecollection-storage-replica-netherlands/digitised/b32848444/v1/data/objects/b32848444_0001_1288.jp2 range bytes=0-: com.azure.storage.blob.models.BlobStorageException: Status code 409, "&lt;?xml version="1.0" encoding="utf-8"?>&lt;Error>&lt;Code>BlobImmutableDueToLegalHold<&lt;/Code>&lt;Message>This operation is not permitted as the blob is immutable due to one or more legal holds.

The Azure replicator inherited the behaviour of the S3 replicator; in particular it would skip checking for existing blobs if the destination prefix was empty when it started.

## Problem 2: slow-running Azure replicas

We've started to see issues with Azure replication when the S3→Azure pipe is saturated. In particular, if we're replicating a lot of bags at once, we may see the following failure mode:

1. An Azure replicator receives a message, acquires a lock over the prefix, starts replicating. There are no blobs in the prefix, so it doesn't check for existing blobs.
2. Because the pipe is saturated, it doesn't actually replicate anything before the lock expires.
3. A second Azure replicator receives the resent message, acquires a new lock over the prefix, starts replicating. There are still no blobs in the prefix, so it doesn't check for existing blobs.
4. At some point both replicators see a blob written by the other. This throws the `BlobImmutableDueToLegalHold` error.

This hasn't happened a lot, but it's more than a handful of times. It's usually fixed by reprocessing the bag, but ideally it shouldn't happen at all.

## The solution

This failure becomes much less likely if the replicator always checks for existing objects before writing anything, which is what I've done in this patch.

It makes the replicator a bit slower, but also simpler and (🤞) more reliable.

There's more we could do here – in particular, I think we should look at locking around individual keys rather than an entire prefix, to avoid cases where locks expire while work is ongoing – but I think this will solve the immediate problem.