### PR TITLE
Bump sbt to 1.10.10 and derive Docker image tag from build.properties

### DIFF
--- a/builds/run_formatting.sh
+++ b/builds/run_formatting.sh
@@ -10,7 +10,7 @@ ROOT=$(git rev-parse --show-toplevel)
 docker run --tty --rm \
 	--volume "$ROOT:/repo" \
 	--workdir /repo \
-	"$ECR_REGISTRY/terraform:light" fmt -recursive
+	"$ECR_REGISTRY/wellcome/terraform:light" fmt -recursive
 
 ./builds/run_sbt_task_in_docker.sh "scalafmt"
 

--- a/builds/run_formatting.sh
+++ b/builds/run_formatting.sh
@@ -10,12 +10,12 @@ ROOT=$(git rev-parse --show-toplevel)
 docker run --tty --rm \
 	--volume "$ROOT:/repo" \
 	--workdir /repo \
-	"public.ecr.aws/hashicorp/terraform:light" fmt -recursive
+	"$ECR_REGISTRY/terraform:light" fmt -recursive
 
 ./builds/run_sbt_task_in_docker.sh "scalafmt"
 
 docker run --tty --rm \
 	--volume "$ROOT:/repo" \
-  --workdir /repo \
-	"$ECR_REGISTRY/pyfound/black" \
-  black --exclude ".lambda_zips/|.terraform/|target/" .
+  	--workdir /repo \
+	"$ECR_REGISTRY/pyfound/black" black \
+  	--exclude ".lambda_zips/|.terraform/|target/" .

--- a/builds/run_formatting.sh
+++ b/builds/run_formatting.sh
@@ -10,12 +10,12 @@ ROOT=$(git rev-parse --show-toplevel)
 docker run --tty --rm \
 	--volume "$ROOT:/repo" \
 	--workdir /repo \
-	"$ECR_REGISTRY/wellcome/terraform:light" fmt -recursive
+	"public.ecr.aws/hashicorp/terraform:light" fmt -recursive
 
 ./builds/run_sbt_task_in_docker.sh "scalafmt"
 
 docker run --tty --rm \
 	--volume "$ROOT:/repo" \
-  	--workdir /repo \
-	"$ECR_REGISTRY/pyfound/black" black \
-  	--exclude ".lambda_zips/|.terraform/|target/" .
+  --workdir /repo \
+	"$ECR_REGISTRY/pyfound/black" \
+  black --exclude ".lambda_zips/|.terraform/|target/" .

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -59,4 +59,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.2" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.7" "$@"

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -59,4 +59,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:no_alpine" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.2" "$@"

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -35,6 +35,7 @@ set -o nounset
 ECR_REGISTRY="760097843905.dkr.ecr.eu-west-1.amazonaws.com"
 
 ROOT=$(git rev-parse --show-toplevel)
+SBT_VERSION=$(sed -n 's/^sbt.version=//p' "$ROOT/project/build.properties")
 
 # Coursier cache location is platform-dependent
 # https://get-coursier.io/docs/cache.html#default-location
@@ -59,4 +60,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.7" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:$SBT_VERSION" "$@"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.10.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.10.10

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.12.11

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.11
+sbt.version=1.10.2


### PR DESCRIPTION
## What does this change?

Bumps sbt from 1.10.2 to 1.10.10 and updates `run_sbt_task_in_docker.sh` to derive the Docker image tag from `project/build.properties` rather than hardcoding it.

This means:
- The sbt version is maintained in a single place (`project/build.properties`)
- The `sbt_wrapper` Docker image tag automatically matches, avoiding the need to download a different sbt version at runtime (which was causing rate-limiting failures in CI)

Depends on https://github.com/wellcomecollection/platform-infrastructure/pull/489 which makes the `sbt_wrapper` image version-configurable.

See also: https://github.com/wellcomecollection/catalogue-pipeline/pull/3368

## How to test

- CI should pass once the `sbt_wrapper:1.10.10` image is available (published via platform-infrastructure#489)
- Locally: `./builds/run_sbt_task_in_docker.sh stage` should succeed without downloading sbt at startup

## How can we measure success?

- CI builds no longer fail with `[launcher] could not retrieve sbt` errors
- sbt startup in CI is faster (no bootstrap download)

## Have we considered potential risks?

- Low risk — this is a patch version bump within the same minor series (1.10.x)
- Requires the matching `sbt_wrapper` Docker image to be published first (platform-infrastructure#489)
