### PR TITLE
New id constraints

### DIFF
--- a/bags_api/src/test/scala/weco/storage_service/bags_api/LookupBagApiTest.scala
+++ b/bags_api/src/test/scala/weco/storage_service/bags_api/LookupBagApiTest.scala
@@ -248,6 +248,10 @@ class LookupBagApiTest
       externalIdentifier = ExternalIdentifier("miro/A images")
     )
 
+    val manifestWithDot: StorageManifest = createStorageManifestWith(
+      externalIdentifier = ExternalIdentifier("PP/GRF/A.41")
+    )
+
     val lookupPaths = Table(
       ("manifest", "path"),
       // when the identifier is URL encoded
@@ -278,6 +282,10 @@ class LookupBagApiTest
       (
         manifestWithSlashAndSpace,
         s"${manifestWithSlashAndSpace.space}/miro%2FA%20images?version=${manifestWithSlashAndSpace.version}"
+      ),
+      (
+        manifestWithDot,
+        s"${manifestWithDot.space}/PP/GRF/A.41?version=${manifestWithDot.version}"
       )
     )
 

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -5,7 +5,7 @@ import weco.json.TypedString
 
 class ExternalIdentifier(val underlying: String)
     extends TypedString[ExternalIdentifier] {
-  private def m(message: String) = s"$message, was $underlying"
+  private def failureMessage(message: String) = s"$message, was $underlying"
 
   require(underlying.nonEmpty, "External identifier cannot be empty")
 
@@ -17,7 +17,7 @@ class ExternalIdentifier(val underlying: String)
   // ends with /versions.
   require(
     !underlying.endsWith("/versions"),
-    m("External identifier cannot end with /versions")
+    failureMessage("External identifier cannot end with /versions")
   )
 
   // When we store a bag in S3, we store different versions of it under the key
@@ -30,17 +30,17 @@ class ExternalIdentifier(val underlying: String)
   // identifier that includes anything that looks like /v1, /v2, etc.
   require(
     !underlying.matches("^.*/v\\d+$"),
-    m("External identifier cannot end with a version string")
+    failureMessage("External identifier cannot end with a version string")
   )
 
   require(
     !underlying.matches("^.*/v\\d+/.*$"),
-    m("External identifier cannot contain a version string")
+    failureMessage("External identifier cannot contain a version string")
   )
 
   require(
     !underlying.matches("^v\\d+/.*$"),
-    m("External identifier cannot start with a version string")
+    failureMessage("External identifier cannot start with a version string")
   )
 
   // If you put a slash at the end of the identifier (e.g. "b12345678/"), you'd
@@ -52,22 +52,22 @@ class ExternalIdentifier(val underlying: String)
   // the key, so prevent people from putting slashes at the beginning or end.
   require(
     !underlying.startsWith("/"),
-    m("External identifier cannot start with a slash")
+    failureMessage("External identifier cannot start with a slash")
   )
   require(
     !underlying.endsWith("/"),
-    m("External identifier cannot end with a slash")
+    failureMessage("External identifier cannot end with a slash")
   )
   require(
     !underlying.contains("//"),
-    m("External identifier cannot contain consecutive slashes")
+    failureMessage("External identifier cannot contain consecutive slashes")
   )
 
   // Consecutive spaces are difficult for a human to count.
   //
   require(
     !underlying.contains("  "),
-    m("External identifier cannot contain consecutive spaces")
+    failureMessage("External identifier cannot contain consecutive spaces")
   )
   // Starting and ending with an alphanumeric character.
   // Although some of the above rules would also be covered by these two,
@@ -76,12 +76,12 @@ class ExternalIdentifier(val underlying: String)
 
   require(
     underlying.head.isLetterOrDigit && underlying.head <= 'z',
-    m("External identifier must begin with a Basic Latin letter or digit")
+    failureMessage("External identifier must begin with a Basic Latin letter or digit")
   )
 
   require(
     underlying.last.isLetterOrDigit && underlying.last <= 'z',
-    m("External identifier must end with a Basic Latin letter or digit")
+    failureMessage("External identifier must end with a Basic Latin letter or digit")
   )
 
   // We're super careful about the characters we allow in external identifiers,
@@ -107,7 +107,7 @@ class ExternalIdentifier(val underlying: String)
 
   require(
     underlying.matches(s"^$characterClass+$$"),
-    m(s"External identifier can only contain characters in the class $characterClass")
+    failureMessage(s"External identifier can only contain characters in the class $characterClass")
   )
 }
 

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -5,6 +5,7 @@ import weco.json.TypedString
 
 class ExternalIdentifier(val underlying: String)
     extends TypedString[ExternalIdentifier] {
+
   require(underlying.nonEmpty, "External identifier cannot be empty")
 
   // When you want to see all versions of a bag in the bags API, you call
@@ -61,6 +62,27 @@ class ExternalIdentifier(val underlying: String)
     "External identifier cannot contain consecutive slashes"
   )
 
+  // Consecutive spaces are difficult for a human to count.
+  //
+  require(
+    !underlying.contains("  "),
+    "External identifier cannot contain consecutive spaces"
+  )
+  // Starting and ending with an alphanumeric character.
+  // Although some of the above rules would also be covered by these two,
+  // They are kept separate in order to provide a more informative
+  // error message
+
+  require(
+    underlying.head.isLetterOrDigit && underlying.head <= 'z',
+    "External identifier must begin with a Basic Latin letter or digit"
+  )
+
+  require(
+    underlying.last.isLetterOrDigit && underlying.last <= 'z',
+    "External identifier must end with a Basic Latin letter or digit"
+  )
+
   // We're super careful about the characters we allow in external identifiers,
   // because anything we use will end up in a URL for the bags API:
   //
@@ -78,7 +100,8 @@ class ExternalIdentifier(val underlying: String)
   //
   //    - We use spaces in the bags of Miro images, e.g. `B images`
   //
-  val regex: String = "^[a-zA-Z0-9_\\-/ ]+$"
+  val permittedNonAlphanumerics = "-_/ ."
+  val regex: String = s"^[${permittedNonAlphanumerics}a-zA-Z0-9]+$$"
   require(
     underlying.matches(regex),
     s"External identifier must match regex: $regex"

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -76,12 +76,14 @@ class ExternalIdentifier(val underlying: String)
 
   require(
     underlying.head.isLetterOrDigit && underlying.head <= 'z',
-    failureMessage("External identifier must begin with a Basic Latin letter or digit")
+    failureMessage(
+      "External identifier must begin with a Basic Latin letter or digit")
   )
 
   require(
     underlying.last.isLetterOrDigit && underlying.last <= 'z',
-    failureMessage("External identifier must end with a Basic Latin letter or digit")
+    failureMessage(
+      "External identifier must end with a Basic Latin letter or digit")
   )
 
   // We're super careful about the characters we allow in external identifiers,
@@ -107,7 +109,8 @@ class ExternalIdentifier(val underlying: String)
 
   require(
     underlying.matches(s"^$characterClass+$$"),
-    failureMessage(s"External identifier can only contain characters in the class $characterClass")
+    failureMessage(
+      s"External identifier can only contain characters in the class $characterClass")
   )
 }
 

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -7,7 +7,7 @@ class ExternalIdentifier(val underlying: String)
     extends TypedString[ExternalIdentifier] {
   private def m(message: String) = s"$message, was $underlying"
 
-  require(underlying.nonEmpty, m("External identifier cannot be empty"))
+  require(underlying.nonEmpty, "External identifier cannot be empty")
 
   // When you want to see all versions of a bag in the bags API, you call
   //

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -5,8 +5,9 @@ import weco.json.TypedString
 
 class ExternalIdentifier(val underlying: String)
     extends TypedString[ExternalIdentifier] {
+  private def m(message: String) = s"$message, was $underlying"
 
-  require(underlying.nonEmpty, "External identifier cannot be empty")
+  require(underlying.nonEmpty, m("External identifier cannot be empty"))
 
   // When you want to see all versions of a bag in the bags API, you call
   //
@@ -16,7 +17,7 @@ class ExternalIdentifier(val underlying: String)
   // ends with /versions.
   require(
     !underlying.endsWith("/versions"),
-    "External identifier cannot end with /versions"
+    m("External identifier cannot end with /versions")
   )
 
   // When we store a bag in S3, we store different versions of it under the key
@@ -29,17 +30,17 @@ class ExternalIdentifier(val underlying: String)
   // identifier that includes anything that looks like /v1, /v2, etc.
   require(
     !underlying.matches("^.*/v\\d+$"),
-    "External identifier cannot end with a version string"
+    m("External identifier cannot end with a version string")
   )
 
   require(
     !underlying.matches("^.*/v\\d+/.*$"),
-    "External identifier cannot contain a version string"
+    m("External identifier cannot contain a version string")
   )
 
   require(
     !underlying.matches("^v\\d+/.*$"),
-    "External identifier cannot start with a version string"
+    m("External identifier cannot start with a version string")
   )
 
   // If you put a slash at the end of the identifier (e.g. "b12345678/"), you'd
@@ -51,22 +52,22 @@ class ExternalIdentifier(val underlying: String)
   // the key, so prevent people from putting slashes at the beginning or end.
   require(
     !underlying.startsWith("/"),
-    "External identifier cannot start with a slash"
+    m("External identifier cannot start with a slash")
   )
   require(
     !underlying.endsWith("/"),
-    "External identifier cannot end with a slash"
+    m("External identifier cannot end with a slash")
   )
   require(
     !underlying.contains("//"),
-    "External identifier cannot contain consecutive slashes"
+    m("External identifier cannot contain consecutive slashes")
   )
 
   // Consecutive spaces are difficult for a human to count.
   //
   require(
     !underlying.contains("  "),
-    "External identifier cannot contain consecutive spaces"
+    m("External identifier cannot contain consecutive spaces")
   )
   // Starting and ending with an alphanumeric character.
   // Although some of the above rules would also be covered by these two,
@@ -75,12 +76,12 @@ class ExternalIdentifier(val underlying: String)
 
   require(
     underlying.head.isLetterOrDigit && underlying.head <= 'z',
-    "External identifier must begin with a Basic Latin letter or digit"
+    m("External identifier must begin with a Basic Latin letter or digit")
   )
 
   require(
     underlying.last.isLetterOrDigit && underlying.last <= 'z',
-    "External identifier must end with a Basic Latin letter or digit"
+    m("External identifier must end with a Basic Latin letter or digit")
   )
 
   // We're super careful about the characters we allow in external identifiers,
@@ -98,13 +99,15 @@ class ExternalIdentifier(val underlying: String)
   //    - We use forward slashes for CALM identifiers, e.g. `ARTCOO/B/14`
   //      These form a hierarchy in CALM, which we can replicate in the storage service.
   //
+  //    - Dots are also present in CALM identifiers, e.g. PP/GRF/A.41
+  //
   //    - We use spaces in the bags of Miro images, e.g. `B images`
   //
-  val permittedNonAlphanumerics = "-_/ ."
-  val regex: String = s"^[${permittedNonAlphanumerics}a-zA-Z0-9]+$$"
+  val characterClass = "[-_/ .a-zA-Z0-9]"
+
   require(
-    underlying.matches(regex),
-    s"External identifier must match regex: $regex"
+    underlying.matches(s"^$characterClass+$$"),
+    m(s"External identifier can only contain characters in the class $characterClass")
   )
 }
 

--- a/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ExternalIdentifierTest extends AnyFunSpec with Matchers {
   describe("permitted characters in identifiers") {
     info(
-      "A permissible identifier consists of alphanumeric characters (Basic Latin only)" +
+      "A permissible identifier consists of alphanumeric characters (Basic Latin only) " +
       "plus spaces, underscores, hyphens and forward slashes."
     )
 
@@ -45,19 +45,19 @@ class ExternalIdentifierTest extends AnyFunSpec with Matchers {
     it("blocks creating an external identifier with non-English letters") {
       assertFailsRequirement(
         identifier = "PP/MIÅ/1",
-        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+        message = "External identifier can only contain characters in the class [-_/ .a-zA-Z0-9]"
       )
     }
 
     it("blocks creating an external identifier with common URL substitutions for spaces") {
       assertFailsRequirement(
         identifier = "miro+space",
-        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+        message = "External identifier can only contain characters in the class [-_/ .a-zA-Z0-9]"
       )
 
       assertFailsRequirement(
         identifier = "miro%20space",
-        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+        message = "External identifier can only contain characters in the class [-_/ .a-zA-Z0-9]"
       )
     }
   }
@@ -170,6 +170,6 @@ class ExternalIdentifierTest extends AnyFunSpec with Matchers {
       ExternalIdentifier(identifier)
     }
 
-    err.getMessage shouldBe s"requirement failed: $message"
+    err.getMessage shouldBe s"requirement failed: $message, was $identifier"
   }
 }

--- a/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
@@ -5,84 +5,161 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class ExternalIdentifierTest extends AnyFunSpec with Matchers {
-  it("allows creating an external identifier") {
-    ExternalIdentifier("b12345678")
+  describe("permitted characters in identifiers") {
+    info(
+      "A permissible identifier consists of alphanumeric characters (Basic Latin only)" +
+      "plus spaces, underscores, hyphens and forward slashes."
+    )
+
+    it("allows creating an alphanumeric external identifier") {
+      ExternalIdentifier("b12345678")
+    }
+
+    it("allows creating an external identifier with spaces") {
+      ExternalIdentifier("PP MIA 1")
+    }
+
+    it("allows creating an external identifier with slashes") {
+      ExternalIdentifier("PP/MIA/1")
+    }
+
+    it("allows creating an external identifier with hyphens") {
+      ExternalIdentifier("PP-MIA-1")
+    }
+
+    it("allows creating an external identifier with underscores") {
+      ExternalIdentifier("PP_MIA_1")
+    }
+
+    it("allows creating an external identifier with dots") {
+      ExternalIdentifier("PP.MIA.1")
+    }
   }
 
-  it("allows creating an external identifier with slashes") {
-    ExternalIdentifier("PP/MIA/1")
+  describe("forbidden characters in identifiers") {
+    info(
+      "the set of characters that may cause an identifier to be rejected is vast, " +
+        "but here are a few examples that are likely to be encountered"
+    )
+
+    it("blocks creating an external identifier with non-English letters") {
+      assertFailsRequirement(
+        identifier = "PP/MIÅ/1",
+        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+      )
+    }
+
+    it("blocks creating an external identifier with common URL substitutions for spaces") {
+      assertFailsRequirement(
+        identifier = "miro+space",
+        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+      )
+
+      assertFailsRequirement(
+        identifier = "miro%20space",
+        message = "External identifier must match regex: ^[-_/ .a-zA-Z0-9]+$"
+      )
+    }
   }
 
-  it("blocks creating an external identifier with an empty string") {
-    assertFailsRequirement(
-      identifier = "",
-      message = "External identifier cannot be empty"
-    )
-  }
-
-  it("blocks creating an external identifier that begins or ends with a slash") {
-    assertFailsRequirement(
-      identifier = "PP/MIA/",
-      message = "External identifier cannot end with a slash"
+  describe("forbidden identifiers") {
+    info(
+      "In addition to the conforming to the permissible character set, " +
+      "there are some further restrictions on the nature of an identifier."
     )
 
-    assertFailsRequirement(
-      identifier = "/PP/MIA",
-      message = "External identifier cannot start with a slash"
-    )
-  }
+    it("blocks creating an external identifier with an empty string") {
+      assertFailsRequirement(
+        identifier = "",
+        message = "External identifier cannot be empty"
+      )
+    }
 
-  it("blocks creating an external identifier with consecutive slashes") {
-    assertFailsRequirement(
-      identifier = "PP//MIA",
-      message = "External identifier cannot contain consecutive slashes"
-    )
-  }
+    describe("start and end characters") {
+      info("the first and last character in an identifier must be alphanumeric")
 
-  it("blocks creating an external identifier that ends with /versions") {
-    assertFailsRequirement(
-      identifier = "b12345678/versions",
-      message = "External identifier cannot end with /versions"
-    )
-  }
+      it("blocks creating an external identifier with a leading non-alphanumeric character") {
+        assertFailsRequirement(
+          identifier = "-abc123",
+          message = "External identifier must begin with a Basic Latin letter or digit"
+        )
+      }
 
-  it("blocks creating an external identifier that contains a /vNN-like string") {
-    assertFailsRequirement(
-      identifier = "b12345678/v1",
-      message = "External identifier cannot end with a version string"
-    )
+      it("blocks creating an external identifier with a trailing non-alphanumeric character") {
+        assertFailsRequirement(
+          identifier = "abc123_",
+          message = "External identifier must end with a Basic Latin letter or digit"
+        )
+      }
+    }
 
-    assertFailsRequirement(
-      identifier = "b12345678/v0",
-      message = "External identifier cannot end with a version string"
-    )
+    describe("restrictions around slashes") {
+      it("blocks creating an external identifier that begins or ends with a slash") {
+        assertFailsRequirement(
+          identifier = "PP/MIA/",
+          message = "External identifier cannot end with a slash"
+        )
 
-    assertFailsRequirement(
-      identifier = "b12345678/v200",
-      message = "External identifier cannot end with a version string"
-    )
+        assertFailsRequirement(
+          identifier = "/PP/MIA",
+          message = "External identifier cannot start with a slash"
+        )
+      }
 
-    assertFailsRequirement(
-      identifier = "v2/a",
-      message = "External identifier cannot start with a version string"
-    )
+      it("blocks creating an external identifier with consecutive slashes") {
+        assertFailsRequirement(
+          identifier = "PP//MIA",
+          message = "External identifier cannot contain consecutive slashes"
+        )
+      }
+    }
 
-    assertFailsRequirement(
-      identifier = "b12345678/v2/a",
-      message = "External identifier cannot contain a version string"
-    )
-  }
+    describe("restrictions around spaces") {
+      it("blocks creating an external identifier with multiple consecutive spaces") {
+        assertFailsRequirement(
+          identifier = "PP  MIA",
+          message = "External identifier cannot contain consecutive spaces"
+        )
+      }
+    }
 
-  it("blocks creating an external identifier with unusual characters") {
-    assertFailsRequirement(
-      identifier = "miro+space",
-      message = "External identifier must match regex: ^[a-zA-Z0-9_\\-/ ]+$"
-    )
+    describe("restrictions to prevent ambiguous URLs") {
+      info("certain sequences are forbidden because they conflict with sequences used for versioning")
 
-    assertFailsRequirement(
-      identifier = "miro%20space",
-      message = "External identifier must match regex: ^[a-zA-Z0-9_\\-/ ]+$"
-    )
+      it("blocks creating an external identifier that ends with /versions") {
+        assertFailsRequirement(
+          identifier = "b12345678/versions",
+          message = "External identifier cannot end with /versions"
+        )
+      }
+
+      it("blocks creating an external identifier that contains a /vNN-like string") {
+        assertFailsRequirement(
+          identifier = "b12345678/v1",
+          message = "External identifier cannot end with a version string"
+        )
+
+        assertFailsRequirement(
+          identifier = "b12345678/v0",
+          message = "External identifier cannot end with a version string"
+        )
+
+        assertFailsRequirement(
+          identifier = "b12345678/v200",
+          message = "External identifier cannot end with a version string"
+        )
+
+        assertFailsRequirement(
+          identifier = "v2/a",
+          message = "External identifier cannot start with a version string"
+        )
+
+        assertFailsRequirement(
+          identifier = "b12345678/v2/a",
+          message = "External identifier cannot contain a version string"
+        )
+      }
+    }
   }
 
   private def assertFailsRequirement(

--- a/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/models/ExternalIdentifierTest.scala
@@ -69,9 +69,9 @@ class ExternalIdentifierTest extends AnyFunSpec with Matchers {
     )
 
     it("blocks creating an external identifier with an empty string") {
-      assertFailsRequirement(
+      assertFailsRequirementExactMessage(
         identifier = "",
-        message = "External identifier cannot be empty"
+        message = "requirement failed: External identifier cannot be empty"
       )
     }
 
@@ -166,10 +166,16 @@ class ExternalIdentifierTest extends AnyFunSpec with Matchers {
     identifier: String,
     message: String
   ): Assertion = {
+    assertFailsRequirementExactMessage(identifier, s"requirement failed: $message, was $identifier")
+  }
+
+  private def assertFailsRequirementExactMessage(
+    identifier: String,
+    message: String
+  ): Assertion = {
     val err = intercept[IllegalArgumentException] {
       ExternalIdentifier(identifier)
     }
-
-    err.getMessage shouldBe s"requirement failed: $message, was $identifier"
+    err.getMessage shouldBe message
   }
 }

--- a/common/src/test/scala/weco/storage_service/bagit/services/BagInfoParserTest.scala
+++ b/common/src/test/scala/weco/storage_service/bagit/services/BagInfoParserTest.scala
@@ -205,7 +205,7 @@ class BagInfoParserTest
       assertIsError(
         bagInfoString,
         errorMessage =
-          "Unable to parse External-Identifier in bag-info.txt: External identifier cannot start with a slash"
+          "Unable to parse External-Identifier in bag-info.txt: External identifier cannot start with a slash, was /a"
       )
     }
 

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
@@ -4,8 +4,15 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
-import weco.storage_service.ingests.models.{AmazonS3StorageProvider, Ingest, StorageProvider}
-import weco.storage_service.display.ingests.{RequestDisplayIngest, ResponseDisplayIngest}
+import weco.storage_service.ingests.models.{
+  AmazonS3StorageProvider,
+  Ingest,
+  StorageProvider
+}
+import weco.storage_service.display.ingests.{
+  RequestDisplayIngest,
+  ResponseDisplayIngest
+}
 import weco.storage_service.ingests_api.services.IngestCreator
 import weco.http.FutureDirectives
 import weco.http.models.{DisplayError, HTTPServerConfig}
@@ -61,12 +68,15 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
       invalidRequest(description)
     )
 
-  private def convertToBadRequestResponse(invalidArg: IllegalArgumentException): Future[Route] = {
+  private def convertToBadRequestResponse(
+    invalidArg: IllegalArgumentException): Future[Route] = {
     def originalMessage = invalidArg.getMessage
     def prefix = "requirement failed: External identifier"
-    def newMessage = if(originalMessage.startsWith(prefix))
-      "Invalid value at .bag.info.externalIdentifier:" + originalMessage.stripPrefix(prefix)
-    else originalMessage
+    def newMessage =
+      if (originalMessage.startsWith(prefix))
+        "Invalid value at .bag.info.externalIdentifier:" + originalMessage
+          .stripPrefix(prefix)
+      else originalMessage
 
     createBadRequestResponse(newMessage)
   }
@@ -78,10 +88,12 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
     Try {
       requestDisplayIngest.toIngest
     } match {
-      case Failure(exception) => exception match {
-        case invalidArg: IllegalArgumentException => convertToBadRequestResponse(invalidArg)
-        case otherException => throw otherException
-      }
+      case Failure(exception) =>
+        exception match {
+          case invalidArg: IllegalArgumentException =>
+            convertToBadRequestResponse(invalidArg)
+          case otherException => throw otherException
+        }
       case Success(ingest) => triggerIngestStarter(ingest)
     }
   }

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
@@ -91,7 +91,7 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
       case Failure(invalidArg: IllegalArgumentException) =>
         convertToBadRequestResponse(invalidArg)
       case Failure(exception) => throw exception
-      case Success(ingest) => triggerIngestStarter(ingest)
+      case Success(ingest)    => triggerIngestStarter(ingest)
     }
   }
 

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
@@ -88,12 +88,9 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
     Try {
       requestDisplayIngest.toIngest
     } match {
-      case Failure(exception) =>
-        exception match {
-          case invalidArg: IllegalArgumentException =>
-            convertToBadRequestResponse(invalidArg)
-          case otherException => throw otherException
-        }
+      case Failure(invalidArg: IllegalArgumentException) =>
+        convertToBadRequestResponse(invalidArg)
+      case Failure(exception) => throw exception
       case Success(ingest) => triggerIngestStarter(ingest)
     }
   }

--- a/ingests/ingests_api/src/test/scala/weco/storage_service/ingests_api/CreateIngestApiTest.scala
+++ b/ingests/ingests_api/src/test/scala/weco/storage_service/ingests_api/CreateIngestApiTest.scala
@@ -341,6 +341,18 @@ class CreateIngestApiTest
             "Invalid value at .bag.info.externalIdentifier: must not be empty."
         )
       }
+
+      it("if the info.externalIdentifier field is invalid") {
+        val badJson = root.bag.info.obj.modify {
+          _.add("externalIdentifier", Json.fromString("-øåæ//v99/versions"))
+        }
+
+        assertCatchesMalformedRequest(
+          badJson(json).noSpaces,
+          expectedMessage =
+            "Invalid value at .bag.info.externalIdentifier: cannot end with /versions, was -øåæ//v99/versions"
+        )
+      }
     }
 
     describe("problems with the sourceLocation") {


### PR DESCRIPTION
See: https://github.com/wellcomecollection/storage-service/issues/1037

This adds the ability to use identifiers containing dots, and also tightens the rules around spaces and start/end characters.