### PR TITLE
Allow posting storing arbitrarily large manifests in the bag tracker

### DIFF
--- a/bag_tracker/docker-compose.yml
+++ b/bag_tracker/docker-compose.yml
@@ -1,10 +1,11 @@
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
-s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
-  environment:
-    - "S3BACKEND=mem"
-  ports:
-    - "33333:8000"
+services:
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"
+  s3:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+    environment:
+      - "S3BACKEND=mem"
+    ports:
+      - "33333:8000"

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/BagTrackerApi.scala
@@ -50,9 +50,17 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
     pathPrefix("bags") {
       concat(
         // Store a new bag in the storage manifest dao.
-        post {
-          entity(as[StorageManifest]) { storageManifest =>
-            createBag(storageManifest)
+        //
+        // Note: we use withoutSizeLimit here to allow storing arbitraily large
+        // bags using this API.  The Akka docs discourage using this function,
+        // because it disables certain protections against Denial of Service attacks
+        // from attackers posting large payloads -- but since this is an internal
+        // API, it should be fine.
+        withoutSizeLimit {
+          post {
+            entity(as[StorageManifest]) { storageManifest =>
+              createBag(storageManifest)
+            }
           }
         },
         // We look for /versions at the end of the path: this means we should


### PR DESCRIPTION
For https://github.com/wellcomecollection/storage-service/issues/1071

## Context

After a bag has been successfully replicated to a verified in our permanent storage buckets, it goes to the "bag register", which creates a storage manifest (a JSON description of the bag). The bag register tries to put this manifest in the storage manifest database.

In front of the database is the "bag tracker", which mediates all access to the database. After the bag register has stored a new manifest, the manifest can be retrieved from the bags API.

```mermaid
flowchart TD
    P["… rest of pipeline …"] --> R[bag register]
    R -->|HTTP POST| T[bag tracker]
    A[bags API] -->|HTTP GET| T
    T --> D[(storage manifest<br/>database)]

    classDef externalNode fill:#e8e8e8,stroke:#8f8f8f
    class P,A,D externalNode

    classDef repoNode fill:#e01b2f3a,stroke:#e01b2f,stroke-width:2px
    class R,T repoNode
```

We're having issues in the register–tracker interaction; the HTTP POST is failing with a 413 Payload Too Large error. This is a protection against Denial-of-Service attacks, but this API is internal-only, so we don't need to worry about protecting this endpoint.