### PR TITLE
Remove the last bits of the V2 SDK

### DIFF
--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/Main.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/Main.scala
@@ -1,7 +1,6 @@
 package weco.storage_service.bag_verifier
 
 import akka.actor.ActorSystem
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -29,9 +28,6 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val s3Client: S3Client =
       S3Client.builder().build()
-
-    implicit val amazonS3: AmazonS3 =
-      AmazonS3ClientBuilder.standard.build()
 
     implicit val metrics: CloudWatchMetrics =
       CloudWatchBuilder.buildCloudWatchMetrics(config)

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/builder/BagVerifierWorkerBuilder.scala
@@ -1,7 +1,6 @@
 package weco.storage_service.bag_verifier.builder
 
 import akka.actor.ActorSystem
-import com.amazonaws.services.s3.AmazonS3
 import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -36,7 +35,6 @@ object BagVerifierWorkerBuilder {
     outgoingPublisher: OutgoingPublisher[SNSConfig]
   )(
     implicit s3: S3Client,
-    amazonS3: AmazonS3,
     metrics: Metrics[Future],
     as: ActorSystem,
     sc: SqsAsyncClient
@@ -95,7 +93,6 @@ object BagVerifierWorkerBuilder {
     outgoingPublisher: OutgoingPublisher[OutgoingDestination]
   )(
     implicit s3: S3Client,
-    amazonS3: AmazonS3,
     metrics: Metrics[Future],
     as: ActorSystem,
     sc: SqsAsyncClient
@@ -126,7 +123,6 @@ object BagVerifierWorkerBuilder {
     outgoingPublisher: OutgoingPublisher[OutgoingDestination]
   )(
     implicit s3: S3Client,
-    amazonS3: AmazonS3,
     metrics: Metrics[Future],
     as: ActorSystem,
     sc: SqsAsyncClient

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifier.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifier.scala
@@ -1,6 +1,5 @@
 package weco.storage_service.bag_verifier.services.s3
 
-import com.amazonaws.services.s3.AmazonS3
 import software.amazon.awssdk.services.s3.S3Client
 import weco.storage_service.bag_verifier.fixity.FixityListChecker
 import weco.storage_service.bag_verifier.fixity.s3.S3FixityChecker
@@ -84,8 +83,7 @@ class S3ReplicatedBagVerifier(
 object S3BagVerifier {
   def standalone(
     primaryBucket: String
-  )(implicit s3Client: S3Client,
-    amazonS3: AmazonS3): S3StandaloneBagVerifier = {
+  )(implicit s3Client: S3Client): S3StandaloneBagVerifier = {
     val bagReader = new S3BagReader()
     val listing = S3ObjectLocationListing()
     val resolvable = new S3Resolvable()
@@ -103,8 +101,7 @@ object S3BagVerifier {
   }
   def replicated(
     primaryBucket: String
-  )(implicit s3Client: S3Client,
-    amazonS3: AmazonS3): S3ReplicatedBagVerifier = {
+  )(implicit s3Client: S3Client): S3ReplicatedBagVerifier = {
     val bagReader = new S3BagReader()
     val listing = S3ObjectLocationListing()
     val resolvable = new S3Resolvable()

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
@@ -1,13 +1,17 @@
 package weco.storage_service.bag_verifier.storage.s3
 
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
-import weco.storage_service.bag_verifier.storage.{Locatable, LocateFailure, LocationParsingError}
+import weco.storage_service.bag_verifier.storage.{
+  Locatable,
+  LocateFailure,
+  LocationParsingError
+}
 
 import java.net.URI
 
 object S3Locatable {
   implicit val s3UriLocatable
-  : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
+    : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
     new Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] {
       override def locate(uri: URI)(
         maybeRoot: Option[S3ObjectLocationPrefix]

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
@@ -1,32 +1,34 @@
 package weco.storage_service.bag_verifier.storage.s3
 
-import java.net.URI
-
-import com.amazonaws.services.s3.AmazonS3URI
-import weco.storage_service.bag_verifier.storage.{
-  Locatable,
-  LocateFailure,
-  LocationParsingError
-}
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import weco.storage_service.bag_verifier.storage.{Locatable, LocateFailure, LocationParsingError}
 
-import scala.util.{Failure, Success, Try}
+import java.net.URI
 
 object S3Locatable {
   implicit val s3UriLocatable
-    : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
+  : Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] =
     new Locatable[S3ObjectLocation, S3ObjectLocationPrefix, URI] {
       override def locate(uri: URI)(
         maybeRoot: Option[S3ObjectLocationPrefix]
       ): Either[LocateFailure[URI], S3ObjectLocation] =
-        Try { new AmazonS3URI(uri) } match {
-          case Success(s3Uri) =>
-            Right(
-              S3ObjectLocation(bucket = s3Uri.getBucket, key = s3Uri.getKey)
-            )
+        uri.getScheme match {
+          case "s3" => {
+            val bucket = uri.getAuthority
 
-          // We are not running in AWS - manually parse URL
-          case Failure(_) if uri.getHost == "localhost" =>
+            val path = uri.getPath
+            val key =
+              if (path.length <= 1) { // s3://bucket or s3://bucket/
+                ""
+              } else { // s3://bucket/key
+                // Remove the leading '/'.
+                uri.getPath.substring(1)
+              }
+
+            Right(S3ObjectLocation(bucket, key))
+          }
+
+          case "http" if uri.getHost == "localhost" =>
             uri.getPath.split("/").toList match {
               case _ :: head :: tail =>
                 Right(S3ObjectLocation(bucket = head, key = tail.mkString("/")))
@@ -40,14 +42,7 @@ object S3Locatable {
                 )
             }
 
-          // We are running in AWS - fail as usual.
-          case Failure(e) =>
-            Left(
-              LocationParsingError(
-                uri,
-                s"Failed to parse S3 URI: ${e.getMessage}"
-              )
-            )
+          case _ => Left(LocationParsingError(uri, "Failed to parse S3 URI"))
         }
     }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
@@ -2,12 +2,10 @@ package weco.storage_service.bag_verifier.storage.s3
 
 import java.net.URI
 
-import com.amazonaws.services.s3.AmazonS3
 import weco.storage_service.bag_verifier.storage.Resolvable
 import weco.storage.s3.S3ObjectLocation
 
-class S3Resolvable(implicit s3Client: AmazonS3)
-    extends Resolvable[S3ObjectLocation] {
+class S3Resolvable extends Resolvable[S3ObjectLocation] {
   override def resolve(location: S3ObjectLocation): URI =
-    s3Client.getUrl(location.bucket, location.key).toURI
+    new URI(s"s3://${location.bucket}/${location.key}")
 }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/s3/S3FixityCheckerTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixity/s3/S3FixityCheckerTest.scala
@@ -1,8 +1,5 @@
 package weco.storage_service.bag_verifier.fixity.s3
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
@@ -69,14 +66,6 @@ class S3FixityCheckerTest
     )
 
   implicit val context: Unit = ()
-
-  implicit val amazonS3: AmazonS3 =
-    AmazonS3ClientBuilder.standard()
-      .withCredentials(new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials("accessKey1", "verySecretKey1")))
-      .withPathStyleAccessEnabled(true)
-      .withEndpointConfiguration(new EndpointConfiguration("http://localhost:33333", "localhost"))
-      .build()
 
   implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/fixtures/BagVerifierFixtures.scala
@@ -1,8 +1,5 @@
 package weco.storage_service.bag_verifier.fixtures
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import weco.akka.fixtures.Akka
 import weco.fixtures.TestWith
@@ -31,14 +28,6 @@ trait BagVerifierFixtures
     with S3Fixtures
     with AzureFixtures
     with DynamoFixtures {
-  implicit val amazonS3: AmazonS3 =
-    AmazonS3ClientBuilder.standard()
-      .withCredentials(new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials("accessKey1", "verySecretKey1")))
-      .withPathStyleAccessEnabled(true)
-      .withEndpointConfiguration(new EndpointConfiguration("http://localhost:33333", "localhost"))
-      .build()
-
   def withStandaloneBagVerifierWorker[R](
     ingests: MemoryMessageSender = new MemoryMessageSender(),
     outgoing: MemoryMessageSender,

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/s3/S3BagVerifierTest.scala
@@ -1,8 +1,5 @@
 package weco.storage_service.bag_verifier.services.s3
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import weco.fixtures.TestWith
 import weco.storage_service.bag_verifier.models.{BagVerifyContext, ReplicatedBagVerifyContext, StandaloneBagVerifyContext}
 import weco.storage_service.bag_verifier.services._
@@ -55,14 +52,6 @@ trait S3BagVerifierTests[Verifier <: BagVerifier[
   override val bagBuilder
     : BagBuilder[S3ObjectLocation, S3ObjectLocationPrefix, Bucket] =
     new S3BagBuilder {}
-
-  implicit val amazonS3: AmazonS3 =
-    AmazonS3ClientBuilder.standard()
-      .withCredentials(new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials("accessKey1", "verySecretKey1")))
-      .withPathStyleAccessEnabled(true)
-      .withEndpointConfiguration(new EndpointConfiguration("http://localhost:33333", "localhost"))
-      .build()
 }
 
 class S3ReplicatedBagVerifierTest

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableTest.scala
@@ -1,17 +1,41 @@
 package weco.storage_service.bag_verifier.storage.s3
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.storage.s3.S3ObjectLocation
+import weco.storage_service.bag_verifier.storage.LocationParsingError
 
 import java.net.URI
 
-class S3LocatableTest extends AnyFunSpec with Matchers {
+class S3LocatableTest extends AnyFunSpec with Matchers with EitherValues {
+  it("decodes an S3 URI") {
+    val uri = new URI("s3://example-bucket/key.txt")
+
+    S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None) shouldBe Right(
+      S3ObjectLocation(bucket = "example-bucket", key = "key.txt")
+    )
+  }
+
   it("decodes a percent-encoded space in a URI") {
     val uri = new URI("s3://example-bucket/key%20with%20spaces.txt")
 
     S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None) shouldBe Right(
       S3ObjectLocation(bucket = "example-bucket", key = "key with spaces.txt")
     )
+  }
+
+  it("decodes an HTTP URL") {
+    val uri = new URI("http://localhost:33333/example-bucket/key.txt")
+
+    S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None) shouldBe Right(
+      S3ObjectLocation(bucket = "example-bucket", key = "key.txt")
+    )
+  }
+
+  it("fails if it cannot decode the URL") {
+    val uri = new URI("https://example.com/cat.jpg")
+
+    S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None).left.value shouldBe a[LocationParsingError[_]]
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val bag_verifier = setupProject(
   project,
   folder = "bag_verifier",
   localDependencies = Seq(common),
-  externalDependencies = ExternalDependencies.mockitoDependencies ++ ExternalDependencies.s3Dependencies,
+  externalDependencies = ExternalDependencies.mockitoDependencies,
   description =
     "Runs checks and rules against a bag: fixity information, file sizes, no missing files, and so on"
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,8 +93,6 @@ object ExternalDependencies {
     val mockito = "1.9.5"
     val scalatest = "3.2.3"
 
-    val aws1 = "1.11.504"
-
     // This should match the version of circe used in scala-json; see
     // https://github.com/wellcomecollection/scala-json/blob/master/project/Dependencies.scala
     val circeOptics = "0.13.0"
@@ -118,10 +116,6 @@ object ExternalDependencies {
 
   val mockitoDependencies: Seq[ModuleID] = Seq(
     "org.mockito" % "mockito-core" % versions.mockito % "test"
-  )
-
-  val s3Dependencies: Seq[ModuleID] = Seq(
-    "com.amazonaws" % "aws-java-sdk-s3" % versions.aws1
   )
 }
 


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4785

There were two classes I didn't migrate in the previous PR:

* S3Resolvable, which turns a storage location into a URI; this URI is in turn used in logs and debugging (e.g. `verified checksum of s3://bukkit/cat.jpg as 1234`)
* S3Locatable, which parses a URI as a location. I dumped all the URIs which get parsed during our tests to a file, then checked them all with the new code. Bits of it are copied from the old implementation.