### PR TITLE
log into ECR with get-login-password

### DIFF
--- a/builds/publish_sbt_image_to_ecr.sh
+++ b/builds/publish_sbt_image_to_ecr.sh
@@ -21,7 +21,8 @@ EOF
 set -o errexit
 set -o nounset
 
-ECR_REGISTRY="975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
+REGISTRY_BASE="975596993436.dkr.ecr.eu-west-1.amazonaws.com"
+ECR_REGISTRY="$REGISTRY_BASE/uk.ac.wellcome"
 
 if (( $# == 2))
 then
@@ -34,7 +35,10 @@ fi
 
 echo "*** Publishing Docker image to ECR"
 
-eval $(aws ecr get-login --no-include-email)
+aws ecr get-login-password \
+| docker login \
+    --username AWS \
+    --password-stdin $REGISTRY_BASE
 
 docker tag "$PROJECT_NAME:$IMAGE_TAG" "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"
 docker push "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"


### PR DESCRIPTION
## What does this change?

This fixes another example of the problem found in https://github.com/wellcomecollection/archivematica-infrastructure/pull/141

See https://buildkite.com/wellcomecollection/storage-service/builds/1691

## How to test

Open a PR and see whether the PR checks pass.

## How can we measure success?

We can build the storage service again.

## Have we considered potential risks?

This has been applied successfully in other project. We can also check it works properly before even merging the change. The build here also signs into ecr public so we might see the problem pop up in another place too.
