### PR TITLE
Add default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,10 @@
-# To ensure only properly audited changes are run in CI, we require reviews
-# from @wellcomecollection/buildkite-admin when updating pipeline config
+# These are default codeowners, later rules take precedence
+*	@wellcomecollection/scala-reviewers
 
-/.buildkite/    @wellcomecollection/buildkite-admin
-/builds/      @wellcomecollection/buildkite-admin
+# To ensure only properly audited changes are run in CI, we require reviews
+# from @wellcomecollection/developers when updating pipeline config
+/CODEOWNERS	@wellcomecollection/developers
+/.buildkite/    @wellcomecollection/developers
+
+# Allow reviews from all developers on infrastructure changes
+/terraform/    @wellcomecollection/developers


### PR DESCRIPTION
## What does this change?

Removes the no-longer existing buildkite-admins group and refers to developers in buildkite directories to prevent permissions leaking into CI. Also adds a default code owner (scala-reviewers) so they automatically get added to PRs as reviewers and they are the people most likely to review them properly.

Follows @rcantin-w's work on:

- https://github.com/wellcomecollection/catalogue-pipeline/pull/2534
- https://github.com/wellcomecollection/catalogue-api/pull/748

## How to test

- PRs gets created and reviewers are automatically added.

## How can we measure success?

Better visibility of pull requests that need reviews.