### PR TITLE
Use Common Runtime Libraries in S3TransferManager

### DIFF
--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -1,17 +1,19 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
-  environment:
-    - "S3BACKEND=mem"
-  ports:
-    - "33333:8000"
-azurite:
-  image: "mcr.microsoft.com/azure-storage/azurite"
-  ports:
-    - "10000:10000"
-  command: ["azurite", "--blobHost", "0.0.0.0"]
+version: "3.3"
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  s3:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+    environment:
+      - "S3BACKEND=mem"
+    ports:
+      - "33333:8000"
+  azurite:
+    image: "mcr.microsoft.com/azure-storage/azurite"
+    ports:
+      - "10000:10000"
+    command: ["azurite", "--blobHost", "0.0.0.0"]

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
@@ -3,7 +3,7 @@ package weco.storage_service.bag_replicator
 import akka.actor.ActorSystem
 import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
 import com.typesafe.config.Config
-import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Client}
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.transfer.s3.S3TransferManager
@@ -24,16 +24,8 @@ import weco.storage_service.bag_replicator.replicator.azure.AzureReplicator
 import weco.storage_service.bag_replicator.replicator.models.ReplicationSummary
 import weco.storage_service.bag_replicator.replicator.s3.S3Replicator
 import weco.storage_service.bag_replicator.services.BagReplicatorWorker
-import weco.storage_service.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
-import weco.storage_service.ingests.models.{
-  AmazonS3StorageProvider,
-  AzureBlobStorageProvider,
-  StorageProvider
-}
+import weco.storage_service.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import weco.storage_service.ingests.models.{AmazonS3StorageProvider, AzureBlobStorageProvider, StorageProvider}
 import weco.storage_service.storage.models.IngestStepResult
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.EnrichConfig._
@@ -52,8 +44,13 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val s3Client: S3Client =
       S3Client.builder().build()
+
+    implicit val s3AsyncClient: S3AsyncClient =
+      S3AsyncClient.crtBuilder().build()
+
     implicit val s3TransferManager: S3TransferManager =
-      S3TransferManager.builder().build()
+      S3TransferManager.builder().s3Client(s3AsyncClient).build()
+
     implicit val s3Presigner: S3Presigner =
       S3Presigner.builder().build()
 

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
@@ -24,8 +24,16 @@ import weco.storage_service.bag_replicator.replicator.azure.AzureReplicator
 import weco.storage_service.bag_replicator.replicator.models.ReplicationSummary
 import weco.storage_service.bag_replicator.replicator.s3.S3Replicator
 import weco.storage_service.bag_replicator.services.BagReplicatorWorker
-import weco.storage_service.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
-import weco.storage_service.ingests.models.{AmazonS3StorageProvider, AzureBlobStorageProvider, StorageProvider}
+import weco.storage_service.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
+import weco.storage_service.ingests.models.{
+  AmazonS3StorageProvider,
+  AzureBlobStorageProvider,
+  StorageProvider
+}
 import weco.storage_service.storage.models.IngestStepResult
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.EnrichConfig._


### PR DESCRIPTION
## What does this change?

This change attempts to make use of the [Common Runtime Libraries](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html) for the AWS SDK intended to improve performance. 

We [include them as a dependency](https://github.com/wellcomecollection/storage-service/blob/main/project/Dependencies.scala#L110) but do not use them in the `S3TransferManager` where we do large transfers. The [documentation describes how to do this](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/transfer/s3/S3TransferManager.html).

The intention is to improve the performance of the replicators which are currently showing issues transferring large files to S3.

## How to test

- [x] Do the tests pass?
- [ ] When deployed do bags with large files get replicated succesfully?

## How can we measure success?

Improved performance, less failures.

## Have we considered potential risks?

This will impact replication performance, hopefully only positively but there are could be negative impacts.
