### PR TITLE
Try lowering the deregistration delay on the API services

### DIFF
--- a/terraform/modules/service/bags/target_group.tf
+++ b/terraform/modules/service/bags/target_group.tf
@@ -7,6 +7,12 @@ resource "aws_lb_target_group" "tcp" {
   port     = module.nginx_container.container_port
   vpc_id   = var.vpc_id
 
+  # The default deregistration delay is 5 minutes, which means that ECS
+  # takes around 5–7 mins to fully drain connections to and deregister
+  # the old task in the course of its blue/green. deployment of an
+  # updated service.  Reducing this parameter to 90s makes deployments faster.
+  deregistration_delay = 90
+
   health_check {
     protocol = "TCP"
   }

--- a/terraform/modules/service/ingest/target_group.tf
+++ b/terraform/modules/service/ingest/target_group.tf
@@ -7,6 +7,12 @@ resource "aws_lb_target_group" "tcp" {
   port     = module.nginx_container.container_port
   vpc_id   = var.vpc_id
 
+  # The default deregistration delay is 5 minutes, which means that ECS
+  # takes around 5–7 mins to fully drain connections to and deregister
+  # the old task in the course of its blue/green. deployment of an
+  # updated service.  Reducing this parameter to 90s makes deployments faster.
+  deregistration_delay = 90
+
   health_check {
     protocol = "TCP"
   }


### PR DESCRIPTION
Currently deployments are failing because the `aws ecs wait` command only waits for 40 × 15s ≈ 10m before marking a deployment as failed. I hope that if I lower the deregistration delay, deployments will go faster and the builds will succeed.

I borrowed this from something Jamie did aaaaaages ago in the catalogue API.

Tentative fix for https://github.com/wellcomecollection/platform/issues/5626