### PR TITLE
Update links to ingest inspector from daily reporter lambda

### DIFF
--- a/.github/workflows/deploy-daily-reporter.yml
+++ b/.github/workflows/deploy-daily-reporter.yml
@@ -1,0 +1,26 @@
+name: Deploy Daily Reporter
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+
+jobs:
+  deploy_ingest_inspector:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.DEPLOY_INGEST_INSPECTOR_GHA_ROLE_ARN }}
+      - name: Deploy Daily Reporter
+        run: |
+          pip3 install -r ./builds/requirements.txt
+          python3 ./builds/publish_lambda_zip.py monitoring/daily_reporter \
+              --bucket=wellcomecollection-storage-infra \
+              --key=lambdas/monitoring/daily_reporter.zip
+          ./builds/deploy_lambda_zip.sh monitoring/daily_reporter daily_reporter

--- a/monitoring/daily_reporter/src/slack.py
+++ b/monitoring/daily_reporter/src/slack.py
@@ -29,7 +29,7 @@ def _get_slack_message(label, ingests):
         if ingests.get(status, []):
             result += "\n" + status.title() + ":"
             for i in ingests[status][:15]:
-                result += f"\n- <https://ingest-inspector.wellcomecollection.org/ingests/{i['id']}|`{i['id']}`> – {i['space']}/{i['externalIdentifier']}"
+                result += f"\n- <https://ingest-inspector.wellcomecollection.org/?ingestId={i['id']}|`{i['id']}`> – {i['space']}/{i['externalIdentifier']}"
                 if i["version"]:
                     result += "/" + i["version"]
 

--- a/monitoring/ingest_inspector/README.md
+++ b/monitoring/ingest_inspector/README.md
@@ -22,8 +22,6 @@ The ingests data isn't sensitive, so we don't need authentication in front of it
 It mostly contains user-facing messages from the storage service, or an identifier used by one of Wellcome's catalogue databases.
 The user-facing messages can be seen in the publicly-available source code, and the identifiers don't encode any sensitive information.
 
-
-
 ## Features
 
 The app has a number of features designed to make it as easy as possible for somebody to get the data they need.
@@ -128,8 +126,6 @@ The app has a number of features designed to make it as easy as possible for som
 
     ![A line "callback status:" pending highlighted in blue.](screenshots/pending_callback.png)
 
-
-
 ## Usage
 
 You can use the app by visiting <https://ingest-inspector.wellcomecollection.org/>.
@@ -166,4 +162,3 @@ the `ingest_inspector/frontend` directory and run:
 ```shell
 AWS_PROFILE=storage-developer sh deploy.sh
 ```
-


### PR DESCRIPTION
## What does this change?

This updates the daily reporter lambda that provides summaries of storage service activities in Slack to use the correct URL pattern for the new ingest inspector. In addition this PR adds a GitHub action workflow to deploy the daily reporter lambda as this previously was done manually.

## How to test

- [ ] Manually trigger the new workflow and invoke the updated lambda from the AWS console, does the updated link appear?

## How can we measure success?

The daily reporter lambda provides working links to the ingest inspector enabling quicker debugging and future updates to the daily-reporter are deployed automatically on merge to main.

## Have we considered potential risks?

This change should not impact any critical storage service processes and can be safely reverted if it does not behave as expected.
