### PR TITLE
Fetch the token whenever it's expired

### DIFF
--- a/python_client/setup.py
+++ b/python_client/setup.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import os
 
 from setuptools import find_packages, setup

--- a/python_client/src/wellcome_storage_service/__init__.py
+++ b/python_client/src/wellcome_storage_service/__init__.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from oauthlib.oauth2 import BackendApplicationClient
+from oauthlib.oauth2.rfc6749.errors import TokenExpiredError
 from requests_oauthlib import OAuth2Session
 
 from .downloader import download_bag, download_compressed_bag
@@ -161,17 +162,23 @@ class RequestsStorageServiceClient(StorageServiceClientBase):
 def needs_token(f):
     @functools.wraps(f)
     def wrapper(self, *args, **kwargs):
-        # We need to refresh the token if:
-        #   1. We've never asked for a token before
-        #   2. The existing token is close to expiry
-        #
-        if not self.sess.token or (time.time() - 10 > self.sess.token["expires_at"]):
+        if not self.sess.token:
             self.sess.fetch_token(
                 token_url=self.token_url,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
             )
-        return f(self, *args, **kwargs)
+
+        # We refresh the token if we get a TokenExpiredError from the client.
+        try:
+            return f(self, *args, **kwargs)
+        except TokenExpiredError:
+            self.sess.fetch_token(
+                token_url=self.token_url,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+            )
+            return f(self, *args, **kwargs)
 
     return wrapper
 

--- a/python_client/src/wellcome_storage_service/__init__.py
+++ b/python_client/src/wellcome_storage_service/__init__.py
@@ -3,7 +3,6 @@
 import functools
 import json
 import os
-import time
 
 from oauthlib.oauth2 import BackendApplicationClient
 from oauthlib.oauth2.rfc6749.errors import TokenExpiredError

--- a/python_client/src/wellcome_storage_service/__init__.py
+++ b/python_client/src/wellcome_storage_service/__init__.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import functools
 import json
 import os

--- a/python_client/src/wellcome_storage_service/_utils.py
+++ b/python_client/src/wellcome_storage_service/_utils.py
@@ -1,6 +1,3 @@
-# -*- encoding: utf-8
-
-
 import errno
 import os
 

--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import abc
 import os
 import shutil

--- a/python_client/src/wellcome_storage_service/exceptions.py
+++ b/python_client/src/wellcome_storage_service/exceptions.py
@@ -1,6 +1,3 @@
-# -*- encoding: utf-8
-
-
 class StorageServiceException(Exception):
     """Base class for all storage service exceptions."""
 

--- a/python_client/src/wellcome_storage_service/version.py
+++ b/python_client/src/wellcome_storage_service/version.py
@@ -1,4 +1,2 @@
-# -*- encoding: utf-8 -*-
-
 __version_info__ = (2, 3, 4)
 __version__ = ".".join(map(str, __version_info__))

--- a/python_client/src/wellcome_storage_service/version.py
+++ b/python_client/src/wellcome_storage_service/version.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
-__version_info__ = (2, 3, 3)
+__version_info__ = (2, 3, 4)
 __version__ = ".".join(map(str, __version_info__))

--- a/python_client/tests/conftest.py
+++ b/python_client/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import json
 import os
 

--- a/python_client/tests/test_bags.py
+++ b/python_client/tests/test_bags.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import pytest
 
 from wellcome_storage_service.exceptions import BagNotFound

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import tarfile
 
 from botocore.exceptions import ClientError

--- a/python_client/tests/test_ingests.py
+++ b/python_client/tests/test_ingests.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import pytest
 
 from wellcome_storage_service.exceptions import IngestNotFound, ServerError, UserError

--- a/python_client/tests/test_oauth.py
+++ b/python_client/tests/test_oauth.py
@@ -1,6 +1,3 @@
-# -*- encoding: utf-8
-
-
 def test_refreshes_an_expired_token(client):
     client.get_ingest("025a929b-7ec4-4fe9-836a-a65b39528b09")
 

--- a/python_client/tests/test_utils.py
+++ b/python_client/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import os
 
 import mock

--- a/scripts/ss_download_bag.py
+++ b/scripts/ss_download_bag.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- encoding: utf-8
+#!/usr/bin/env python3
 """
 Download the contents of a bag.  Usage:
 

--- a/scripts/ss_get_bag.py
+++ b/scripts/ss_get_bag.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- encoding: utf-8
+#!/usr/bin/env python3
 """
 Look up an bag.  Usage:
 


### PR DESCRIPTION
I suspect the logic for deciding when to fetch a token was a bit borked; this changes it so we fetch a new token if:

1. we don't have one
2. the existing token has expired

which feels more robust.

Tentatively closes https://github.com/wellcomecollection/storage-service/issues/983