### PR TITLE
set up new autoformat workflow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,7 @@
 steps:
   - command: |
-      ./builds/run_formatting.sh
-      .buildkite/scripts/push_autoformatting_changes.sh
       ./builds/run_linting.sh
-    label: "autoformat"
+    label: "linting"
     agents:
       queue: "scala"
 

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,13 @@
+# Runs auto-formatting script on push to any branch
+name: "Scala auto-formatting"
+
+on: push
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  autoformat:
+    uses: wellcomecollection/.github/.github/workflows/scala_formatting.yml@main
+    secrets: inherit

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -48,6 +48,9 @@ else
 fi
 
 docker run --tty --rm \
+  -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
+  -e AWS_SECRET_KEY="${AWS_SECRET_KEY:-}" \
+  -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \


### PR DESCRIPTION
## What does this change?

Use this [workflow](https://github.com/wellcomecollection/.github/blob/main/.github/workflows/scala_formatting.yml) to run formatting on push

## How to test

Pushing to any branch in the repo and watch the format workflow run
Add a badly formatted file in the commit so as to check the "push formatting changes" step as well

## How can we measure success?

The formatting workflow run successfully and is able to push a formatting change commit to the branch

## Have we considered potential risks?

This has been tested in [catalogue-api](https://github.com/wellcomecollection/catalogue-api/pull/804/files)
It runs on feature branches so we can test and validate without affecting the main branch or production systems.

