### PR TITLE
Pin fluentbit container tags to the latest version

### DIFF
--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -89,7 +89,7 @@ module "stack_prod" {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
     # https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v3.13.1
-    container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
+    container_tag = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 
   nginx_container = {

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -88,6 +88,7 @@ module "stack_prod" {
   logging_container = {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
+    # https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v3.13.1
     container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -88,7 +88,7 @@ module "stack_prod" {
   logging_container = {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
-    container_tag      = "0fe256a94441ceff15629344d4225fbb64457fdd"
+    container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 
   nginx_container = {

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -93,7 +93,7 @@ module "stack_staging" {
   logging_container = {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
-    container_tag      = "0fe256a94441ceff15629344d4225fbb64457fdd"
+    container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 
   nginx_container = {

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -93,6 +93,7 @@ module "stack_staging" {
   logging_container = {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
+    # https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v3.13.1
     container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -94,7 +94,7 @@ module "stack_staging" {
     container_registry = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
     container_name     = "fluentbit"
     # https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v3.13.1
-    container_tag      = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
+    container_tag = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
   }
 
   nginx_container = {


### PR DESCRIPTION
I realised https://github.com/wellcomecollection/storage-service/pull/1056 was not actually doing anything because the storage service stacks have the container version specified