### PR TITLE
Allow verifying bags with a space in the key

### DIFF
--- a/bag_verifier/docker-compose.yml
+++ b/bag_verifier/docker-compose.yml
@@ -1,21 +1,23 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
-  environment:
-    - "S3BACKEND=mem"
-  ports:
-    - "33333:8000"
-azurite:
-  image: "mcr.microsoft.com/azure-storage/azurite"
-  ports:
-    - "10000:10000"
-  command: ["azurite", "--blobHost", "0.0.0.0"]
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
+version: "2.1"
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  s3:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+    environment:
+      - "S3BACKEND=mem"
+    ports:
+      - "33333:8000"
+  azurite:
+    image: "mcr.microsoft.com/azure-storage/azurite"
+    ports:
+      - "10000:10000"
+    command: ["azurite", "--blobHost", "0.0.0.0"]
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
@@ -7,7 +7,8 @@ import weco.storage.providers.s3.S3ObjectLocation
 
 class S3Resolvable extends Resolvable[S3ObjectLocation] {
   override def resolve(location: S3ObjectLocation): URI = {
-    val encodedKey = URLEncoder.encode(location.key, "UTF-8").replace("+", "%20")
+    val encodedKey =
+      URLEncoder.encode(location.key, "UTF-8").replace("+", "%20")
     new URI(s"s3://${location.bucket}/$encodedKey")
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
@@ -1,13 +1,13 @@
 package weco.storage_service.bag_verifier.storage.s3
 
-import java.net.URI
+import java.net.{URI, URLEncoder}
 
 import weco.storage_service.bag_verifier.storage.Resolvable
 import weco.storage.providers.s3.S3ObjectLocation
 
 class S3Resolvable extends Resolvable[S3ObjectLocation] {
   override def resolve(location: S3ObjectLocation): URI = {
-    val encodedKey = UriUtils.encodePath(location.key, "UTF-8")
+    val encodedKey = URLEncoder.encode(location.key, "UTF-8")
     new URI(s"s3://${location.bucket}/$encodedKey")
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
@@ -6,6 +6,8 @@ import weco.storage_service.bag_verifier.storage.Resolvable
 import weco.storage.providers.s3.S3ObjectLocation
 
 class S3Resolvable extends Resolvable[S3ObjectLocation] {
-  override def resolve(location: S3ObjectLocation): URI =
-    new URI(s"s3://${location.bucket}/${location.key}")
+  override def resolve(location: S3ObjectLocation): URI = {
+    val encodedKey = UriUtils.encodePath(location.key, "UTF-8")
+    new URI(s"s3://${location.bucket}/$encodedKey")
+  }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Resolvable.scala
@@ -7,7 +7,7 @@ import weco.storage.providers.s3.S3ObjectLocation
 
 class S3Resolvable extends Resolvable[S3ObjectLocation] {
   override def resolve(location: S3ObjectLocation): URI = {
-    val encodedKey = URLEncoder.encode(location.key, "UTF-8")
+    val encodedKey = URLEncoder.encode(location.key, "UTF-8").replace("+", "%20")
     new URI(s"s3://${location.bucket}/$encodedKey")
   }
 }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/services/BagVerifierTestCases.scala
@@ -276,6 +276,11 @@ trait BagVerifierTestCases[Verifier <: BagVerifier[
     val uppercaseBuilder = new BagBuilderImpl {
       override protected def createDigest(string: String): String =
         super.createDigest(string).toUpperCase
+
+      // This is to avoid having to deal with URI-encoding the spaces
+      // in the fetch.txt file.
+      override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+        0
     }
 
     withNamespace { implicit namespace =>

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
@@ -43,7 +43,7 @@ class S3LocatableResolvableTest extends AnyFunSpec with Matchers with EitherValu
 
   def assertLocationIsRoundtrippedCorrectly(location: S3ObjectLocation): Assertion = {
     val encodedUri = resolver.resolve(location)
-    val decodedLocation = S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None)
+    val decodedLocation = S3Locatable.s3UriLocatable.locate(encodedUri)(maybeRoot = None)
 
     decodedLocation.value shouldBe location
   }

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
@@ -1,0 +1,50 @@
+package weco.storage_service.bag_verifier.storage.s3
+
+import org.scalatest.{Assertion, EitherValues}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.storage.providers.s3.S3ObjectLocation
+
+import java.net.URI
+
+class S3LocatableResolvableTest extends AnyFunSpec with Matchers with EitherValues {
+  val resolver = new S3Resolvable()
+
+  it("round-trips an S3 location") {
+    assertLocationIsRoundtrippedCorrectly(
+      location = S3ObjectLocation(bucket = "example-bucket", key = "key.txt")
+    )
+  }
+
+  it("round-trips an S3 URI") {
+    assertUriIsRoundtrippedCorrectly(
+      uri = new URI("s3://example-bucket/key.txt")
+    )
+  }
+
+  it("round-trips an S3 location with a space in the key") {
+    assertLocationIsRoundtrippedCorrectly(
+      location = S3ObjectLocation(bucket = "example-bucket", key = "key with spaces.txt")
+    )
+  }
+
+  it("round-trips an S3 URI with spaces in the key") {
+    assertUriIsRoundtrippedCorrectly(
+      uri = new URI("s3://example-bucket/key%20with%20spaces.txt")
+    )
+  }
+
+  def assertUriIsRoundtrippedCorrectly(uri: URI): Assertion {
+    val encodedLocation = S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None)
+    val decodedUri = resolver.resolve(encodedLocation.value)
+
+    decodedUri shouldBe uri
+  }
+
+  def assertLocationIsRoundtrippedCorrectly(location: S3ObjectLocation): Assertion {
+    val encodedUri = resolver.resolve(location)
+    val decodedLocation = S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None)
+
+    decodedLocation.value shouldBe location
+  }
+}

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3LocatableResolvableTest.scala
@@ -34,14 +34,14 @@ class S3LocatableResolvableTest extends AnyFunSpec with Matchers with EitherValu
     )
   }
 
-  def assertUriIsRoundtrippedCorrectly(uri: URI): Assertion {
+  def assertUriIsRoundtrippedCorrectly(uri: URI): Assertion = {
     val encodedLocation = S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None)
     val decodedUri = resolver.resolve(encodedLocation.value)
 
     decodedUri shouldBe uri
   }
 
-  def assertLocationIsRoundtrippedCorrectly(location: S3ObjectLocation): Assertion {
+  def assertLocationIsRoundtrippedCorrectly(location: S3ObjectLocation): Assertion = {
     val encodedUri = resolver.resolve(location)
     val decodedLocation = S3Locatable.s3UriLocatable.locate(uri)(maybeRoot = None)
 

--- a/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3ResolvableTest.scala
+++ b/bag_verifier/src/test/scala/weco/storage_service/bag_verifier/storage/s3/S3ResolvableTest.scala
@@ -1,0 +1,25 @@
+package weco.storage_service.bag_verifier.storage.s3
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.storage.providers.s3.S3ObjectLocation
+
+import java.net.URI
+
+class S3ResolvableTest extends AnyFunSpec with Matchers {
+  val resolver = new S3Resolvable()
+
+  it("encodes an S3 URI") {
+    val location = S3ObjectLocation(bucket = "example-bucket", key = "key.txt")
+    val uri = resolver.resolve(location)
+
+    uri shouldBe new URI("s3://example-bucket/key.txt")
+  }
+
+  it("encodes a space in the URI") {
+    val location = S3ObjectLocation(bucket = "example-bucket", key = "key with spaces.txt")
+    val uri = resolver.resolve(location)
+
+    uri shouldBe new URI("s3://example-bucket/key%20with%20spaces.txt")
+  }
+}


### PR DESCRIPTION
This fixes a small regression; we need this bugfix for https://github.com/wellcomecollection/platform/issues/5708

We definitely used to support this, because we have Miro bags that have spaces in the external identifier/keys. You could make an argument that we shouldn't support this, but there's historical precedent for it and S3 is fine with it, so this patch adds support and proper test coverage for this case.

(In unsurprising news, the bug was in S3Resolvable, a class we thought was simple enough not to require tests – oops.)