### PR TITLE
Remove auth for dependency graph action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -16,8 +16,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.S3_SCALA_RELEASES_READ_ROLE_ARN }}
       - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
## What does this change?

The dependency graph action used to update dependabot with Scala deps, no longer needs to authenticate itself in AWS as packages are pulled from Sonatype, not S3. 

The role it used has been deleted: https://github.com/wellcomecollection/aws-account-infrastructure/pull/38, so this action now fails.

Removing the auth step should fix it.

## How to test

- [ ] Merge this change, does the running run successfully?

## How can we measure success?

Green ticks on our builds are less confusing than a partial failure indicating that not everything has succeeded (this is also a non-critical error so more confusing).

## Have we considered potential risks?

Risks should be minimal, this does not impact end-users.
