### PR TITLE
Use AWS CodeArtifact Maven mirror for dependency resolution in CI

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,8 @@
+version = "3.7.17"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]
-version=3.7.13
+runner.dialect = scala212
+
+newlines.implicitParamListModifierPrefer = before
+newlines.beforeCurlyLambdaParams = multiline

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]
+version=3.7.13

--- a/bag_register/src/main/scala/weco/storage_service/bag_register/Main.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/Main.scala
@@ -25,46 +25,47 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client =
-      S3Client.builder().build()
+      implicit val s3Client: S3Client =
+        S3Client.builder().build()
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val operationName = OperationNameBuilder.getName(config)
+      val operationName = OperationNameBuilder.getName(config)
 
-    val ingestUpdater = IngestUpdaterBuilder.build(config, operationName)
+      val ingestUpdater = IngestUpdaterBuilder.build(config, operationName)
 
-    val storageManifestService = new S3StorageManifestService()
+      val storageManifestService = new S3StorageManifestService()
 
-    val register = new Register(
-      bagReader = new S3BagReader(),
-      bagTrackerClient = new PekkoBagTrackerClient(
-        trackerHost = config.requireString("bags.tracker.host")
-      ),
-      storageManifestService = storageManifestService
-    )
+      val register = new Register(
+        bagReader = new S3BagReader(),
+        bagTrackerClient = new PekkoBagTrackerClient(
+          trackerHost = config.requireString("bags.tracker.host")
+        ),
+        storageManifestService = storageManifestService
+      )
 
-    val registrationNotifications = SNSBuilder.buildSNSMessageSender(
-      config,
-      namespace = "registration-notifications",
-      subject = "Sent by the bag register"
-    )
+      val registrationNotifications = SNSBuilder.buildSNSMessageSender(
+        config,
+        namespace = "registration-notifications",
+        subject = "Sent by the bag register"
+      )
 
-    new BagRegisterWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      ingestUpdater = ingestUpdater,
-      registrationNotifications = registrationNotifications,
-      register = register
-    )
+      new BagRegisterWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        ingestUpdater = ingestUpdater,
+        registrationNotifications = registrationNotifications,
+        register = register
+      )
   }
 }

--- a/bag_register/src/main/scala/weco/storage_service/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/services/BagRegisterWorker.scala
@@ -27,8 +27,7 @@ class BagRegisterWorker[IngestDestination, NotificationDestination](
   registrationNotifications: MessageSender[NotificationDestination],
   register: Register
 )(
-  implicit
-  val mc: Metrics[Future],
+  implicit val mc: Metrics[Future],
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[KnownReplicasPayload]

--- a/bag_register/src/main/scala/weco/storage_service/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/services/Register.scala
@@ -44,7 +44,9 @@ class Register(
     )
 
     val result: Future[IngestStepResult[RegistrationSummary]] = for {
-      bag <- bagReader.get(location.prefix.asInstanceOf[S3ObjectLocationPrefix]) match {
+      bag <- bagReader.get(
+        location.prefix.asInstanceOf[S3ObjectLocationPrefix]
+      ) match {
         case Right(value) => Future(value)
         case Left(err) =>
           Future.failed(

--- a/bag_register/src/main/scala/weco/storage_service/bag_register/services/S3StorageManifestService.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/services/S3StorageManifestService.scala
@@ -108,20 +108,19 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
     location match {
       case s3Location: S3ObjectLocation     => s3Location.key
       case azureLocation: AzureBlobLocation => azureLocation.name
-      case _                                => throw new Throwable(s"Unsupported location: $location")
+      case _ => throw new Throwable(s"Unsupported location: $location")
     }
 
   /** The replicator writes bags inside a bucket to paths of the form
     *
-    *     /{storageSpace}/{externalIdentifier}/v{version}
+    * /{storageSpace}/{externalIdentifier}/v{version}
     *
-    * All the versions of a bag should follow this convention, so if we
-    * strip off the /:version prefix we'll find the root of all bags
-    * with this (storage space, external ID) pair.
+    * All the versions of a bag should follow this convention, so if we strip
+    * off the /:version prefix we'll find the root of all bags with this
+    * (storage space, external ID) pair.
     *
-    * TODO: It would be better if we passed a structured object out of
-    * the replicator.
-    *
+    * TODO: It would be better if we passed a structured object out of the
+    * replicator.
     */
   private def getBagRoot(
     replicaRoot: Prefix[_ <: Location],
@@ -161,9 +160,12 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
     tagManifest: TagManifest
   ): Try[ChecksumAlgorithm] =
     ChecksumAlgorithms.algorithms
-      .find { algorithm =>
-        payloadManifest.algorithms.contains(algorithm) && tagManifest.algorithms
-          .contains(algorithm)
+      .find {
+        algorithm =>
+          payloadManifest.algorithms.contains(
+            algorithm
+          ) && tagManifest.algorithms
+            .contains(algorithm)
       } match {
       case Some(algorithm) => Success(algorithm)
       case None =>
@@ -200,8 +202,7 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
     *
     * The map contains data
     *
-    *   (bag path) -> (location, size if known)
-    *
+    * (bag path) -> (location, size if known)
     */
   private def createPathLocationMap(
     matchedLocations: Seq[MatchedLocation],
@@ -209,11 +210,12 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
     version: BagVersion
   ): Try[Map[BagPath, (S3ObjectLocation, Option[Long])]] =
     Try {
-      matchedLocations.map { matchedLoc =>
-        (
-          matchedLoc.bagPath,
-          getSizeAndLocation(matchedLoc, bagRoot, version)
-        )
+      matchedLocations.map {
+        matchedLoc =>
+          (
+            matchedLoc.bagPath,
+            getSizeAndLocation(matchedLoc, bagRoot, version)
+          )
       }.toMap
     }
 
@@ -290,8 +292,9 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
       )
       .map {
         // Remember to prefix all the entries with a version string
-        _.map { f =>
-          f.copy(path = s"$version/${f.path}")
+        _.map {
+          f =>
+            f.copy(path = s"$version/${f.path}")
         }
       }
 
@@ -301,13 +304,14 @@ class S3StorageManifestService(implicit s3Client: S3Client) extends Logging {
   ): Try[Seq[SecondaryStorageLocation]] = {
     val rootReplicas =
       replicas
-        .map { loc =>
-          getBagRoot(replicaRoot = loc.prefix, version = version)
-            .map { SecondaryStorageLocation(_) }
+        .map {
+          loc =>
+            getBagRoot(replicaRoot = loc.prefix, version = version)
+              .map { SecondaryStorageLocation(_) }
         }
 
     val successes = rootReplicas.collect { case Success(loc) => loc }
-    val failures = rootReplicas.collect { case Failure(err)  => err }
+    val failures = rootReplicas.collect { case Failure(err) => err }
 
     if (failures.isEmpty) {
       Success(successes)

--- a/bag_register/src/main/scala/weco/storage_service/bag_register/services/TagManifestFileFinder.scala
+++ b/bag_register/src/main/scala/weco/storage_service/bag_register/services/TagManifestFileFinder.scala
@@ -13,8 +13,8 @@ import scala.util.{Failure, Success, Try}
   * any of the other manifests in the bag, but we still want to include them in
   * the storage manifest created by the storage service.
   *
-  * This class creates the `StorageManifestFile` entries for BagIt tag manifest files.
-  *
+  * This class creates the `StorageManifestFile` entries for BagIt tag manifest
+  * files.
   */
 class TagManifestFileFinder[BagLocation <: Location](
   implicit streamReader: Readable[BagLocation, InputStreamWithLength]

--- a/bag_replicator/src/main/scala/weco/storage/transfer/PrefixTransfer.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/PrefixTransfer.scala
@@ -19,37 +19,39 @@ trait PrefixTransfer[SrcPrefix, SrcLocation, DstPrefix, DstLocation]
   private def copyPrefix(
     iterator: Iterable[SrcLocation],
     srcPrefix: SrcPrefix,
-    dstPrefix: DstPrefix,
+    dstPrefix: DstPrefix
   ): Either[PrefixTransferIncomplete, PrefixTransferSuccess] = {
     var successes = 0
     var failures = 0
 
     iterator
       .grouped(10)
-      .foreach { locations =>
-        val results: ParIterable[(SrcLocation, transfer.TransferEither)] =
-          locations.par.map { srcLocation =>
-            (
-              srcLocation,
-              transfer.transfer(
-                src = srcLocation,
-                dst = buildDstLocation(
-                  srcPrefix = srcPrefix,
-                  dstPrefix = dstPrefix,
-                  srcLocation = srcLocation
+      .foreach {
+        locations =>
+          val results: ParIterable[(SrcLocation, transfer.TransferEither)] =
+            locations.par.map {
+              srcLocation =>
+                (
+                  srcLocation,
+                  transfer.transfer(
+                    src = srcLocation,
+                    dst = buildDstLocation(
+                      srcPrefix = srcPrefix,
+                      dstPrefix = dstPrefix,
+                      srcLocation = srcLocation
+                    )
+                  )
                 )
-              )
-            )
-          }
+            }
 
-        results.foreach {
-          case (srcLocation, Right(_)) =>
-            debug(s"Successfully copied $srcLocation to $dstPrefix")
-            successes += 1
-          case (srcLocation, Left(err)) =>
-            warn(s"Error copying $srcLocation to $dstPrefix: $err")
-            failures += 1
-        }
+          results.foreach {
+            case (srcLocation, Right(_)) =>
+              debug(s"Successfully copied $srcLocation to $dstPrefix")
+              successes += 1
+            case (srcLocation, Left(err)) =>
+              warn(s"Error copying $srcLocation to $dstPrefix: $err")
+              failures += 1
+          }
       }
 
     Either.cond(

--- a/bag_replicator/src/main/scala/weco/storage/transfer/PrefixTransferResult.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/PrefixTransferResult.scala
@@ -9,8 +9,9 @@ sealed trait PrefixTransferFailure extends PrefixTransferResult
 case class PrefixTransferIncomplete(failures: Int, successes: Int)
     extends PrefixTransferFailure
 
-case class PrefixTransferListingFailure[Prefix](prefix: Prefix,
-                                                e: ListingFailure[Prefix])
-    extends PrefixTransferFailure
+case class PrefixTransferListingFailure[Prefix](
+  prefix: Prefix,
+  e: ListingFailure[Prefix]
+) extends PrefixTransferFailure
 
 case class PrefixTransferSuccess(successes: Int) extends PrefixTransferResult

--- a/bag_replicator/src/main/scala/weco/storage/transfer/TransferResult.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/TransferResult.scala
@@ -10,31 +10,33 @@ sealed trait TransferFailure[SrcLocation, DstLocation]
   val e: Throwable
 }
 
-case class TransferSourceFailure[SrcLocation, DstLocation](src: SrcLocation,
-                                                           dst: DstLocation,
-                                                           e: Throwable =
-                                                             new Error())
-    extends TransferFailure[SrcLocation, DstLocation]
+case class TransferSourceFailure[SrcLocation, DstLocation](
+  src: SrcLocation,
+  dst: DstLocation,
+  e: Throwable = new Error()
+) extends TransferFailure[SrcLocation, DstLocation]
 
 case class TransferDestinationFailure[SrcLocation, DstLocation](
   src: SrcLocation,
   dst: DstLocation,
-  e: Throwable = new Error())
-    extends TransferFailure[SrcLocation, DstLocation]
+  e: Throwable = new Error()
+) extends TransferFailure[SrcLocation, DstLocation]
 
-case class TransferOverwriteFailure[SrcLocation, DstLocation](src: SrcLocation,
-                                                              dst: DstLocation,
-                                                              e: Throwable =
-                                                                new Error())
-    extends TransferFailure[SrcLocation, DstLocation]
+case class TransferOverwriteFailure[SrcLocation, DstLocation](
+  src: SrcLocation,
+  dst: DstLocation,
+  e: Throwable = new Error()
+) extends TransferFailure[SrcLocation, DstLocation]
 
 sealed trait TransferSuccess[SrcLocation, DstLocation]
     extends TransferResult[SrcLocation, DstLocation]
 
-case class TransferNoOp[SrcLocation, DstLocation](src: SrcLocation,
-                                                  dst: DstLocation)
-    extends TransferSuccess[SrcLocation, DstLocation]
+case class TransferNoOp[SrcLocation, DstLocation](
+  src: SrcLocation,
+  dst: DstLocation
+) extends TransferSuccess[SrcLocation, DstLocation]
 
-case class TransferPerformed[SrcLocation, DstLocation](src: SrcLocation,
-                                                       dst: DstLocation)
-    extends TransferSuccess[SrcLocation, DstLocation]
+case class TransferPerformed[SrcLocation, DstLocation](
+  src: SrcLocation,
+  dst: DstLocation
+) extends TransferSuccess[SrcLocation, DstLocation]

--- a/bag_replicator/src/main/scala/weco/storage/transfer/azure/AzurePrefixTransfer.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/azure/AzurePrefixTransfer.scala
@@ -8,8 +8,7 @@ import weco.storage.providers.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.transfer.PrefixTransfer
 
 class AzurePrefixTransfer(
-  implicit
-  s3Client: S3Client,
+  implicit s3Client: S3Client,
   val transfer: AzureTransfer[_]
 ) extends PrefixTransfer[
       S3ObjectLocationPrefix,
@@ -24,14 +23,18 @@ class AzurePrefixTransfer(
 
     new Listing[S3ObjectLocationPrefix, SourceS3Object] {
       override def list(prefix: S3ObjectLocationPrefix): ListingResult =
-        underlying.list(prefix).map { iterable =>
-          iterable.map { s3Object =>
-            SourceS3Object(
-              location =
-                S3ObjectLocation(bucket = prefix.bucket, key = s3Object.key()),
-              size = s3Object.size()
-            )
-          }
+        underlying.list(prefix).map {
+          iterable =>
+            iterable.map {
+              s3Object =>
+                SourceS3Object(
+                  location = S3ObjectLocation(
+                    bucket = prefix.bucket,
+                    key = s3Object.key()
+                  ),
+                  size = s3Object.size()
+                )
+            }
         }
     }
   }

--- a/bag_replicator/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -192,20 +192,24 @@ trait AzureTransfer[Context]
       case Failure(err) => throw err
     }
 
-  override def transfer(src: SourceS3Object,
-                        dst: AzureBlobLocation): TransferEither =
+  override def transfer(
+    src: SourceS3Object,
+    dst: AzureBlobLocation
+  ): TransferEither =
     getAzureStream(dst) match {
       // If the destination object doesn't exist, we can go ahead and
       // start the transfer.
       case Left(_: NotFoundError) =>
-        runTransfer(src, dst).map { _ =>
-          TransferPerformed(src, dst)
+        runTransfer(src, dst).map {
+          _ =>
+            TransferPerformed(src, dst)
         }
 
       case Left(e) =>
         warn(s"Unexpected error retrieving Azure blob from $dst: $e")
-        runTransfer(src, dst).map { _ =>
-          TransferPerformed(src, dst)
+        runTransfer(src, dst).map {
+          _ =>
+            TransferPerformed(src, dst)
         }
 
       case Right(Identified(_, dstStream)) =>
@@ -275,8 +279,7 @@ class AzurePutBlockTransfer(
   // high may cause issues.
   val blockSize: Long = 1000000000
 )(
-  implicit
-  val s3Client: S3Client,
+  implicit val s3Client: S3Client,
   val blobServiceClient: BlobServiceClient
 ) extends AzureTransfer[Unit] {
 
@@ -322,12 +325,11 @@ class AzurePutBlockTransfer(
   }
 }
 
-class AzurePutBlockFromUrlTransfer(azureSizeFinder: AzureSizeFinder,
-                                   blockTransfer: AzurePutBlockTransfer)(
-  signedUrlValidity: FiniteDuration,
-  val blockSize: Long)(
-  implicit
-  val s3Client: S3Client,
+class AzurePutBlockFromUrlTransfer(
+  azureSizeFinder: AzureSizeFinder,
+  blockTransfer: AzurePutBlockTransfer
+)(signedUrlValidity: FiniteDuration, val blockSize: Long)(
+  implicit val s3Client: S3Client,
   val s3Presigner: S3Presigner,
   val blobServiceClient: BlobServiceClient
 ) extends AzureTransfer[URL] {
@@ -341,10 +343,12 @@ class AzurePutBlockFromUrlTransfer(azureSizeFinder: AzureSizeFinder,
     s3PresignedUrls
       .getPresignedGetURL(
         location = src.location,
-        expiryLength = signedUrlValidity)
+        expiryLength = signedUrlValidity
+      )
       .left
-      .map { readError =>
-        TransferSourceFailure(src, dst, e = readError.e)
+      .map {
+        readError =>
+          TransferSourceFailure(src, dst, e = readError.e)
       }
 
   override protected def writeBlockToAzure(
@@ -389,8 +393,10 @@ class AzurePutBlockFromUrlTransfer(azureSizeFinder: AzureSizeFinder,
   private def isWeirdKey(key: String): Boolean =
     key.endsWith(".")
 
-  override def transfer(src: SourceS3Object,
-                        dst: AzureBlobLocation): TransferEither =
+  override def transfer(
+    src: SourceS3Object,
+    dst: AzureBlobLocation
+  ): TransferEither =
     if (isWeirdKey(src.location.key)) {
       blockTransfer.transfer(src, dst)
     } else {
@@ -400,10 +406,10 @@ class AzurePutBlockFromUrlTransfer(azureSizeFinder: AzureSizeFinder,
 
 object AzurePutBlockFromUrlTransfer {
   def apply(signedUrlValidity: FiniteDuration, blockSize: Long)(
-    implicit
-    s3Client: S3Client,
+    implicit s3Client: S3Client,
     s3Presigner: S3Presigner,
-    blobServiceClient: BlobServiceClient) = {
+    blobServiceClient: BlobServiceClient
+  ) = {
 
     // In the actual replicator, if there's an object in S3 and an object in Azure,
     // assume they're both the same.  The verifier will validate the checksum later.
@@ -427,6 +433,7 @@ object AzurePutBlockFromUrlTransfer {
     val blockTransfer = new AzurePutBlockTransfer(blockSize = blockSize)
     new AzurePutBlockFromUrlTransfer(azureSizeFinder, blockTransfer)(
       signedUrlValidity,
-      blockSize)
+      blockSize
+    )
   }
 }

--- a/bag_replicator/src/main/scala/weco/storage/transfer/s3/S3PrefixTransfer.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/s3/S3PrefixTransfer.scala
@@ -13,7 +13,7 @@ class S3PrefixTransfer()(
       S3ObjectLocationPrefix,
       S3ObjectLocation,
       S3ObjectLocationPrefix,
-      S3ObjectLocation,
+      S3ObjectLocation
     ] {
 
   override protected def buildDstLocation(
@@ -27,8 +27,10 @@ class S3PrefixTransfer()(
 }
 
 object S3PrefixTransfer {
-  def apply()(implicit s3Client: S3Client,
-              transferManager: S3TransferManager): S3PrefixTransfer = {
+  def apply()(
+    implicit s3Client: S3Client,
+    transferManager: S3TransferManager
+  ): S3PrefixTransfer = {
     implicit val transfer: S3Transfer = S3Transfer.apply()
     implicit val listing: S3ObjectLocationListing = S3ObjectLocationListing()
 

--- a/bag_replicator/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
+++ b/bag_replicator/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
@@ -22,15 +22,18 @@ import java.io.InputStream
 import java.util.concurrent.CompletionException
 import scala.util.{Failure, Success, Try}
 
-class S3Transfer(implicit transferManager: S3TransferManager,
-                 s3Readable: S3StreamReadable)
-    extends Transfer[S3ObjectLocation, S3ObjectLocation]
+class S3Transfer(
+  implicit transferManager: S3TransferManager,
+  s3Readable: S3StreamReadable
+) extends Transfer[S3ObjectLocation, S3ObjectLocation]
     with Logging {
 
   import weco.storage.RetryOps._
 
-  override def transfer(src: S3ObjectLocation,
-                        dst: S3ObjectLocation): TransferEither =
+  override def transfer(
+    src: S3ObjectLocation,
+    dst: S3ObjectLocation
+  ): TransferEither =
     getStream(dst) match {
 
       // If the destination object doesn't exist, we can go ahead and
@@ -80,12 +83,15 @@ class S3Transfer(implicit transferManager: S3TransferManager,
         }
     }
 
-  private def compare(src: S3ObjectLocation,
-                      dst: S3ObjectLocation,
-                      srcStream: InputStream,
-                      dstStream: InputStream)
-    : Either[TransferOverwriteFailure[S3ObjectLocation, S3ObjectLocation],
-             TransferNoOp[S3ObjectLocation, S3ObjectLocation]] =
+  private def compare(
+    src: S3ObjectLocation,
+    dst: S3ObjectLocation,
+    srcStream: InputStream,
+    dstStream: InputStream
+  ): Either[
+    TransferOverwriteFailure[S3ObjectLocation, S3ObjectLocation],
+    TransferNoOp[S3ObjectLocation, S3ObjectLocation]
+  ] =
     if (IOUtils.contentEquals(srcStream, dstStream)) {
       Right(TransferNoOp(src, dst))
     } else {
@@ -95,8 +101,10 @@ class S3Transfer(implicit transferManager: S3TransferManager,
   private def getStream(location: S3ObjectLocation) =
     s3Readable.get(location).map(id => id.identifiedT)
 
-  private def runTransfer(src: S3ObjectLocation,
-                          dst: S3ObjectLocation): TransferEither =
+  private def runTransfer(
+    src: S3ObjectLocation,
+    dst: S3ObjectLocation
+  ): TransferEither =
     for {
       transfer <- tryCopyFromSource(src, dst)
         .retry(maxAttempts = 3)
@@ -116,7 +124,8 @@ class S3Transfer(implicit transferManager: S3TransferManager,
 
   private def tryCopyFromSource(
     src: S3ObjectLocation,
-    dst: S3ObjectLocation): Either[ReadError, Copy] = {
+    dst: S3ObjectLocation
+  ): Either[ReadError, Copy] = {
     // We use tags in the verifier in the storage service to check if we've already
     // verified an object.  For safety, we drop all the tags every time an object
     // gets rewritten or copied around.
@@ -150,9 +159,11 @@ class S3Transfer(implicit transferManager: S3TransferManager,
     }
   }
 
-  private def tryCopyToDestination(src: S3ObjectLocation,
-                                   dst: S3ObjectLocation,
-                                   transfer: Copy) =
+  private def tryCopyToDestination(
+    src: S3ObjectLocation,
+    dst: S3ObjectLocation,
+    transfer: Copy
+  ) =
     Try {
       transfer.completionFuture().join()
     } match {
@@ -164,8 +175,10 @@ class S3Transfer(implicit transferManager: S3TransferManager,
 }
 
 object S3Transfer {
-  def apply()(implicit s3Client: S3Client,
-              transferManager: S3TransferManager): S3Transfer = {
+  def apply()(
+    implicit s3Client: S3Client,
+    transferManager: S3TransferManager
+  ): S3Transfer = {
     implicit val readable: S3StreamReader = new S3StreamReader()
 
     new S3Transfer()

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/Main.scala
@@ -42,101 +42,101 @@ import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    import scala.concurrent.duration._
+  runWithConfig {
+    config: Config =>
+      import scala.concurrent.duration._
 
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client =
-      S3Client.builder().build()
+      implicit val s3Client: S3Client =
+        S3Client.builder().build()
 
-    implicit val s3AsyncClient: S3AsyncClient =
-      S3AsyncClient.crtBuilder().build()
+      implicit val s3AsyncClient: S3AsyncClient =
+        S3AsyncClient.crtBuilder().build()
 
-    implicit val s3TransferManager: S3TransferManager =
-      S3TransferManager.builder().s3Client(s3AsyncClient).build()
+      implicit val s3TransferManager: S3TransferManager =
+        S3TransferManager.builder().s3Client(s3AsyncClient).build()
 
-    implicit val s3Presigner: S3Presigner =
-      S3Presigner.builder().build()
+      implicit val s3Presigner: S3Presigner =
+        S3Presigner.builder().build()
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    implicit val lockDao: DynamoLockDao =
-      DynamoLockDaoBuilder.buildDynamoLockDao(config)
+      implicit val lockDao: DynamoLockDao =
+        DynamoLockDaoBuilder.buildDynamoLockDao(config)
 
-    val operationName =
-      OperationNameBuilder.getName(config)
+      val operationName =
+        OperationNameBuilder.getName(config)
 
-    val provider =
-      StorageProvider.apply(config.requireString("bag-replicator.provider"))
+      val provider =
+        StorageProvider.apply(config.requireString("bag-replicator.provider"))
 
-    def createLockingService[DstPrefix <: Prefix[_ <: Location]] =
-      new DynamoLockingService[
-        IngestStepResult[ReplicationSummary[DstPrefix]],
-        Try]()
+      def createLockingService[DstPrefix <: Prefix[_ <: Location]] =
+        new DynamoLockingService[IngestStepResult[
+          ReplicationSummary[DstPrefix]
+        ], Try]()
 
-    def createBagReplicatorWorker[
-      SrcLocation,
-      DstLocation <: Location,
-      DstPrefix <: Prefix[
-        DstLocation
-      ]
-    ](
-      lockingService: DynamoLockingService[IngestStepResult[
-                                             ReplicationSummary[DstPrefix]
-                                           ],
-                                           Try],
-      replicator: Replicator[SrcLocation, DstLocation, DstPrefix]
-    ): BagReplicatorWorker[
-      SNSConfig,
-      SNSConfig,
-      SrcLocation,
-      DstLocation,
-      DstPrefix
-    ] =
-      new BagReplicatorWorker(
-        config = PekkoSQSWorkerConfigBuilder.build(config),
-        ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
-        outgoingPublisher =
-          OutgoingPublisherBuilder.build(config, operationName),
-        lockingService = lockingService,
-        destinationConfig = ReplicatorDestinationConfig
-          .buildDestinationConfig(config),
-        replicator = replicator
-      )
-
-    provider match {
-      case AmazonS3StorageProvider =>
-        createBagReplicatorWorker(
-          lockingService = createLockingService[S3ObjectLocationPrefix],
-          replicator = new S3Replicator()
+      def createBagReplicatorWorker[
+        SrcLocation,
+        DstLocation <: Location,
+        DstPrefix <: Prefix[
+          DstLocation
+        ]
+      ](
+        lockingService: DynamoLockingService[IngestStepResult[
+          ReplicationSummary[DstPrefix]
+        ], Try],
+        replicator: Replicator[SrcLocation, DstLocation, DstPrefix]
+      ): BagReplicatorWorker[
+        SNSConfig,
+        SNSConfig,
+        SrcLocation,
+        DstLocation,
+        DstPrefix
+      ] =
+        new BagReplicatorWorker(
+          config = PekkoSQSWorkerConfigBuilder.build(config),
+          ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
+          outgoingPublisher =
+            OutgoingPublisherBuilder.build(config, operationName),
+          lockingService = lockingService,
+          destinationConfig = ReplicatorDestinationConfig
+            .buildDestinationConfig(config),
+          replicator = replicator
         )
 
-      case AzureBlobStorageProvider =>
-        implicit val azureBlobClient: BlobServiceClient =
-          new BlobServiceClientBuilder()
-            .endpoint(config.requireString("azure.endpoint"))
-            .buildClient()
-        // The max length you can put in a single Put Block from URL API call is 100 MiB.
-        // The class will load a block of this size into memory, so setting it too
-        // high may cause issues.
-        val blockSize: Long = 100000000L
-
-        //Some objects can big, and take a long time to transfer, so we need to set a high validity for the s3 URL
-        val s3UrlValidity = 12.hours
-        createBagReplicatorWorker(
-          lockingService = createLockingService[AzureBlobLocationPrefix],
-          replicator = new AzureReplicator(
-            transfer = AzurePutBlockFromUrlTransfer(s3UrlValidity, blockSize)
+      provider match {
+        case AmazonS3StorageProvider =>
+          createBagReplicatorWorker(
+            lockingService = createLockingService[S3ObjectLocationPrefix],
+            replicator = new S3Replicator()
           )
-        )
-    }
+
+        case AzureBlobStorageProvider =>
+          implicit val azureBlobClient: BlobServiceClient =
+            new BlobServiceClientBuilder()
+              .endpoint(config.requireString("azure.endpoint"))
+              .buildClient()
+          // The max length you can put in a single Put Block from URL API call is 100 MiB.
+          // The class will load a block of this size into memory, so setting it too
+          // high may cause issues.
+          val blockSize: Long = 100000000L
+
+          // Some objects can big, and take a long time to transfer, so we need to set a high validity for the s3 URL
+          val s3UrlValidity = 12.hours
+          createBagReplicatorWorker(
+            lockingService = createLockingService[AzureBlobLocationPrefix],
+            replicator = new AzureReplicator(
+              transfer = AzurePutBlockFromUrlTransfer(s3UrlValidity, blockSize)
+            )
+          )
+      }
   }
 }

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/Replicator.scala
@@ -20,12 +20,9 @@ import weco.storage.transfer.{PrefixTransfer, PrefixTransferFailure}
 // For example, in the BagReplicator, we verify the tag manifests
 // are the same after replication completes.
 
-trait Replicator[SrcLocation,
-                 DstLocation <: Location,
-                 DstPrefix <: Prefix[
-                   DstLocation
-                 ]]
-    extends Logging {
+trait Replicator[SrcLocation, DstLocation <: Location, DstPrefix <: Prefix[
+  DstLocation
+]] extends Logging {
   implicit val prefixTransfer: PrefixTransfer[
     S3ObjectLocationPrefix,
     SrcLocation,

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/replicator/s3/S3Replicator.scala
@@ -6,9 +6,10 @@ import weco.storage_service.bag_replicator.replicator.Replicator
 import weco.storage.providers.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.transfer.s3.S3PrefixTransfer
 
-class S3Replicator(implicit s3Client: S3Client,
-                   s3TransferManager: S3TransferManager)
-    extends Replicator[
+class S3Replicator(
+  implicit s3Client: S3Client,
+  s3TransferManager: S3TransferManager
+) extends Replicator[
       S3ObjectLocation,
       S3ObjectLocation,
       S3ObjectLocationPrefix

--- a/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/weco/storage_service/bag_replicator/services/BagReplicatorWorker.scala
@@ -34,27 +34,22 @@ class BagReplicatorWorker[
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination],
   lockingService: LockingService[IngestStepResult[
-                                   ReplicationSummary[DstPrefix]
-                                 ],
-                                 Try,
-                                 LockDao[
-                                   String,
-                                   UUID
-                                 ]],
+    ReplicationSummary[DstPrefix]
+  ], Try, LockDao[
+    String,
+    UUID
+  ]],
   destinationConfig: ReplicatorDestinationConfig,
   replicator: Replicator[SrcLocation, DstLocation, DstPrefix],
   override val visibilityTimeout: Duration = 3.minutes
 )(
-  implicit
-  val mc: Metrics[Future],
+  implicit val mc: Metrics[Future],
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[VersionedBagRootPayload]
-) extends IngestStepWorker[
-      VersionedBagRootPayload,
-      ReplicationSummary[
-        DstPrefix
-      ]] {
+) extends IngestStepWorker[VersionedBagRootPayload, ReplicationSummary[
+      DstPrefix
+    ]] {
 
   def processMessage(
     payload: VersionedBagRootPayload
@@ -114,11 +109,9 @@ class BagReplicatorWorker[
   def lockFailed(
     ingestId: IngestID,
     request: ReplicationRequest[DstPrefix]
-  ): PartialFunction[Either[FailedLockingServiceOp,
-                            IngestStepResult[
-                              ReplicationSummary[DstPrefix]
-                            ]],
-                     IngestStepResult[ReplicationSummary[DstPrefix]]] = {
+  ): PartialFunction[Either[FailedLockingServiceOp, IngestStepResult[
+    ReplicationSummary[DstPrefix]
+  ]], IngestStepResult[ReplicationSummary[DstPrefix]]] = {
     case Right(result) => result
     case Left(failedLockingServiceOp) =>
       warn(s"Unable to lock successfully: $failedLockingServiceOp")

--- a/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/Main.scala
+++ b/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/Main.scala
@@ -22,27 +22,29 @@ import weco.typesafe.WellcomeTypesafeApp
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client = S3Client.builder().build()
+      implicit val s3Client: S3Client = S3Client.builder().build()
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val operationName = OperationNameBuilder.getName(config)
+      val operationName = OperationNameBuilder.getName(config)
 
-    new BagRootFinderWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      bagRootFinder = new BagRootFinder(),
-      ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
-      outgoingPublisher = OutgoingPublisherBuilder.build(config, operationName)
-    )
+      new BagRootFinderWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        bagRootFinder = new BagRootFinder(),
+        ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
+        outgoingPublisher =
+          OutgoingPublisherBuilder.build(config, operationName)
+      )
   }
 }

--- a/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/services/BagRootFinderWorker.scala
@@ -27,8 +27,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination]
 )(
-  implicit
-  val mc: Metrics[Future],
+  implicit val mc: Metrics[Future],
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[UnpackedBagLocationPayload]

--- a/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/services/S3BagLocator.scala
+++ b/bag_root_finder/src/main/scala/weco/storage_service/bag_root_finder/services/S3BagLocator.scala
@@ -20,19 +20,18 @@ import scala.util.{Failure, Success, Try}
   *
   * Anything else is an error.
   *
-  * This code is deliberately conservative -- it has the potential to lose
-  * data from a bag if we infer incorrectly.
+  * This code is deliberately conservative -- it has the potential to lose data
+  * from a bag if we infer incorrectly.
   *
-  * If you find yourself adding lots of logic to this class, STOP.  THINK.
-  * If clients are putting bags in odd locations, consider modifying the
-  * ingests API so the clients can *tell us* where they're putting the bag,
-  * not leave us to reverse-engineer their logic.
+  * If you find yourself adding lots of logic to this class, STOP. THINK. If
+  * clients are putting bags in odd locations, consider modifying the ingests
+  * API so the clients can *tell us* where they're putting the bag, not leave us
+  * to reverse-engineer their logic.
   *
-  * The method returns an ObjectLocation for bag-info.txt, or an error
-  * if it can't find it.
+  * The method returns an ObjectLocation for bag-info.txt, or an error if it
+  * can't find it.
   *
   * SERIOUSLY, THINK CAREFULLY BEFORE YOU ADD COMPLEXITY HERE.
-  *
   */
 class S3BagLocator(s3Client: S3Client) extends Logging {
   def locateBagInfo(prefix: S3ObjectLocationPrefix): Try[S3ObjectLocation] = {
@@ -55,8 +54,9 @@ class S3BagLocator(s3Client: S3Client) extends Logging {
   def locateBagRoot(
     prefix: S3ObjectLocationPrefix
   ): Try[S3ObjectLocationPrefix] =
-    locateBagInfo(prefix).map { loc =>
-      loc.copy(key = loc.key.stripSuffix("/bag-info.txt")).asPrefix
+    locateBagInfo(prefix).map {
+      loc =>
+        loc.copy(key = loc.key.stripSuffix("/bag-info.txt")).asPrefix
     }
 
   /** Find a bag directly below a given ObjectLocation. */
@@ -82,7 +82,6 @@ class S3BagLocator(s3Client: S3Client) extends Logging {
 
   /** Look for a subdirectory of the current location, and find a bag-info.txt
     * if there's exactly one such subdirectory.
-    *
     */
   private def findBagInfoInDirectory(
     prefix: S3ObjectLocationPrefix

--- a/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/Main.scala
+++ b/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/Main.scala
@@ -20,30 +20,31 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val bagTrackerClient = new PekkoBagTrackerClient(
-      trackerHost = config.requireString("bags.tracker.host")
-    )
+      val bagTrackerClient = new PekkoBagTrackerClient(
+        trackerHost = config.requireString("bags.tracker.host")
+      )
 
-    implicit val s3Client: S3Client =
-      S3Client.builder().build()
+      implicit val s3Client: S3Client =
+        S3Client.builder().build()
 
-    new BagTaggerWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      bagTrackerClient = bagTrackerClient,
-      applyTags = ApplyTags(),
-      tagRules = TagRules.chooseTags
-    )
+      new BagTaggerWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        bagTrackerClient = bagTrackerClient,
+        applyTags = ApplyTags(),
+        tagRules = TagRules.chooseTags
+      )
   }
 }

--- a/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/ApplyTags.scala
+++ b/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/ApplyTags.scala
@@ -21,28 +21,30 @@ class ApplyTags(s3Tags: S3Tags) extends Logging {
   ): Try[Unit] =
     Try {
       val results: Seq[Either[UpdateError, Unit]] =
-        storageLocations.flatMap { location =>
-          location match {
-            case s3Location: S3StorageLocation =>
-              applyTagsToPrefix(
-                tags = s3Tags,
-                prefix = s3Location.prefix,
-                tagsToApply = tagsToApply
-              )
+        storageLocations.flatMap {
+          location =>
+            location match {
+              case s3Location: S3StorageLocation =>
+                applyTagsToPrefix(
+                  tags = s3Tags,
+                  prefix = s3Location.prefix,
+                  tagsToApply = tagsToApply
+                )
 
-            // We don't write tags to our replica in Azure -- at present, they're only
-            // used to inform S3 lifecycle rules, which aren't important in Azure.
-            // Additionally, Azure doesn't allow using hyphens (-) in tag names, because
-            // names have to be valid C# identifiers.
-            //
-            // See https://github.com/wellcomecollection/platform/issues/4730
-            // https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-properties-metadata?tabs=dotnet
-            case azureLocation: AzureStorageLocation =>
-              info(s"Azure location: not applying tags to $azureLocation")
-              tagsToApply.map { _ =>
-                Right(())
-              }
-          }
+              // We don't write tags to our replica in Azure -- at present, they're only
+              // used to inform S3 lifecycle rules, which aren't important in Azure.
+              // Additionally, Azure doesn't allow using hyphens (-) in tag names, because
+              // names have to be valid C# identifiers.
+              //
+              // See https://github.com/wellcomecollection/platform/issues/4730
+              // https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-properties-metadata?tabs=dotnet
+              case azureLocation: AzureStorageLocation =>
+                info(s"Azure location: not applying tags to $azureLocation")
+                tagsToApply.map {
+                  _ =>
+                    Right(())
+                }
+            }
         }
 
       val failures = results.collect { case Left(updateError) => updateError }
@@ -68,20 +70,22 @@ class ApplyTags(s3Tags: S3Tags) extends Logging {
           )
           val location = prefix.asLocation(storageManifestFile.path)
 
-          val result = tags.update(location) { existingTags =>
-            // The bag tagger runs after the bag verifier, which means we should see
-            // a Content-SHA256 tag here.  If not, we should abort -- either the storage
-            // service is broken, or we're waiting for something to happen with consistency.
-            existingTags.get("Content-SHA256") match {
-              case Some(_) => Right(existingTags ++ newTags)
-              case None =>
-                throw new Throwable(s"No Content-SHA256 tag on $location")
-            }
+          val result = tags.update(location) {
+            existingTags =>
+              // The bag tagger runs after the bag verifier, which means we should see
+              // a Content-SHA256 tag here.  If not, we should abort -- either the storage
+              // service is broken, or we're waiting for something to happen with consistency.
+              existingTags.get("Content-SHA256") match {
+                case Some(_) => Right(existingTags ++ newTags)
+                case None =>
+                  throw new Throwable(s"No Content-SHA256 tag on $location")
+              }
           }
           debug(s"Result of applying tags: $result")
 
-          result.map { _ =>
-            ()
+          result.map {
+            _ =>
+              ()
           }
       }
 }

--- a/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/BagTaggerWorker.scala
+++ b/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/BagTaggerWorker.scala
@@ -27,8 +27,7 @@ class BagTaggerWorker(
   applyTags: ApplyTags,
   tagRules: StorageManifest => Map[StorageManifestFile, Map[String, String]]
 )(
-  implicit
-  val mc: Metrics[Future],
+  implicit val mc: Metrics[Future],
   val as: ActorSystem,
   val sc: SqsAsyncClient,
   val wd: Decoder[BagRegistrationNotification]
@@ -64,7 +63,8 @@ class BagTaggerWorker(
 
       _ <- Future.fromTry {
         applyTags.applyTags(
-          storageLocations = Seq(manifest.location) ++ manifest.replicaLocations,
+          storageLocations =
+            Seq(manifest.location) ++ manifest.replicaLocations,
           tagsToApply = tagsToApply
         )
       }

--- a/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/TagRules.scala
+++ b/bag_tagger/src/main/scala/weco/storage_service/bag_tagger/services/TagRules.scala
@@ -8,7 +8,6 @@ import weco.storage_service.storage.models.{
 
 /** Given a storage manifest, decide what tags (if any) should be applied to the
   * objects in the bag.
-  *
   */
 object TagRules {
   def chooseTags(
@@ -21,9 +20,9 @@ object TagRules {
     * Our tags are based on the official list of MIME types from
     * http://www.iana.org/assignments/media-types/media-types.xhtml
     *
-    * We prefer to tag with MIME types because these are standardised tags
-    * that might be useful elsewhere, rather than inventing an unnecessary
-    * tagging scheme solely for the storage service.
+    * We prefer to tag with MIME types because these are standardised tags that
+    * might be useful elsewhere, rather than inventing an unnecessary tagging
+    * scheme solely for the storage service.
     */
   private def createContentTypeTags(
     manifest: StorageManifest
@@ -63,9 +62,10 @@ object TagRules {
 
   implicit class FileOps(f: StorageManifestFile) {
     def hasExtension(exts: String*): Boolean = {
-      exts.foreach { e =>
-        assert(e.startsWith("."))
-        assert(e.toLowerCase == e)
+      exts.foreach {
+        e =>
+          assert(e.startsWith("."))
+          assert(e.toLowerCase == e)
       }
 
       exts.exists(f.path.toLowerCase.endsWith)

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/BagTrackerApi.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/BagTrackerApi.scala
@@ -25,8 +25,7 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
   host: String,
   port: Int
 )(
-  implicit
-  actorSystem: ActorSystem
+  implicit actorSystem: ActorSystem
 ) extends Runnable
     with Logging
     with CreateBag
@@ -58,8 +57,9 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
         // API, it should be fine.
         withoutSizeLimit {
           post {
-            entity(as[StorageManifest]) { storageManifest =>
-              createBag(storageManifest)
+            entity(as[StorageManifest]) {
+              storageManifest =>
+                createBag(storageManifest)
             }
           }
         },
@@ -80,10 +80,14 @@ class BagTrackerApi(val storageManifestDao: StorageManifestDao)(
               )
 
               get {
-                parameter('before.as[Int] ?) { maybeBefore =>
-                  lookupVersions(bagId = bagId, maybeBefore = maybeBefore.map {
-                    BagVersion(_)
-                  })
+                parameter('before.as[Int] ?) {
+                  maybeBefore =>
+                    lookupVersions(
+                      bagId = bagId,
+                      maybeBefore = maybeBefore.map {
+                        BagVersion(_)
+                      }
+                    )
                 }
               }
           }

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/Main.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/Main.scala
@@ -6,23 +6,24 @@ import weco.storage_service.bag_tracker.config.builders.StorageManifestDaoBuilde
 import weco.typesafe.WellcomeTypesafeApp
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    // We need to bind to 0.0.0.0, not localhost, so the API listens for connections
-    // from other services.
-    //
-    // If you bind to localhost, the API is only available to containers within
-    // the same task definition in ECS.
-    val host = "0.0.0.0"
-    val port = 8080
+      // We need to bind to 0.0.0.0, not localhost, so the API listens for connections
+      // from other services.
+      //
+      // If you bind to localhost, the API is only available to containers within
+      // the same task definition in ECS.
+      val host = "0.0.0.0"
+      val port = 8080
 
-    val storageManifestDao = StorageManifestDaoBuilder.build(config)
+      val storageManifestDao = StorageManifestDaoBuilder.build(config)
 
-    new BagTrackerApi(storageManifestDao = storageManifestDao)(
-      host = host,
-      port = port
-    )
+      new BagTrackerApi(storageManifestDao = storageManifestDao)(
+        host = host,
+        port = port
+      )
   }
 }

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/services/LookupBagVersions.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/services/LookupBagVersions.scala
@@ -31,11 +31,12 @@ trait LookupBagVersions extends Logging {
         )
         val bagVersionList = BagVersionList(
           id = bagId,
-          versions = storageManifests.map { manifest =>
-            BagVersionEntry(
-              version = manifest.version,
-              createdDate = manifest.createdDate
-            )
+          versions = storageManifests.map {
+            manifest =>
+              BagVersionEntry(
+                version = manifest.version,
+                createdDate = manifest.createdDate
+              )
           }
         )
 

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/StorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/StorageManifestDao.scala
@@ -63,7 +63,9 @@ trait StorageManifestDao {
     vhs.get(id) match {
       // Two manifests are equivalent if they are the same modulo createdDate.
       case Right(Identified(_, storedManifest)) =>
-        manifest.copy(createdDate = storedManifest.createdDate) == storedManifest
+        manifest.copy(createdDate =
+          storedManifest.createdDate
+        ) == storedManifest
 
       case _ => false
     }

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/dynamo/DynamoStorageManifestDao.scala
@@ -35,9 +35,8 @@ class DynamoStorageManifestDao(
   dynamoConfig: DynamoConfig,
   s3Config: S3Config
 )(
-  implicit
-  dynamoClient: DynamoDbClient,
-  s3Client: S3Client,
+  implicit dynamoClient: DynamoDbClient,
+  s3Client: S3Client
 ) extends StorageManifestDao {
 
   //  By default reads are eventually consistent
@@ -134,7 +133,7 @@ class DynamoStorageManifestDao(
       }
 
       scanamoSuccesses = scanamoResult.collect { case Right(entry) => entry }
-      scanamoErrors = scanamoResult.collect { case Left(err)       => err }
+      scanamoErrors = scanamoResult.collect { case Left(err) => err }
 
       indexEntries <- Either.cond(
         scanamoErrors.isEmpty,

--- a/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/memory/MemoryStorageManifestDao.scala
+++ b/bag_tracker/src/main/scala/weco/storage_service/bag_tracker/storage/memory/MemoryStorageManifestDao.scala
@@ -27,12 +27,13 @@ class MemoryStorageManifestDao(
         }
         .map { case (_, manifest) => manifest }
         .toSeq
-        .filter { manifest =>
-          before match {
-            case Some(beforeVersion) =>
-              manifest.version.underlying < beforeVersion.underlying
-            case _ => true
-          }
+        .filter {
+          manifest =>
+            before match {
+              case Some(beforeVersion) =>
+                manifest.version.underlying < beforeVersion.underlying
+              case _ => true
+            }
         }
         .sortBy { _.version.underlying }
         .reverse

--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/Main.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/Main.scala
@@ -21,42 +21,43 @@ import weco.typesafe.WellcomeTypesafeApp
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client =
-      S3Client.builder().build()
+      implicit val s3Client: S3Client =
+        S3Client.builder().build()
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val PekkoSQSWorkerConfig =
-      PekkoSQSWorkerConfigBuilder.build(config)
+      val PekkoSQSWorkerConfig =
+        PekkoSQSWorkerConfigBuilder.build(config)
 
-    val unpackerWorkerConfig =
-      UnpackerWorkerConfigBuilder.build(config)
+      val unpackerWorkerConfig =
+        UnpackerWorkerConfigBuilder.build(config)
 
-    val operationName = OperationNameBuilder.getName(config)
+      val operationName = OperationNameBuilder.getName(config)
 
-    val ingestUpdater =
-      IngestUpdaterBuilder.build(config, operationName = operationName)
+      val ingestUpdater =
+        IngestUpdaterBuilder.build(config, operationName = operationName)
 
-    val outgoingPublisher =
-      OutgoingPublisherBuilder.build(config, operationName = operationName)
+      val outgoingPublisher =
+        OutgoingPublisherBuilder.build(config, operationName = operationName)
 
-    new BagUnpackerWorker(
-      config = PekkoSQSWorkerConfig,
-      bagUnpackerWorkerConfig = unpackerWorkerConfig,
-      ingestUpdater = ingestUpdater,
-      outgoingPublisher = outgoingPublisher,
-      unpacker = new S3Unpacker()
-    )
+      new BagUnpackerWorker(
+        config = PekkoSQSWorkerConfig,
+        bagUnpackerWorkerConfig = unpackerWorkerConfig,
+        ingestUpdater = ingestUpdater,
+        outgoingPublisher = outgoingPublisher,
+        unpacker = new S3Unpacker()
+      )
   }
 }

--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/Unpacker.scala
@@ -44,8 +44,9 @@ trait Unpacker[
   ): Either[StorageError, Unit] =
     writer
       .put(location)(inputStream)
-      .map { _ =>
-        ()
+      .map {
+        _ =>
+          ()
       }
 
   def unpack(
@@ -62,8 +63,9 @@ trait Unpacker[
       )
 
     val result = for {
-      srcStream <- get(srcLocation).left.map { storageError =>
-        UnpackerStorageError(storageError)
+      srcStream <- get(srcLocation).left.map {
+        storageError =>
+          UnpackerStorageError(storageError)
       }
 
       unpackSummary <- unpack(unpackSummary, srcStream, dstPrefix)

--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/UnpackerMessage.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/UnpackerMessage.scala
@@ -13,6 +13,6 @@ object UnpackerMessage {
   def create(summary: UnpackSummary[_, _]): String = {
     val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
     s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s"
-    else ""}"
+      else ""}"
   }
 }

--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/services/s3/S3Unpacker.scala
@@ -19,7 +19,11 @@ import weco.storage.streaming.InputStreamWithLength
 class S3Unpacker(
   bufferSize: Long = 128 * FileUtils.ONE_MB
 )(implicit s3Client: S3Client)
-    extends Unpacker[S3ObjectLocation, S3ObjectLocation, S3ObjectLocationPrefix] {
+    extends Unpacker[
+      S3ObjectLocation,
+      S3ObjectLocation,
+      S3ObjectLocationPrefix
+    ] {
   override protected val writer
     : Writable[S3ObjectLocation, InputStreamWithLength] =
     new S3StreamStore()

--- a/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/storage/Unarchiver.scala
+++ b/bag_unpacker/src/main/scala/weco/storage_service/bag_unpacker/storage/Unarchiver.scala
@@ -17,27 +17,26 @@ import org.apache.commons.io.input.CloseShieldInputStream
 import scala.util.{Failure, Success, Try}
 
 /** You pass this class an inputStream that comes from the storage provider,
-  * e.g. a FileInputStream or an S3InputStream.  The stream should be a tar.gz
-  * or similar container + compression format.
+  * e.g. a FileInputStream or an S3InputStream. The stream should be a tar.gz or
+  * similar container + compression format.
   *
   * The iterator it produces has two pieces:
-  *  1. ArchiveEntry -- metadata about the original file, e.g. name/size
-  *  2. InputStream -- a stream that gives you the content for this file
+  *   1. ArchiveEntry -- metadata about the original file, e.g. name/size 2.
+  *      InputStream -- a stream that gives you the content for this file
   *
-  * This InputStream is really just a view into the original stream.
-  * If you advance one, the other advances.  They move together.
+  * This InputStream is really just a view into the original stream. If you
+  * advance one, the other advances. They move together.
   *
-  *       +------------------------------------------+ original stream
+  * \+------------------------------------------+ original stream
   *
-  *       +-------+                                    file1
-  *               +------------------+                 file2
-  *                                  +---------+       file3
-  *                                            +-----+ file4
+  * \+-------+ file1
+  * \+------------------+ file2
+  * \+---------+ file3
+  * \+-----+ file4
   *
-  * This is why we wrap the output in a close shield: if the caller closed
-  * the individual stream, they'd close the underlying stream and we'd be
-  * unable to read any more of the archive.
-  *
+  * This is why we wrap the output in a close shield: if the caller closed the
+  * individual stream, they'd close the underlying stream and we'd be unable to
+  * read any more of the archive.
   */
 object Unarchiver {
   def open(
@@ -86,7 +85,7 @@ object Unarchiver {
     } match {
       case Success(stream)                   => Right(stream)
       case Failure(err: CompressorException) => Left(CompressorError(err))
-      case Failure(err)                      => Left(UnexpectedUnarchiverError(err))
+      case Failure(err) => Left(UnexpectedUnarchiverError(err))
     }
   private def extract(
     inputStream: InputStream
@@ -100,7 +99,7 @@ object Unarchiver {
     } match {
       case Success(stream)                => Right(stream)
       case Failure(err: ArchiveException) => Left(ArchiveFormatError(err))
-      case Failure(err)                   => Left(UnexpectedUnarchiverError(err))
+      case Failure(err) => Left(UnexpectedUnarchiverError(err))
     }
 }
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/Main.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/Main.scala
@@ -17,34 +17,35 @@ import weco.typesafe.WellcomeTypesafeApp
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client =
-      S3Client.builder().build()
+      implicit val s3Client: S3Client =
+        S3Client.builder().build()
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val operationName =
-      OperationNameBuilder.getName(config)
+      val operationName =
+        OperationNameBuilder.getName(config)
 
-    val ingestUpdater =
-      IngestUpdaterBuilder.build(config, operationName)
+      val ingestUpdater =
+        IngestUpdaterBuilder.build(config, operationName)
 
-    val outgoingPublisher =
-      OutgoingPublisherBuilder.build(config, operationName)
+      val outgoingPublisher =
+        OutgoingPublisherBuilder.build(config, operationName)
 
-    BagVerifierWorkerBuilder.buildBagVerifierWorker(config)(
-      ingestUpdater = ingestUpdater,
-      outgoingPublisher = outgoingPublisher
-    )
+      BagVerifierWorkerBuilder.buildBagVerifierWorker(config)(
+        ingestUpdater = ingestUpdater,
+        outgoingPublisher = outgoingPublisher
+      )
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/builder/BagVerifierWorkerBuilder.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/builder/BagVerifierWorkerBuilder.scala
@@ -145,7 +145,7 @@ object BagVerifierWorkerBuilder {
           srcRoot = payload.srcPrefix,
           replicaRoot =
             payload.dstLocation.prefix.asInstanceOf[S3ObjectLocationPrefix]
-      )
+        )
     )
   }
 
@@ -187,7 +187,7 @@ object BagVerifierWorkerBuilder {
           srcRoot = payload.srcPrefix,
           replicaRoot =
             payload.dstLocation.prefix.asInstanceOf[AzureBlobLocationPrefix]
-      )
+        )
     )
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/ExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/ExpectedFixity.scala
@@ -1,8 +1,7 @@
 package weco.storage_service.bag_verifier.fixity
 
-/** Given some Container of files, get the expected fixity information (size/checksum)
-  * for every file in the container.
-  *
+/** Given some Container of files, get the expected fixity information
+  * (size/checksum) for every file in the container.
   */
 trait ExpectedFixity[Container] {
   def create(

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityChecker.scala
@@ -20,7 +20,6 @@ import weco.storage.{DoesNotExistError, Location, Prefix, ReadError}
 import scala.util.{Failure, Success}
 
 /** Look up and check the fixity info (checksum, size) on an individual file.
-  *
   */
 trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
     extends FixityTagChecker
@@ -261,22 +260,23 @@ trait FixityChecker[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]]
   ): Unit = {
     val updateResult =
       tags
-        .update(location) { existingTags =>
-          val newFixityTags = expectedFileFixity.fixityTags
+        .update(location) {
+          existingTags =>
+            val newFixityTags = expectedFileFixity.fixityTags
 
-          // We've already checked the tags on this location once, so we shouldn't
-          // see conflicting values here.  Check we're not about to blat some existing
-          // tags just in case.  If we do see conflicting tags here, there's something
-          // badly wrong with the storage service.
-          //
-          // Note: this is a fairly weak guarantee, because tags aren't locked during
-          // an update operation.
-          assert(
-            existingTags.isCompatibleWith(newFixityTags),
-            s"Trying to write $newFixityTags to $location; existing tags conflict: $existingTags"
-          )
+            // We've already checked the tags on this location once, so we shouldn't
+            // see conflicting values here.  Check we're not about to blat some existing
+            // tags just in case.  If we do see conflicting tags here, there's something
+            // badly wrong with the storage service.
+            //
+            // Note: this is a fairly weak guarantee, because tags aren't locked during
+            // an update operation.
+            assert(
+              existingTags.isCompatibleWith(newFixityTags),
+              s"Trying to write $newFixityTags to $location; existing tags conflict: $existingTags"
+            )
 
-          Right(existingTags ++ newFixityTags)
+            Right(existingTags ++ newFixityTags)
         }
 
     updateResult match {

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityListChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityListChecker.scala
@@ -8,15 +8,11 @@ import scala.util.Random
 
 /** Given some Container of files, get the expected fixity information for every
   * file in the container, then verify the fixity on each of them.
-  *
   */
-class FixityListChecker[BagLocation <: Location,
-                        BagPrefix <: Prefix[
-                          BagLocation
-                        ],
-                        Container](
-  implicit
-  dataDirectoryFixityChecker: FixityChecker[BagLocation, BagPrefix],
+class FixityListChecker[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+], Container](
+  implicit dataDirectoryFixityChecker: FixityChecker[BagLocation, BagPrefix],
   val fetchEntriesFixityChecker: FixityChecker[
     S3ObjectLocation,
     S3ObjectLocationPrefix
@@ -53,14 +49,14 @@ class FixityListChecker[BagLocation <: Location,
           ) {
 
             case (
-                existingCorrect: FixityListAllCorrect[BagLocation],
-                newCorrect: FileFixityCorrect[BagLocation]
+                  existingCorrect: FixityListAllCorrect[BagLocation],
+                  newCorrect: FileFixityCorrect[BagLocation]
                 ) =>
               FixityListAllCorrect(newCorrect :: existingCorrect.locations)
 
             case (
-                correct: FixityListAllCorrect[BagLocation],
-                err: FileFixityError[BagLocation]
+                  correct: FixityListAllCorrect[BagLocation],
+                  err: FileFixityError[BagLocation]
                 ) =>
               FixityListWithErrors(
                 errors = List(err),
@@ -68,8 +64,8 @@ class FixityListChecker[BagLocation <: Location,
               )
 
             case (
-                existingErrors: FixityListWithErrors[BagLocation],
-                c: FileFixityCorrect[BagLocation]
+                  existingErrors: FixityListWithErrors[BagLocation],
+                  c: FileFixityCorrect[BagLocation]
                 ) =>
               FixityListWithErrors(
                 existingErrors.errors,
@@ -77,8 +73,8 @@ class FixityListChecker[BagLocation <: Location,
               )
 
             case (
-                existingErrors: FixityListWithErrors[BagLocation],
-                err: FileFixityError[BagLocation]
+                  existingErrors: FixityListWithErrors[BagLocation],
+                  err: FileFixityError[BagLocation]
                 ) =>
               FixityListWithErrors(
                 errors = err :: existingErrors.errors,

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/FixityTagChecker.scala
@@ -51,8 +51,9 @@ trait FixityTagChecker {
     def isCompatibleWith(other: Map[K, V]): Boolean =
       m.keySet
         .intersect(other.keySet)
-        .map { key =>
-          (m(key), other(key))
+        .map {
+          key =>
+            (m(key), other(key))
         }
         .collect {
           case (mValue, otherValue) if mValue != otherValue =>

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/azure/AzureDynamoTags.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/azure/AzureDynamoTags.scala
@@ -20,8 +20,7 @@ import scala.util.{Failure, Success, Try}
 // Using DynamoDB to store tags about blobs in Azure is a stopgap until we get
 // access to first-class Azure tags.
 class AzureDynamoTags(dynamoConfig: DynamoConfig)(
-  implicit
-  blobServiceClient: BlobServiceClient,
+  implicit blobServiceClient: BlobServiceClient,
   dynamoClient: DynamoDbClient
 ) extends Tags[AzureBlobLocation] {
   case class DynamoTagsEntry(id: String, tags: Map[String, String])

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/fixity/bag/BagExpectedFixity.scala
@@ -14,10 +14,9 @@ import weco.storage_service.bagit.models._
 import weco.storage_service.bagit.services.BagMatcher
 import weco.storage.{Location, Prefix}
 
-class BagExpectedFixity[BagLocation <: Location,
-                        BagPrefix <: Prefix[
-                          BagLocation
-                        ]](root: BagPrefix)(
+class BagExpectedFixity[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]](root: BagPrefix)(
   implicit resolvable: Resolvable[BagLocation]
 ) extends ExpectedFixity[Bag]
     with Logging {
@@ -42,7 +41,7 @@ class BagExpectedFixity[BagLocation <: Location,
 
         val matches = matched.map(getVerifiableLocation)
 
-        val failures = matches collect { case Left(f)           => f }
+        val failures = matches collect { case Left(f) => f }
         val successes = matches collect { case Right(locations) => locations }
 
         debug(s"Got ($successes, $failures)")

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/services/BagVerifier.scala
@@ -45,12 +45,11 @@ trait ReplicatedBagVerifier[
     bagReader.readable
 }
 
-trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix],
-                  BagLocation <: Location,
-                  BagPrefix <: Prefix[
-                    BagLocation
-                  ]]
-    extends Logging
+trait BagVerifier[BagContext <: BagVerifyContext[
+  BagPrefix
+], BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] extends Logging
     with VerifyBagDeclaration[BagLocation, BagPrefix]
     with VerifyChecksumAndSize[BagLocation, BagPrefix]
     with VerifyExternalIdentifier
@@ -209,7 +208,7 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix],
         )
 
       case Right(
-          creationError: CouldNotCreateExpectedFixityList[BagLocation]
+            creationError: CouldNotCreateExpectedFixityList[BagLocation]
           ) =>
         IngestFailed(
           summary = VerificationIncompleteSummary(
@@ -237,8 +236,9 @@ trait BagVerifier[BagContext <: BagVerifyContext[BagPrefix],
       case Right(result: FixityListWithErrors[BagLocation]) =>
         val verificationFailureMessage =
           result.errors
-            .map { fixityError: FileFixityError[BagLocation] =>
-              s"${fixityError.expectedFileFixity.uri}: ${fixityError.e.getMessage}"
+            .map {
+              fixityError: FileFixityError[BagLocation] =>
+                s"${fixityError.expectedFileFixity.uri}: ${fixityError.e.getMessage}"
             }
             .mkString("\n")
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/azure/AzureLocatable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/azure/AzureLocatable.scala
@@ -24,10 +24,11 @@ class AzureLocatable
         container = blobUrlParts.getBlobContainerName,
         name = blobUrlParts.getBlobName
       )
-    }.toEither.left.map { throwable =>
-      LocationParsingError(
-        uri,
-        s"Failed parsing Azure location: ${throwable.getMessage}"
-      )
+    }.toEither.left.map {
+      throwable =>
+        LocationParsingError(
+          uri,
+          s"Failed parsing Azure location: ${throwable.getMessage}"
+        )
     }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/bag/BagLocatable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/bag/BagLocatable.scala
@@ -9,16 +9,15 @@ import weco.storage_service.bagit.models.BagPath
 import weco.storage.{Location, Prefix}
 
 object BagLocatable {
-  implicit def bagPathLocatable[BagLocation <: Location,
-                                BagPrefix <: Prefix[
-                                  BagLocation
-                                ]]: Locatable[BagLocation, BagPrefix, BagPath] =
+  implicit def bagPathLocatable[BagLocation <: Location, BagPrefix <: Prefix[
+    BagLocation
+  ]]: Locatable[BagLocation, BagPrefix, BagPath] =
     new Locatable[BagLocation, BagPrefix, BagPath] {
       override def locate(bagPath: BagPath)(
         maybeRoot: Option[BagPrefix]
       ): Either[LocateFailure[BagPath], BagLocation] =
         maybeRoot match {
-          case None       => Left(LocationNotFound(bagPath, s"No root specified!"))
+          case None => Left(LocationNotFound(bagPath, s"No root specified!"))
           case Some(root) => Right(root.asLocation(bagPath.value))
         }
     }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/storage/s3/S3Locatable.scala
@@ -41,7 +41,7 @@ object S3Locatable {
                   LocationParsingError(
                     uri,
                     s"Failed to parse S3 URI: invalid path trying to parse local URL (${default
-                      .mkString("/")})"
+                        .mkString("/")})"
                   )
                 )
             }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyBagDeclaration.scala
@@ -9,10 +9,9 @@ import weco.storage.streaming.Codec._
 import scala.io.Source
 import scala.util.matching.Regex
 
-trait VerifyBagDeclaration[BagLocation <: Location,
-                           BagPrefix <: Prefix[
-                             BagLocation
-                           ]] {
+trait VerifyBagDeclaration[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] {
   protected val streamReader: Readable[BagLocation, InputStreamWithLength]
 
   private val versionLine = new Regex("BagIt-Version: \\d\\.\\d+")
@@ -57,10 +56,11 @@ trait VerifyBagDeclaration[BagLocation <: Location,
             )
 
           case Right(declaration) =>
-            validateDeclaration(declaration).left.map { message =>
-              BagVerifierError(
-                s"Error loading Bag Declaration (bagit.txt): $message"
-              )
+            validateDeclaration(declaration).left.map {
+              message =>
+                BagVerifierError(
+                  s"Error loading Bag Declaration (bagit.txt): $message"
+                )
             }
         }
 
@@ -85,7 +85,6 @@ trait VerifyBagDeclaration[BagLocation <: Location,
 
   /** Checks whether the Bag Declaration is correctly formatted, or explains why
     * it isn't if not.
-    *
     */
   private def validateDeclaration(contents: String): Either[String, Unit] = {
     val lines = Source.fromString(contents).getLines().toList
@@ -97,7 +96,7 @@ trait VerifyBagDeclaration[BagLocation <: Location,
       case Seq(versionLine(), _)  => Left("encoding line was not correct")
       case Seq(_, encodingLine()) => Left("version line was not correct")
       case Seq(_, _)              => Left("not correctly formatted")
-      case other                  => Left(s"expected 2 lines, got ${other.size}")
+      case other => Left(s"expected 2 lines, got ${other.size}")
     }
   }
 }

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyChecksumAndSize.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyChecksumAndSize.scala
@@ -12,10 +12,9 @@ import weco.storage.{Location, Prefix}
 
 import scala.util.{Failure, Success, Try}
 
-trait VerifyChecksumAndSize[BagLocation <: Location,
-                            BagPrefix <: Prefix[
-                              BagLocation
-                            ]] {
+trait VerifyChecksumAndSize[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] {
   implicit val resolvable: Resolvable[BagLocation]
   val fixityListChecker: FixityListChecker[BagLocation, BagPrefix, Bag]
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyFetch.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyFetch.scala
@@ -44,7 +44,7 @@ trait VerifyFetch[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
             Left(
               BagVerifierError(
                 s"fetch.txt refers to paths in a mismatched prefix or with a non-S3 URI scheme: ${mismatchedPaths
-                  .mkString(", ")}"
+                    .mkString(", ")}"
               )
             )
         }
@@ -68,8 +68,9 @@ trait VerifyFetch[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
     val bagFetchLocations: Seq[(BagPath, BagLocation)] = fetch match {
       case Some(bagFetch) =>
         bagFetch.paths
-          .map { path: BagPath =>
-            path -> root.asLocation(path.value)
+          .map {
+            path: BagPath =>
+              path -> root.asLocation(path.value)
           }
 
       case None => Seq.empty

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyNoUnreferencedFiles.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyNoUnreferencedFiles.scala
@@ -9,11 +9,9 @@ import weco.storage_service.bag_verifier.models.BagVerifierError
 import weco.storage_service.bagit.models.UnreferencedFiles
 import weco.storage.{Location, Prefix}
 
-trait VerifyNoUnreferencedFiles[BagLocation <: Location,
-                                BagPrefix <: Prefix[
-                                  BagLocation
-                                ]]
-    extends Logging {
+trait VerifyNoUnreferencedFiles[BagLocation <: Location, BagPrefix <: Prefix[
+  BagLocation
+]] extends Logging {
 
   // Files that it's okay not to be referenced by any other manifests/files.
   //
@@ -44,8 +42,9 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location,
 
         val unreferencedFiles = actualLocations
           .filterNot { expectedLocations.contains }
-          .filterNot { location =>
-            excludedFiles.exists { root.asLocation(_) == location }
+          .filterNot {
+            location =>
+              excludedFiles.exists { root.asLocation(_) == location }
           }
 
         if (unreferencedFiles.isEmpty) {
@@ -72,8 +71,9 @@ trait VerifyNoUnreferencedFiles[BagLocation <: Location,
 
           val userMessage = messagePrefix +
             unreferencedFiles
-              .map { loc: BagLocation =>
-                getRelativePath(root, loc)
+              .map {
+                loc: BagLocation =>
+                  getRelativePath(root, loc)
               }
               .mkString(", ")
 

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyPayloadOxum.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifyPayloadOxum.scala
@@ -31,8 +31,9 @@ trait VerifyPayloadOxum {
 
     val actualSize =
       locations
-        .filter { loc =>
-          payloadPaths.contains(loc.expectedFileFixity.path)
+        .filter {
+          loc =>
+            payloadPaths.contains(loc.expectedFileFixity.path)
         }
         .map { _.size }
         .sum

--- a/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifySourceTagManifest.scala
+++ b/bag_verifier/src/main/scala/weco/storage_service/bag_verifier/verify/steps/VerifySourceTagManifest.scala
@@ -15,15 +15,13 @@ trait VerifySourceTagManifest[ReplicaBagLocation <: Location] {
     InputStreamWithLength
   ]
 
-  /** This step is here to check the bag created by the replica and the
-    * original bag are the same; the verifier can only check that a
-    * bag is correctly formed.
+  /** This step is here to check the bag created by the replica and the original
+    * bag are the same; the verifier can only check that a bag is correctly
+    * formed.
     *
-    * Without this check, it would be possible for the replicator to
-    * write an entirely different, valid bag -- and because the verifier
-    * doesn't have context for the original bag, it wouldn't flag
-    * it as an error.
-    *
+    * Without this check, it would be possible for the replicator to write an
+    * entirely different, valid bag -- and because the verifier doesn't have
+    * context for the original bag, it wouldn't flag it as an error.
     */
   def verifySourceTagManifestIsTheSame(
     srcPrefix: S3ObjectLocationPrefix,
@@ -33,17 +31,18 @@ trait VerifySourceTagManifest[ReplicaBagLocation <: Location] {
       srcManifest <- getTagManifest(srcPrefix, srcReader)
       replicaManifest <- getTagManifest(replicaPrefix, replicaReader)
 
-      result <- if (IOUtils.contentEquals(srcManifest, replicaManifest)) {
-        Right(())
-      } else {
-        Left(
-          BagVerifierError(
-            new Throwable(
-              "tagmanifest-sha256.txt in replica source and replica location do not match!"
+      result <-
+        if (IOUtils.contentEquals(srcManifest, replicaManifest)) {
+          Right(())
+        } else {
+          Left(
+            BagVerifierError(
+              new Throwable(
+                "tagmanifest-sha256.txt in replica source and replica location do not match!"
+              )
             )
           )
-        )
-      }
+        }
     } yield result
   }
 

--- a/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/Main.scala
+++ b/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/Main.scala
@@ -36,47 +36,49 @@ import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    implicit val lockDao = DynamoLockDaoBuilder
-      .buildDynamoLockDao(config)
+      implicit val lockDao = DynamoLockDaoBuilder
+        .buildDynamoLockDao(config)
 
-    val operationName = OperationNameBuilder.getName(config)
+      val operationName = OperationNameBuilder.getName(config)
 
-    val lockingService =
-      new DynamoLockingService[
-        Either[IngestVersionManagerError, BagVersion],
-        Id
-      ]()
+      val lockingService =
+        new DynamoLockingService[
+          Either[IngestVersionManagerError, BagVersion],
+          Id
+        ]()
 
-    val ingestVersionManagerDao = new DynamoIngestVersionManagerDao(
-      dynamoClient = DynamoDbClient.builder().build(),
-      dynamoConfig =
-        DynamoBuilder.buildDynamoConfig(config, namespace = "versions")
-    )
+      val ingestVersionManagerDao = new DynamoIngestVersionManagerDao(
+        dynamoClient = DynamoDbClient.builder().build(),
+        dynamoConfig =
+          DynamoBuilder.buildDynamoConfig(config, namespace = "versions")
+      )
 
-    val versionPicker = new VersionPicker(
-      lockingService = lockingService,
-      ingestVersionManager =
-        new DynamoIngestVersionManager(ingestVersionManagerDao)
-    )
+      val versionPicker = new VersionPicker(
+        lockingService = lockingService,
+        ingestVersionManager =
+          new DynamoIngestVersionManager(ingestVersionManagerDao)
+      )
 
-    new BagVersionerWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      bagVersioner = new BagVersioner(versionPicker = versionPicker),
-      ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
-      outgoingPublisher = OutgoingPublisherBuilder.build(config, operationName)
-    )
+      new BagVersionerWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        bagVersioner = new BagVersioner(versionPicker = versionPicker),
+        ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
+        outgoingPublisher =
+          OutgoingPublisherBuilder.build(config, operationName)
+      )
   }
 }

--- a/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/services/BagVersioner.scala
+++ b/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/services/BagVersioner.scala
@@ -72,6 +72,6 @@ class BagVersioner(versionPicker: VersionPicker) {
   ): Throwable =
     error match {
       case err: IngestVersionManagerDaoError => err.e
-      case err                               => new Throwable(s"Unexpected error in the bag versioner: $err")
+      case err => new Throwable(s"Unexpected error in the bag versioner: $err")
     }
 }

--- a/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/IngestVersionManager.scala
+++ b/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/IngestVersionManager.scala
@@ -125,25 +125,25 @@ trait IngestVersionManager {
 
   /** We always want to assign the same version to a given ingest ID.
     *
-    * That way, if a message is double-sent or an ingest gets retried, we
-    * won't have multiple versions for the same ingest.
+    * That way, if a message is double-sent or an ingest gets retried, we won't
+    * have multiple versions for the same ingest.
     *
-    * This function checks that the external identifier/space on the
-    * stored version match the ingest.
+    * This function checks that the external identifier/space on the stored
+    * version match the ingest.
     *
-    * In theory an ingest is immutable, and the externalIdentifier/space
-    * will always be the same.  If they're different, something funky is
-    * definitely happening, so we should fail the ingest and flag it for
-    * further attention.
-    *
+    * In theory an ingest is immutable, and the externalIdentifier/space will
+    * always be the same. If they're different, something funky is definitely
+    * happening, so we should fail the ingest and flag it for further attention.
     */
   private def verifyExistingVersion(
     existingVersion: VersionRecord,
     externalIdentifier: ExternalIdentifier,
     space: StorageSpace
   ): Either[IngestVersionManagerError, BagVersion] =
-    if (existingVersion.externalIdentifier == externalIdentifier &&
-        existingVersion.storageSpace == space)
+    if (
+      existingVersion.externalIdentifier == externalIdentifier &&
+      existingVersion.storageSpace == space
+    )
       Right(existingVersion.version)
     else if (existingVersion.externalIdentifier != externalIdentifier)
       Left(

--- a/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDao.scala
+++ b/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDao.scala
@@ -20,8 +20,7 @@ class DynamoIngestVersionManagerDao(
   dynamoClient: DynamoDbClient,
   dynamoConfig: DynamoConfig
 )(
-  implicit
-  formatVersionRecord: DynamoFormat[DynamoVersionRecord]
+  implicit formatVersionRecord: DynamoFormat[DynamoVersionRecord]
 ) extends IngestVersionManagerDao {
 
   private val scanamoTable =

--- a/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/memory/MemoryIngestVersionManagerDao.scala
+++ b/bag_versioner/src/main/scala/weco/storage_service/bag_versioner/versioning/memory/MemoryIngestVersionManagerDao.scala
@@ -29,9 +29,10 @@ class MemoryIngestVersionManagerDao() extends IngestVersionManagerDao {
   ): Either[MaximaError, VersionRecord] = {
     val matchingVersions =
       records
-        .filter { record =>
-          record.externalIdentifier == externalIdentifier &&
-          record.storageSpace == space
+        .filter {
+          record =>
+            record.externalIdentifier == externalIdentifier &&
+            record.storageSpace == space
         }
 
     if (matchingVersions.isEmpty) {

--- a/bags_api/src/main/scala/weco/storage_service/bags_api/BagsApi.scala
+++ b/bags_api/src/main/scala/weco/storage_service/bags_api/BagsApi.scala
@@ -43,13 +43,14 @@ trait BagsApi
                       externalIdentifier = externalIdentifier
                     )
 
-                    parameter('before.as[String] ?) { maybeBefore =>
-                      withFuture {
-                        lookupVersions(
-                          bagId = bagId,
-                          maybeBeforeString = maybeBefore
-                        )
-                      }
+                    parameter('before.as[String] ?) {
+                      maybeBefore =>
+                        withFuture {
+                          lookupVersions(
+                            bagId = bagId,
+                            maybeBeforeString = maybeBefore
+                          )
+                        }
                     }
 
                   case Failure(_) =>
@@ -105,13 +106,14 @@ trait BagsApi
                         )
                       )
                     case _ =>
-                      parameter('version.as[String] ?) { maybeVersionString =>
-                        withFuture {
-                          lookupBag(
-                            bagId = bagId,
-                            maybeVersionString = maybeVersionString
-                          )
-                        }
+                      parameter('version.as[String] ?) {
+                        maybeVersionString =>
+                          withFuture {
+                            lookupBag(
+                              bagId = bagId,
+                              maybeVersionString = maybeVersionString
+                            )
+                          }
                       }
                   }
 

--- a/bags_api/src/main/scala/weco/storage_service/bags_api/Main.scala
+++ b/bags_api/src/main/scala/weco/storage_service/bags_api/Main.scala
@@ -30,61 +30,62 @@ object Main extends WellcomeTypesafeApp {
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
   val defaultMaxByteLength = 9 * FileUtils.ONE_MB
 
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val s3Client: S3Client = S3Client.builder().build()
-    implicit val s3Presigner: S3Presigner = S3Presigner.builder().build()
+      implicit val s3Client: S3Client = S3Client.builder().build()
+      implicit val s3Presigner: S3Presigner = S3Presigner.builder().build()
 
-    val uploader = new S3Uploader()
+      val uploader = new S3Uploader()
 
-    val s3Config = S3Builder.buildS3Config(
-      config,
-      namespace = "responses"
-    )
+      val s3Config = S3Builder.buildS3Config(
+        config,
+        namespace = "responses"
+      )
 
-    val locationPrefix = S3ObjectLocationPrefix(
-      bucket = s3Config.bucketName,
-      keyPrefix = "responses"
-    )
+      val locationPrefix = S3ObjectLocationPrefix(
+        bucket = s3Config.bucketName,
+        keyPrefix = "responses"
+      )
 
-    val client = new PekkoBagTrackerClient(
-      trackerHost = config.requireString("bags.tracker.host")
-    )
+      val client = new PekkoBagTrackerClient(
+        trackerHost = config.requireString("bags.tracker.host")
+      )
 
-    val router: BagsApi = new BagsApi {
-      override val httpServerConfig: HTTPServerConfig =
-        HTTPServerBuilder.buildHTTPServerConfig(config)
-      override implicit val ec: ExecutionContext = actorSystem.dispatcher
+      val router: BagsApi = new BagsApi {
+        override val httpServerConfig: HTTPServerConfig =
+          HTTPServerBuilder.buildHTTPServerConfig(config)
+        override implicit val ec: ExecutionContext = actorSystem.dispatcher
 
-      override val bagTrackerClient: BagTrackerClient = client
+        override val bagTrackerClient: BagTrackerClient = client
 
-      override val s3PresignedUrls: S3PresignedUrls =
-        new S3PresignedUrls()
+        override val s3PresignedUrls: S3PresignedUrls =
+          new S3PresignedUrls()
 
-      override val s3Uploader: S3Uploader = uploader
-      override val s3Prefix: S3ObjectLocationPrefix = locationPrefix
+        override val s3Uploader: S3Uploader = uploader
+        override val s3Prefix: S3ObjectLocationPrefix = locationPrefix
 
-      override val maximumResponseByteLength: Long = defaultMaxByteLength
-      override val cacheDuration: Duration = defaultCacheDuration
-      override implicit val materializer: Materializer =
-        Materializer(actorSystem)
-    }
+        override val maximumResponseByteLength: Long = defaultMaxByteLength
+        override val cacheDuration: Duration = defaultCacheDuration
+        override implicit val materializer: Materializer =
+          Materializer(actorSystem)
+      }
 
-    val appName = "BagsApi"
+      val appName = "BagsApi"
 
-    new WellcomeHttpApp(
-      routes = router.bags,
-      httpMetrics = new HttpMetrics(
-        name = appName,
-        metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
-      ),
-      httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),
-      appName = appName
-    )
+      new WellcomeHttpApp(
+        routes = router.bags,
+        httpMetrics = new HttpMetrics(
+          name = appName,
+          metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
+        ),
+        httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),
+        appName = appName
+      )
   }
 }

--- a/bags_api/src/main/scala/weco/storage_service/bags_api/models/DisplayBagVersionList.scala
+++ b/bags_api/src/main/scala/weco/storage_service/bags_api/models/DisplayBagVersionList.scala
@@ -11,11 +11,12 @@ case class DisplayBagVersionList(
 case object DisplayBagVersionList {
   def apply(bagVersionList: BagVersionList): DisplayBagVersionList =
     DisplayBagVersionList(
-      results = bagVersionList.versions.map { entry =>
-        DisplayBagVersionEntry(
-          id = bagVersionList.id,
-          entry = entry
-        )
+      results = bagVersionList.versions.map {
+        entry =>
+          DisplayBagVersionEntry(
+            id = bagVersionList.id,
+            entry = entry
+          )
       }
     )
 }

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -52,6 +52,7 @@ docker run --tty --rm \
   -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
   -e AWS_SECRET_KEY="${AWS_SECRET_KEY:-}" \
   -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
+  -e CODEARTIFACT_AUTH_TOKEN="${CODEARTIFACT_AUTH_TOKEN:-}" \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \

--- a/common/src/main/scala/weco/messaging/sqsworker/pekko/PekkoSQSWorker.scala
+++ b/common/src/main/scala/weco/messaging/sqsworker/pekko/PekkoSQSWorker.scala
@@ -19,20 +19,20 @@ import weco.monitoring.Metrics
 
 import scala.concurrent.Future
 
-/**
-  * Implementation of [[PekkoWorker]] that uses SQS as source and sink.
-  * It receives messages from SQS and deletes messages from SQS on successful completion
+/** Implementation of [[PekkoWorker]] that uses SQS as source and sink. It
+  * receives messages from SQS and deletes messages from SQS on successful
+  * completion
   */
 class PekkoSQSWorker[Work, Summary](
   config: PekkoSQSWorkerConfig
 )(
   val doWork: Work => Future[Result[Summary]]
-)(implicit
-  val as: ActorSystem,
+)(
+  implicit val as: ActorSystem,
   val wd: Decoder[Work],
   sc: SqsAsyncClient,
-  val metrics: Metrics[Future])
-    extends PekkoWorker[SQSMessage, Work, Summary, MessageAction]
+  val metrics: Metrics[Future]
+) extends PekkoWorker[SQSMessage, Work, Summary, MessageAction]
     with Logging {
   override protected val metricsNamespace: String =
     config.metricsConfig.namespace
@@ -102,7 +102,8 @@ class PekkoSQSWorker[Work, Summary](
 
       case exc: SdkClientException
           if exc.getMessage.startsWith(
-            "Received an UnknownHostException when attempting to interact with a service") =>
+            "Received an UnknownHostException when attempting to interact with a service"
+          ) =>
         true
 
       case _: SocketTimeoutException => true

--- a/common/src/main/scala/weco/messaging/worker/Worker.scala
+++ b/common/src/main/scala/weco/messaging/worker/Worker.scala
@@ -67,8 +67,8 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
       case r @ TerminalFailure(e, _)  => error(r.toString, e)
     }
 
-  /** Records metrics about the work that's just been completed; in particular the
-    * outcome and the duration.
+  /** Records metrics about the work that's just been completed; in particular
+    * the outcome and the duration.
     */
   private def recordEnd(startTime: Instant, result: Result[_]): Future[Unit] = {
     val futures = Seq(

--- a/common/src/main/scala/weco/storage/Tags.scala
+++ b/common/src/main/scala/weco/storage/Tags.scala
@@ -11,7 +11,8 @@ trait Tags[Ident]
 
   protected def writeTags(
     id: Ident,
-    tags: Map[String, String]): Either[WriteError, Map[String, String]]
+    tags: Map[String, String]
+  ): Either[WriteError, Map[String, String]]
 
   def update(id: Ident)(updateFunction: UpdateFunction): UpdateEither = {
     debug(s"Tags on $id: updating tags")
@@ -29,19 +30,20 @@ trait Tags[Ident]
 
       _ = debug(s"Tags on $id: new tags      = $newTags")
 
-      result <- if (newTags == existingTags.identifiedT) {
-        debug(s"Tags on $id: no change, so skipping a write")
-        Right(existingTags)
-      } else {
-        debug(s"Tags on $id: tags have changed, so writing new tags")
-        writeTags(id = id, tags = newTags) match {
-          case Right(value) => Right(Identified(id, value))
-          case Left(err) => {
-            warn(s"Tags on $id: error when trying to write: $err")
-            Left(UpdateWriteError(err))
+      result <-
+        if (newTags == existingTags.identifiedT) {
+          debug(s"Tags on $id: no change, so skipping a write")
+          Right(existingTags)
+        } else {
+          debug(s"Tags on $id: tags have changed, so writing new tags")
+          writeTags(id = id, tags = newTags) match {
+            case Right(value) => Right(Identified(id, value))
+            case Left(err) => {
+              warn(s"Tags on $id: error when trying to write: $err")
+              Left(UpdateWriteError(err))
+            }
           }
         }
-      }
     } yield result
   }
 }

--- a/common/src/main/scala/weco/storage/listing/azure/AzureBlobLocationListing.scala
+++ b/common/src/main/scala/weco/storage/listing/azure/AzureBlobLocationListing.scala
@@ -8,19 +8,22 @@ class AzureBlobLocationListing(implicit itemListing: AzureBlobItemListing)
   override def list(prefix: AzureBlobLocationPrefix): ListingResult =
     itemListing
       .list(prefix)
-      .map { iterator =>
-        iterator.map { item =>
-          AzureBlobLocation(
-            container = prefix.container,
-            name = item.getName
-          )
-        }
+      .map {
+        iterator =>
+          iterator.map {
+            item =>
+              AzureBlobLocation(
+                container = prefix.container,
+                name = item.getName
+              )
+          }
       }
 }
 
 object AzureBlobLocationListing {
   def apply()(
-    implicit blobClient: BlobServiceClient): AzureBlobLocationListing = {
+    implicit blobClient: BlobServiceClient
+  ): AzureBlobLocationListing = {
     implicit val itemListing: AzureBlobItemListing =
       new AzureBlobItemListing()
 

--- a/common/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
+++ b/common/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
@@ -8,8 +8,9 @@ class S3ObjectLocationListing(implicit objectListing: S3ObjectListing)
   override def list(prefix: S3ObjectLocationPrefix): ListingResult =
     objectListing.list(prefix) match {
       case Right(result) =>
-        Right(result.map { s3Object =>
-          S3ObjectLocation(bucket = prefix.bucket, key = s3Object.key())
+        Right(result.map {
+          s3Object =>
+            S3ObjectLocation(bucket = prefix.bucket, key = s3Object.key())
         })
       case Left(err) => Left(err)
     }

--- a/common/src/main/scala/weco/storage/memory/MemoryTags.scala
+++ b/common/src/main/scala/weco/storage/memory/MemoryTags.scala
@@ -15,13 +15,15 @@ class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]])
           Left(
             DoesNotExistError(
               new Throwable(s"There is no entry for id=$id")
-            ))
+            )
+          )
       }
     }
 
   override protected def writeTags(
     id: Ident,
-    tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+    tags: Map[String, String]
+  ): Either[WriteError, Map[String, String]] =
     synchronized {
       debug(s"MemoryTags.put($id, $tags) before = $underlying")
       underlying = underlying ++ Map(id -> tags)

--- a/common/src/main/scala/weco/storage/s3/S3Tags.scala
+++ b/common/src/main/scala/weco/storage/s3/S3Tags.scala
@@ -20,7 +20,8 @@ class S3Tags(val maxRetries: Int = 3)(implicit s3Client: S3Client)
     with RetryableReadable[S3ObjectLocation, Map[String, String]] {
 
   override protected def retryableGetFunction(
-    location: S3ObjectLocation): Map[String, String] = {
+    location: S3ObjectLocation
+  ): Map[String, String] = {
     val request = GetObjectTaggingRequest
       .builder()
       .bucket(location.bucket)
@@ -32,8 +33,9 @@ class S3Tags(val maxRetries: Int = 3)(implicit s3Client: S3Client)
     response
       .tagSet()
       .asScala
-      .map { tag: Tag =>
-        tag.key() -> tag.value()
+      .map {
+        tag: Tag =>
+          tag.key() -> tag.value()
       }
       .toMap
   }
@@ -55,7 +57,8 @@ class S3Tags(val maxRetries: Int = 3)(implicit s3Client: S3Client)
 
   private def writeTagsOnce(
     location: S3ObjectLocation,
-    tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+    tags: Map[String, String]
+  ): Either[WriteError, Map[String, String]] = {
     val tagSet = tags
       .map { case (k, v) => Tag.builder().key(k).value(v).build() }
       .toSeq

--- a/common/src/main/scala/weco/storage/services/ByteRangeUtil.scala
+++ b/common/src/main/scala/weco/storage/services/ByteRangeUtil.scala
@@ -6,10 +6,11 @@ object ByteRangeUtil {
   // Partitions an object of size 1..length into ranges of size at most `bufferSize`
   def partition(length: Long, bufferSize: Long): Seq[ByteRange] =
     ((0L to length - 1) by bufferSize)
-      .map { offset: Long =>
-        if (offset + bufferSize > length)
-          OpenByteRange(offset)
-        else
-          ClosedByteRange(offset, bufferSize)
+      .map {
+        offset: Long =>
+          if (offset + bufferSize > length)
+            OpenByteRange(offset)
+          else
+            ClosedByteRange(offset, bufferSize)
       }
 }

--- a/common/src/main/scala/weco/storage/services/LargeStreamReader.scala
+++ b/common/src/main/scala/weco/storage/services/LargeStreamReader.scala
@@ -15,27 +15,27 @@ case class LargeStreamReaderCannotReadRange[Ident](
   err: ReadError
 ) extends Throwable(s"Unable to read range $range from $ident: ${err.e}")
 
-/** If you hold open an InputStream for a long time, eventually the network times out
-  * and you get an error.
+/** If you hold open an InputStream for a long time, eventually the network
+  * times out and you get an error.
   *
   * For example, from S3:
   *
-  *     com.amazonaws.SdkClientException: Data read has a different length than the expected:
-  *     dataLength=1234; expectedLength=56789
+  * com.amazonaws.SdkClientException: Data read has a different length than the
+  * expected: dataLength=1234; expectedLength=56789
   *
   * and Azure:
   *
+  * Could not create checksum: java.util.concurrent.TimeoutException: Did not
+  * observe any item or terminal signal within 60000ms in 'map' (and no fallback
+  * has been configured)
   *
-  *     Could not create checksum: java.util.concurrent.TimeoutException: Did not observe
-  *     any item or terminal signal within 60000ms in 'map' (and no fallback has been configured)
+  * To get around this issue, we read large streams in "chunks", making a
+  * separate request for each segment. The individual streams are then stitched
+  * back together in a SequenceInputStream, so to the caller it's presented as a
+  * single continuous stream.
   *
-  * To get around this issue, we read large streams in "chunks", making a separate
-  * request for each segment.  The individual streams are then stitched back together
-  * in a SequenceInputStream, so to the caller it's presented as a single continuous stream.
-  *
-  * We're hoping that making regular Get requests will keep the network "fresh", and
-  * reduce the risk of a timeout while we're reading the stream.
-  *
+  * We're hoping that making regular Get requests will keep the network "fresh",
+  * and reduce the risk of a timeout while we're reading the stream.
   */
 trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
   val bufferSize: Long
@@ -56,8 +56,9 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
       ranges = ByteRangeUtil.partition(size, bufferSize = bufferSize)
 
       individualStreams = ranges.iterator
-        .map { range =>
-          getBytes(ident, range = range)
+        .map {
+          range =>
+            getBytes(ident, range = range)
         }
         .map { new ByteArrayInputStream(_) }
         .asJavaEnumeration
@@ -91,7 +92,8 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
         throw new LargeStreamReaderCannotReadRange(
           ident = ident,
           range = range,
-          err = err)
+          err = err
+        )
     }
   }
 }

--- a/common/src/main/scala/weco/storage/services/s3/S3ObjectExists.scala
+++ b/common/src/main/scala/weco/storage/services/s3/S3ObjectExists.scala
@@ -25,7 +25,7 @@ class S3ObjectExists(s3Client: S3Client)
     } match {
       case Success(exists)                                  => Right(true)
       case Failure(e: S3Exception) if e.statusCode() == 404 => Right(false)
-      case Failure(e)                                       => Left(StoreReadError(e))
+      case Failure(e) => Left(StoreReadError(e))
     }
   }
 }

--- a/common/src/main/scala/weco/storage/services/s3/S3Uploader.scala
+++ b/common/src/main/scala/weco/storage/services/s3/S3Uploader.scala
@@ -31,11 +31,12 @@ class S3Uploader(implicit val s3Client: S3Client, s3Presigner: S3Presigner) {
     for {
       exists <- location.exists
 
-      _ <- if (!exists || !checkExists) {
-        s3StreamStore.put(location)(content)
-      } else {
-        Right(Identified(location, content))
-      }
+      _ <-
+        if (!exists || !checkExists) {
+          s3StreamStore.put(location)(content)
+        } else {
+          Right(Identified(location, content))
+        }
 
       url <- presignedUrls.getPresignedGetURL(location, expiryLength)
     } yield url

--- a/common/src/main/scala/weco/storage/store/azure/AzureStreamReadable.scala
+++ b/common/src/main/scala/weco/storage/store/azure/AzureStreamReadable.scala
@@ -11,7 +11,8 @@ trait AzureStreamReadable
   implicit val blobClient: BlobServiceClient
 
   override protected def retryableGetFunction(
-    location: AzureBlobLocation): InputStreamWithLength = {
+    location: AzureBlobLocation
+  ): InputStreamWithLength = {
     val blobInputStream = blobClient
       .getBlobContainerClient(location.container)
       .getBlobClient(location.name)
@@ -19,7 +20,7 @@ trait AzureStreamReadable
 
     new InputStreamWithLength(
       inputStream = blobInputStream,
-      length = blobInputStream.getProperties.getBlobSize,
+      length = blobInputStream.getProperties.getBlobSize
     )
   }
 

--- a/common/src/main/scala/weco/storage/store/azure/AzureStreamWritable.scala
+++ b/common/src/main/scala/weco/storage/store/azure/AzureStreamWritable.scala
@@ -16,8 +16,9 @@ trait AzureStreamWritable
   implicit val blobClient: BlobServiceClient
   val allowOverwrites: Boolean
 
-  override def put(location: AzureBlobLocation)(
-    inputStream: InputStreamWithLength): WriteEither =
+  override def put(
+    location: AzureBlobLocation
+  )(inputStream: InputStreamWithLength): WriteEither =
     Try {
       val individualBlobClient =
         blobClient
@@ -58,7 +59,7 @@ trait AzureStreamWritable
     } match {
       case Success(_) => Right(Identified(location, inputStream))
       case Failure(
-          exc: BlobStorageException
+            exc: BlobStorageException
           ) if exc.getErrorCode == BlobErrorCode.BLOB_ALREADY_EXISTS =>
         Left(OverwriteError(exc))
       case Failure(throwable) => Left(StoreWriteError(throwable))

--- a/common/src/main/scala/weco/storage/store/azure/AzureTypedStore.scala
+++ b/common/src/main/scala/weco/storage/store/azure/AzureTypedStore.scala
@@ -11,8 +11,10 @@ class AzureTypedStore[T](
 ) extends TypedStore[AzureBlobLocation, T]
 
 object AzureTypedStore {
-  def apply[T](implicit codec: Codec[T],
-               blobServiceClient: BlobServiceClient): AzureTypedStore[T] = {
+  def apply[T](
+    implicit codec: Codec[T],
+    blobServiceClient: BlobServiceClient
+  ): AzureTypedStore[T] = {
     implicit val streamStore: AzureStreamStore = new AzureStreamStore()
 
     new AzureTypedStore[T]()

--- a/common/src/main/scala/weco/storage_service/BagRegistrationNotification.scala
+++ b/common/src/main/scala/weco/storage_service/BagRegistrationNotification.scala
@@ -5,13 +5,12 @@ import weco.storage_service.bagit.models.ExternalIdentifier
 import weco.storage_service.storage.models.{StorageManifest, StorageSpace}
 
 /** This notification is sent by the storage service to notify another system
-  * (which may be entirely separate from the storage service, e.g. the catalogue)
-  * that a bag has been registered.  You should be able to use this information to
-  * get a bag from the external API.
+  * (which may be entirely separate from the storage service, e.g. the
+  * catalogue) that a bag has been registered. You should be able to use this
+  * information to get a bag from the external API.
   *
-  * We encode a version as a string (v1, v2, v3) rather than a number because that's
-  * what the external API expects.
-  *
+  * We encode a version as a string (v1, v2, v3) rather than a number because
+  * that's what the external API expects.
   */
 case class BagRegistrationNotification(
   space: StorageSpace,

--- a/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/BagFetch.scala
@@ -25,17 +25,15 @@ object BagFetch {
     *
     *   - Each line of a fetch file MUST be of the form
     *
-    *         url length filepath
+    * url length filepath
     *
-    *     `url` must be an absolute URI, and whitespace characters must be
-    *     percent encoded
-    *     `length` is the number of octets in the file, or "-" if unspecified
-    *     `filename` is the path to the file.  Line break characters (LR, CF, LRCF)
-    *     and *only* those characters must be percent-encoded.
+    * `url` must be an absolute URI, and whitespace characters must be percent
+    * encoded `length` is the number of octets in the file, or "-" if
+    * unspecified `filename` is the path to the file. Line break characters (LR,
+    * CF, LRCF) and *only* those characters must be percent-encoded.
     *
     *   - A fetch file must not list any tag files (everything in the fetch file
     *     must be in the payload; that is, in the data/ directory).
-    *
     */
   val FETCH_LINE_REGEX: Regex = new Regex(
     "(.*)[ \t]+(\\d*|-)[ \t]+(.*)",

--- a/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/ExternalIdentifier.scala
@@ -77,13 +77,15 @@ class ExternalIdentifier(val underlying: String)
   require(
     underlying.head.isLetterOrDigit && underlying.head <= 'z',
     failureMessage(
-      "External identifier must begin with a Basic Latin letter or digit")
+      "External identifier must begin with a Basic Latin letter or digit"
+    )
   )
 
   require(
     underlying.last.isLetterOrDigit && underlying.last <= 'z',
     failureMessage(
-      "External identifier must end with a Basic Latin letter or digit")
+      "External identifier must end with a Basic Latin letter or digit"
+    )
   )
 
   // We're super careful about the characters we allow in external identifiers,
@@ -110,7 +112,8 @@ class ExternalIdentifier(val underlying: String)
   require(
     underlying.matches(s"^$characterClass+$$"),
     failureMessage(
-      s"External identifier can only contain characters in the class $characterClass")
+      s"External identifier can only contain characters in the class $characterClass"
+    )
   )
 }
 

--- a/common/src/main/scala/weco/storage_service/bagit/models/UnreferencedFiles.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/models/UnreferencedFiles.scala
@@ -2,39 +2,31 @@ package weco.storage_service.bagit.models
 
 import weco.storage_service.checksum.ChecksumAlgorithms
 
-/** In a bag, we have payload files.  Those files are referred to by a payload
-  * manifest file, which is in turn referred to by a tag manifest file.  But how
+/** In a bag, we have payload files. Those files are referred to by a payload
+  * manifest file, which is in turn referred to by a tag manifest file. But how
   * do we know the tag manifest file is there?
   *
-  *      tagmanifest-sha256.txt
-  *        tag manifest file
-  *               |
-  *          (references)
-  *               |
-  *               v
-  *       manifest-sha256.txt
-  *      payload manifest file
-  *              |
-  *         (references)
-  *              |
-  *              v
-  *           b12345.jpg
-  *          payload file
+  * tagmanifest-sha256.txt tag manifest file
+  * \| (references)
+  * \| v manifest-sha256.txt payload manifest file
+  * \| (references)
+  * \| v b12345.jpg payload file
   *
-  * There's nothing in a bag that refers to the tag manifest file.  This is okay --
-  * the chain of checksums/references has to stop somewhere!
+  * There's nothing in a bag that refers to the tag manifest file. This is okay
+  * -- the chain of checksums/references has to stop somewhere!
   *
-  * This object records the filenames of all the tag manifests we might expect to see.
+  * This object records the filenames of all the tag manifests we might expect
+  * to see.
   *
-  * We only ignore tag manifests for checksum algorithms that the storage service knows
-  * how to use -- so we know it's reading and verifying all the checksums in these
-  * manifests.  If we start seeing bags with other manifests, we should consider adding
-  * support for those checksums.
-  *
+  * We only ignore tag manifests for checksum algorithms that the storage
+  * service knows how to use -- so we know it's reading and verifying all the
+  * checksums in these manifests. If we start seeing bags with other manifests,
+  * we should consider adding support for those checksums.
   */
 object UnreferencedFiles {
   val tagManifestFiles: Seq[String] =
-    ChecksumAlgorithms.algorithms.map { h =>
-      s"tagmanifest-${h.pathRepr}.txt"
+    ChecksumAlgorithms.algorithms.map {
+      h =>
+        s"tagmanifest-${h.pathRepr}.txt"
     }
 }

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagInfoParser.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagInfoParser.scala
@@ -69,25 +69,26 @@ object BagInfoParser extends Logging {
     metadata: BagInfoMetadata
   ): Try[ExternalIdentifier] =
     getSingleRequiredValue(metadata, label = "External-Identifier")
-      .flatMap { value =>
-        Try { ExternalIdentifier(value) } match {
-          case Success(externalIdentifier) => Success(externalIdentifier)
+      .flatMap {
+        value =>
+          Try { ExternalIdentifier(value) } match {
+            case Success(externalIdentifier) => Success(externalIdentifier)
 
-          // The error messages from the External-Identifier apply() method are typically
-          // of the form
-          //
-          //      requirement failed: External identifier cannot start with a slash
-          //
-          // That's an internal Scala detail, and not something we want to expose in an
-          // end-user facing message.
-          case Failure(e) =>
-            Failure(
-              new RuntimeException(
-                s"Unable to parse External-Identifier in bag-info.txt: ${e.getMessage
-                  .replaceAll("^requirement failed: ", "")}"
+            // The error messages from the External-Identifier apply() method are typically
+            // of the form
+            //
+            //      requirement failed: External identifier cannot start with a slash
+            //
+            // That's an internal Scala detail, and not something we want to expose in an
+            // end-user facing message.
+            case Failure(e) =>
+              Failure(
+                new RuntimeException(
+                  s"Unable to parse External-Identifier in bag-info.txt: ${e.getMessage
+                      .replaceAll("^requirement failed: ", "")}"
+                )
               )
-            )
-        }
+          }
       }
 
   // Matches the Payload-Oxum value, which is of the form "_OctetCount_._StreamCount_",
@@ -112,16 +113,17 @@ object BagInfoParser extends Logging {
 
   private def extractBaggingDate(metadata: BagInfoMetadata): Try[LocalDate] =
     getSingleRequiredValue(metadata, label = "Bagging-Date")
-      .flatMap { dateString =>
-        Try { LocalDate.parse(dateString) } match {
-          case Success(baggingDate) => Success(baggingDate)
-          case Failure(e) =>
-            Failure(
-              new RuntimeException(
-                s"Unable to parse Bagging-Date in bag-info.txt: ${e.getMessage}"
+      .flatMap {
+        dateString =>
+          Try { LocalDate.parse(dateString) } match {
+            case Success(baggingDate) => Success(baggingDate)
+            case Failure(e) =>
+              Failure(
+                new RuntimeException(
+                  s"Unable to parse Bagging-Date in bag-info.txt: ${e.getMessage}"
+                )
               )
-            )
-        }
+          }
       }
 
   private def extractSourceOrganisation(

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagManifestParser.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagManifestParser.scala
@@ -10,18 +10,17 @@ import scala.util.{Failure, Success, Try}
 
 /** Each line in a manifest file _manifest-algorithm.txt_ is of the form
   *
-  *     checksum filepath
+  * checksum filepath
   *
-  * where _checksum_ is a hex-encoded checksum for the file at _filepath_ created
-  * using _algorithm_ (e.g. md5, sha256).  The payload manifest lists every
-  * file in the data/ directory; the tag manifest lists every file in the
+  * where _checksum_ is a hex-encoded checksum for the file at _filepath_
+  * created using _algorithm_ (e.g. md5, sha256). The payload manifest lists
+  * every file in the data/ directory; the tag manifest lists every file in the
   * top directory.
   *
   * This class parses the contents of a manifest file.
   *
   * See https://tools.ietf.org/html/rfc8493#section-2.1.3
-  *     https://tools.ietf.org/html/rfc8493#section-2.2.1
-  *
+  * https://tools.ietf.org/html/rfc8493#section-2.2.1
   */
 object BagManifestParser {
 

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagMatcher.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagMatcher.scala
@@ -8,11 +8,10 @@ import weco.storage_service.bagit.models.{
   MatchedLocation
 }
 
-/** A bag can contain concrete files or refer to files stored elsewhere
-  * in the fetch file.  This object takes a list of files referenced in
-  * the manifest and the fetch entries (if any), and works out which
-  * are files held outside the main bag.
-  *
+/** A bag can contain concrete files or refer to files stored elsewhere in the
+  * fetch file. This object takes a list of files referenced in the manifest and
+  * the fetch entries (if any), and works out which are files held outside the
+  * main bag.
   */
 object BagMatcher {
 

--- a/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
+++ b/common/src/main/scala/weco/storage_service/bagit/services/BagReader.scala
@@ -156,15 +156,15 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
     * i.e. loads manifest-{algorithm}.txt or tagmanifest-{algorithm}.txt for
     * every supported checksum algorithm
     *
-    * Returns a list of checksum algorithms for which the manifest files are defined
-    * in the bag, and a list of entries correlated across the manifests.  These are
-    * returned separately because the list of entries may be empty (if there's nothing
-    * in the payload manifests).
+    * Returns a list of checksum algorithms for which the manifest files are
+    * defined in the bag, and a list of entries correlated across the manifests.
+    * These are returned separately because the list of entries may be empty (if
+    * there's nothing in the payload manifests).
     *
-    * This function is responsible for checking consistency within a type of manifest,
-    * e.g. does every manifest list the same filenames.  Callers may assume the manifest
-    * data is consistent, although we can't easily enforce that in the type system.
-    *
+    * This function is responsible for checking consistency within a type of
+    * manifest, e.g. does every manifest list the same filenames. Callers may
+    * assume the manifest data is consistent, although we can't easily enforce
+    * that in the type system.
     */
   private def loadManifestEntries(
     root: BagPrefix
@@ -222,13 +222,14 @@ trait BagReader[BagLocation <: Location, BagPrefix <: Prefix[BagLocation]] {
       }
 
       entries <- Try {
-        filenames.map { bagPath =>
-          bagPath -> MultiManifestChecksum(
-            md5 = md5.map(_(bagPath)),
-            sha1 = sha1.map(_(bagPath)),
-            sha256 = sha256.map(_(bagPath)),
-            sha512 = sha512.map(_(bagPath))
-          )
+        filenames.map {
+          bagPath =>
+            bagPath -> MultiManifestChecksum(
+              md5 = md5.map(_(bagPath)),
+              sha1 = sha1.map(_(bagPath)),
+              sha256 = sha256.map(_(bagPath)),
+              sha512 = sha512.map(_(bagPath))
+            )
         }.toMap
       } match {
         case Success(entries) => Right(entries)

--- a/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/ChecksumAlgorithm.scala
@@ -7,9 +7,9 @@ import org.apache.commons.codec.digest.MessageDigestAlgorithms
   *
   * It is not an exhaustive list, and we may add new checksums in the future.
   *
-  * As much as possible, we try to keep all the code related to checksum algorithms
-  * within this directory, to make it as easy as possible to add new algorithms later.
-  *
+  * As much as possible, we try to keep all the code related to checksum
+  * algorithms within this directory, to make it as easy as possible to add new
+  * algorithms later.
   */
 sealed trait ChecksumAlgorithm {
   val value: String

--- a/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MultiChecksum.scala
@@ -7,9 +7,8 @@ import java.security.MessageDigest
 import scala.util.Try
 
 /** This class records the actual checksum of a file in a bag, based on the
-  * contents of the file as read from storage.  It records checksums for every
+  * contents of the file as read from storage. It records checksums for every
   * checksum algorithm supported by the storage service.
-  *
   */
 case class MultiChecksum(
   md5: ChecksumValue,
@@ -25,9 +24,8 @@ case class MultiChecksum(
       case SHA512 => sha512
     }
 
-  /** Compare to the expected checksum information.  Does the actual file match the
-    * expected checksum, or are they different?
-    *
+  /** Compare to the expected checksum information. Does the actual file match
+    * the expected checksum, or are they different?
     */
   def compare(
     manifestChecksum: MultiManifestChecksum

--- a/common/src/main/scala/weco/storage_service/checksum/MultiManifestChecksum.scala
+++ b/common/src/main/scala/weco/storage_service/checksum/MultiManifestChecksum.scala
@@ -8,12 +8,12 @@ object MultiManifestChecksumException {
 }
 
 /** This class records the expected checksum of a file in a bag, based on the
-  * manifests provided in the bag.  It can record checksums for multiple checksum
+  * manifests provided in the bag. It can record checksums for multiple checksum
   * algorithms, e.g. a file in an MD5 manifest and a SHA-256 manifest.
   *
-  * Note: the omission of default values is deliberate here -- it's so that if we add
-  * a new checksum algorithm, we remember to add it everywhere we use MultiManifestChecksum.
-  *
+  * Note: the omission of default values is deliberate here -- it's so that if
+  * we add a new checksum algorithm, we remember to add it everywhere we use
+  * MultiManifestChecksum.
   */
 case class MultiManifestChecksum(
   md5: Option[ChecksumValue],
@@ -32,8 +32,9 @@ case class MultiManifestChecksum(
 
   def definedChecksums: Set[(ChecksumAlgorithm, ChecksumValue)] =
     definedAlgorithms
-      .map { algorithm =>
-        algorithm -> getValue(algorithm).get
+      .map {
+        algorithm =>
+          algorithm -> getValue(algorithm).get
       }
 
   def getValue(algorithm: ChecksumAlgorithm): Option[ChecksumValue] =

--- a/common/src/main/scala/weco/storage_service/ingests/models/Ingest.scala
+++ b/common/src/main/scala/weco/storage_service/ingests/models/Ingest.scala
@@ -32,16 +32,14 @@ case object Ingest {
   /** These are the four states of an ingest.
     *
     * When an ingest is created through the ingests API, it starts in the
-    * "accepted" state.  As soon as any activity happens, it moves to "processing".
+    * "accepted" state. As soon as any activity happens, it moves to
+    * "processing".
     *
     * These are the expected state transitions:
     *
-    *                                  +---> succeeded
-    *                                  |
-    *      accepted ---> processing ---+
-    *                                  |
-    *                                  +---> failed
-    *
+    * \+---> succeeded
+    * \| accepted ---> processing ---+
+    * \| +---> failed
     */
   sealed trait Status
   sealed trait Completed extends Status

--- a/common/src/main/scala/weco/storage_service/ingests/models/IngestEvent.scala
+++ b/common/src/main/scala/weco/storage_service/ingests/models/IngestEvent.scala
@@ -4,6 +4,5 @@ import java.time.Instant
 
 /** Records some processing activity on a bag, e.g. "started unpacking" or
   * "completed fixity checking".
-  *
   */
 case class IngestEvent(description: String, createdDate: Instant = Instant.now)

--- a/common/src/main/scala/weco/storage_service/ingests/models/IngestType.scala
+++ b/common/src/main/scala/weco/storage_service/ingests/models/IngestType.scala
@@ -6,12 +6,12 @@ import io.circe._
 
 import scala.util.{Failure, Success, Try}
 
-/** The ingest type tells you what sort of processing is occurring in this ingest.
+/** The ingest type tells you what sort of processing is occurring in this
+  * ingest.
   *
-  * Although currently we only support two values, it's designed to allow for future
-  * extension, for example creating ingests that delete a bag, or replicate it to
-  * a new location.
-  *
+  * Although currently we only support two values, it's designed to allow for
+  * future extension, for example creating ingests that delete a bag, or
+  * replicate it to a new location.
   */
 sealed trait IngestType { val id: String }
 

--- a/common/src/main/scala/weco/storage_service/ingests/models/IngestUpdate.scala
+++ b/common/src/main/scala/weco/storage_service/ingests/models/IngestUpdate.scala
@@ -3,38 +3,37 @@ package weco.storage_service.ingests.models
 import weco.storage_service.bagit.models.BagVersion
 
 /** These are the messages sent to the `ingests_tracker` by the individual
-  * worker services.  They send a message asynchronously whenever they start
-  * or stop a processing step, and the tracker updates the ingests database.
+  * worker services. They send a message asynchronously whenever they start or
+  * stop a processing step, and the tracker updates the ingests database.
   *
-  *         worker1 ---+
-  *                    |
-  *         worker2 ---+---> ingests tracker ---> ingests database
-  *                    |
-  *         worker3 ---+
-  *
+  * worker1 ---+
+  * \| worker2 ---+---> ingests tracker ---> ingests database
+  * \| worker3 ---+
   */
 sealed trait IngestUpdate {
   val id: IngestID
   val events: Seq[IngestEvent]
 }
 
-/** This is the most general update, that just records "some processing happened".
+/** This is the most general update, that just records "some processing
+  * happened".
   *
-  * This is sent by services that aren't using one of the more specific update types.
-  *
+  * This is sent by services that aren't using one of the more specific update
+  * types.
   */
 case class IngestEventUpdate(
   id: IngestID,
   events: Seq[IngestEvent]
 ) extends IngestUpdate
 
-/** This records a change in the status of the ingest.  This can be sent in two ways:
+/** This records a change in the status of the ingest. This can be sent in two
+  * ways:
   *
-  *     1)  when the bag register successfully stores a bag, it sends a "success"
-  *         status update so the ingests tracker can mark the ingest as succeeded
+  * 1) when the bag register successfully stores a bag, it sends a "success"
+  * status update so the ingests tracker can mark the ingest as succeeded
   *
-  *     2)  if there's an error while processing, any worker can send a "failed" update
-  *
+  * 2) if there's an error while processing, any worker can send a "failed"
+  * update
   */
 case class IngestStatusUpdate(
   id: IngestID,
@@ -44,10 +43,9 @@ case class IngestStatusUpdate(
 
 /** This is sent by the notifier when it completes a callback.
   *
-  * It includes the status of the callback, which is separate from the overall status
-  * of the ingest -- e.g. a bag may store successfully but we can't tell the original
-  * workflow system for some reason.
-  *
+  * It includes the status of the callback, which is separate from the overall
+  * status of the ingest -- e.g. a bag may store successfully but we can't tell
+  * the original workflow system for some reason.
   */
 case class IngestCallbackStatusUpdate(
   id: IngestID,
@@ -71,7 +69,6 @@ case object IngestCallbackStatusUpdate {
 /** This is sent by the bag versioner when it assigns a version to the bag.
   *
   * The version will be recorded as part of the ingest.
-  *
   */
 case class IngestVersionUpdate(
   id: IngestID,

--- a/common/src/main/scala/weco/storage_service/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/weco/storage_service/operation/services/OutgoingPublisher.scala
@@ -23,9 +23,8 @@ class OutgoingPublisher[Destination](
     result match {
       case IngestStepSucceeded(_, _) | IngestCompleted(_) =>
         debug(
-          msg =
-            "Ingest step succeeded/completed: " +
-              s"sending an outgoing message $outgoing"
+          msg = "Ingest step succeeded/completed: " +
+            s"sending an outgoing message $outgoing"
         )
 
         send(outgoing)

--- a/common/src/main/scala/weco/storage_service/storage/models/IngestStepResult.scala
+++ b/common/src/main/scala/weco/storage_service/storage/models/IngestStepResult.scala
@@ -80,7 +80,7 @@ trait IngestStepWorker[Work <: PipelinePayload, Summary] extends Runnable {
           MessageAction.changeMessageVisibility(
             message,
             visibilityTimeout.toSeconds.toInt
-        )
+          )
     }
 
   def run(): Future[Any] = worker.start

--- a/common/src/main/scala/weco/storage_service/storage/models/KnownReplicas.scala
+++ b/common/src/main/scala/weco/storage_service/storage/models/KnownReplicas.scala
@@ -1,11 +1,10 @@
 package weco.storage_service.storage.models
 
-/** This records a complete set of replicas which can be passed around
-  * between services.
+/** This records a complete set of replicas which can be passed around between
+  * services.
   *
-  * This is very similar to AggregatorInternalRecord, but it ensures that
-  * we do have a primary replica.
-  *
+  * This is very similar to AggregatorInternalRecord, but it ensures that we do
+  * have a primary replica.
   */
 case class KnownReplicas(
   location: PrimaryReplicaLocation,

--- a/display/src/main/scala/weco/storage_service/display/ingests/DisplayIngestType.scala
+++ b/display/src/main/scala/weco/storage_service/display/ingests/DisplayIngestType.scala
@@ -30,12 +30,12 @@ object DisplayIngestType {
         .apply(cursor)
         .map {
           DisplayIngestType(_)
-      }
+        }
 
   implicit val encoder: Encoder[DisplayIngestType] =
     (ingestType: DisplayIngestType) =>
       Json.obj(
         "id" -> Json.fromString(ingestType.id),
         "type" -> Json.fromString("IngestType")
-    )
+      )
 }

--- a/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/BagIndexer.scala
+++ b/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/BagIndexer.scala
@@ -9,8 +9,7 @@ import weco.storage_service.indexer.Indexer
 import scala.concurrent.ExecutionContext
 
 class BagIndexer(val client: ElasticClient, val index: Index)(
-  implicit
-  val ec: ExecutionContext,
+  implicit val ec: ExecutionContext,
   val encoder: Encoder[IndexedStorageManifest]
 ) extends Indexer[StorageManifest, IndexedStorageManifest] {
 

--- a/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/BagIndexerWorker.scala
+++ b/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/BagIndexerWorker.scala
@@ -29,8 +29,7 @@ class BagIndexerWorker(
   val indexer: Indexer[StorageManifest, IndexedStorageManifest],
   val bagTrackerClient: BagTrackerClient
 )(
-  implicit
-  val actorSystem: ActorSystem,
+  implicit val actorSystem: ActorSystem,
   val sqsAsync: SqsAsyncClient,
   val metrics: Metrics[Future],
   val decoder: Decoder[BagRegistrationNotification]

--- a/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/Main.scala
+++ b/indexer/bag_indexer/src/main/scala/weco/storage_service/indexer/bags/Main.scala
@@ -17,46 +17,47 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContextExecutor
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val executionContext: ExecutionContextExecutor =
-      actorSystem.dispatcher
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val index = Index(name = config.requireString("es.bags.index-name"))
-    info(s"Writing bags to index $index")
+      val index = Index(name = config.requireString("es.bags.index-name"))
+      info(s"Writing bags to index $index")
 
-    info(s"Creating the Elasticsearch index mapping")
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
+      info(s"Creating the Elasticsearch index mapping")
+      val elasticClient = ElasticBuilder.buildElasticClient(config)
 
-    val indexCreator = new ElasticsearchIndexCreator(
-      elasticClient = elasticClient,
-      index = index,
-      config = BagsIndexConfig.config
-    )
+      val indexCreator = new ElasticsearchIndexCreator(
+        elasticClient = elasticClient,
+        index = index,
+        config = BagsIndexConfig.config
+      )
 
-    indexCreator.create
+      indexCreator.create
 
-    val bagIndexer = new BagIndexer(
-      client = elasticClient,
-      index = index
-    )
+      val bagIndexer = new BagIndexer(
+        client = elasticClient,
+        index = index
+      )
 
-    val bagTrackerClient = new PekkoBagTrackerClient(
-      trackerHost = config.requireString("bags.tracker.host")
-    )
+      val bagTrackerClient = new PekkoBagTrackerClient(
+        trackerHost = config.requireString("bags.tracker.host")
+      )
 
-    new BagIndexerWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      indexer = bagIndexer,
-      bagTrackerClient = bagTrackerClient
-    )
+      new BagIndexerWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        indexer = bagIndexer,
+        bagTrackerClient = bagTrackerClient
+      )
   }
 }

--- a/indexer/common/src/main/scala/weco/storage_service/indexer/Indexer.scala
+++ b/indexer/common/src/main/scala/weco/storage_service/indexer/Indexer.scala
@@ -29,40 +29,44 @@ trait Indexer[Document, DisplayDocument] extends Logging {
   ): Future[Either[Seq[Document], Seq[Document]]] = {
     debug(s"Indexing documents: ${documents.map { id }.mkString(", ")}")
 
-    val inserts = documents.map { doc =>
-      indexInto(index)
-        .id { id(doc) }
-        .version(version(doc))
-        .versionType(ExternalGte)
-        .doc { toDisplay(doc) }
+    val inserts = documents.map {
+      doc =>
+        indexInto(index)
+          .id { id(doc) }
+          .version(version(doc))
+          .versionType(ExternalGte)
+          .doc { toDisplay(doc) }
     }
 
     client
       .execute { bulk(inserts) }
-      .map { response: Response[BulkResponse] =>
-        if (response.isError) {
-          error(s"Error from Elasticsearch: $response")
-          Left(documents)
-        } else {
-          val actualFailures =
-            response.result.failures
-              .filterNot { isVersionConflictException }
-
-          if (actualFailures.isEmpty) {
-            Right(documents)
+      .map {
+        response: Response[BulkResponse] =>
+          if (response.isError) {
+            error(s"Error from Elasticsearch: $response")
+            Left(documents)
           } else {
-            val failedIds = actualFailures.map { failure =>
-              error(s"Error indexing ${failure.id}: ${failure.error}")
-              failure.id
-            }.toSet
+            val actualFailures =
+              response.result.failures
+                .filterNot { isVersionConflictException }
 
-            val failedDocuments = documents.filter { doc =>
-              failedIds.contains(id(doc))
+            if (actualFailures.isEmpty) {
+              Right(documents)
+            } else {
+              val failedIds = actualFailures.map {
+                failure =>
+                  error(s"Error indexing ${failure.id}: ${failure.error}")
+                  failure.id
+              }.toSet
+
+              val failedDocuments = documents.filter {
+                doc =>
+                  failedIds.contains(id(doc))
+              }
+
+              Left(failedDocuments)
             }
-
-            Left(failedDocuments)
           }
-        }
       }
   }
 

--- a/indexer/common/src/main/scala/weco/storage_service/indexer/IndexerWorker.scala
+++ b/indexer/common/src/main/scala/weco/storage_service/indexer/IndexerWorker.scala
@@ -25,8 +25,7 @@ abstract class IndexerWorker[SourceT, T, IndexedT](
   config: PekkoSQSWorkerConfig,
   indexer: Indexer[T, IndexedT]
 )(
-  implicit
-  actorSystem: ActorSystem,
+  implicit actorSystem: ActorSystem,
   sqsAsync: SqsAsyncClient,
   metrics: Metrics[Future],
   decoder: Decoder[SourceT]
@@ -82,7 +81,7 @@ abstract class IndexerWorker[SourceT, T, IndexedT](
           MessageAction.changeMessageVisibility(
             message = message,
             visibilityTimeout = visibilityTimeoutInSeconds
-        )
+          )
     }
 
   def run(): Future[Any] = worker.start

--- a/indexer/common/src/main/scala/weco/storage_service/indexer/elasticsearch/StorageServiceIndexConfig.scala
+++ b/indexer/common/src/main/scala/weco/storage_service/indexer/elasticsearch/StorageServiceIndexConfig.scala
@@ -6,9 +6,8 @@ import com.sksamuel.elastic4s.fields.{ElasticField, KeywordField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import weco.elasticsearch.{ElasticFieldOps, IndexConfig}
 
-/** Helpers for creating Elasticsearch index definitions based on
-  * the display models.
-  *
+/** Helpers for creating Elasticsearch index definitions based on the display
+  * models.
   */
 trait StorageServiceIndexConfig extends ElasticFieldOps {
   protected val displayProviderMappingFields: Seq[KeywordField] =

--- a/indexer/file_finder/src/main/scala/weco/storage_service/indexer/file_finder/FileFinderWorker.scala
+++ b/indexer/file_finder/src/main/scala/weco/storage_service/indexer/file_finder/FileFinderWorker.scala
@@ -31,8 +31,7 @@ class FileFinderWorker(
   // a bit of overhead to be safe.
   batchSize: Int = 140
 )(
-  implicit
-  actorSystem: ActorSystem,
+  implicit actorSystem: ActorSystem,
   sqsAsync: SqsAsyncClient,
   mc: Metrics[Future],
   wd: Decoder[BagRegistrationNotification],
@@ -68,13 +67,15 @@ class FileFinderWorker(
           case Right(bag) =>
             Right(
               bag.manifest.files
-              // Only index files that are new in this version.
-              // e.g. if this is a V2 manifest, skip reindexing files from V1
-                .filter { f =>
-                  f.path.startsWith(s"${bag.version}/")
+                // Only index files that are new in this version.
+                // e.g. if this is a V2 manifest, skip reindexing files from V1
+                .filter {
+                  f =>
+                    f.path.startsWith(s"${bag.version}/")
                 }
-                .map { f =>
-                  FileContext(bag, f)
+                .map {
+                  f =>
+                    FileContext(bag, f)
                 }
             )
           case Left(BagTrackerUnknownGetError(e)) =>
@@ -105,14 +106,16 @@ class FileFinderWorker(
 
         val futures =
           batches
-            .map { b =>
-              Future.fromTry(messageSender.sendT(b))
+            .map {
+              b =>
+                Future.fromTry(messageSender.sendT(b))
             }
 
         Future
           .sequence(futures)
-          .map { _ =>
-            Successful(None)
+          .map {
+            _ =>
+              Successful(None)
           }
           .recover { case t: Throwable => RetryableFailure(t) }
 

--- a/indexer/file_finder/src/main/scala/weco/storage_service/indexer/file_finder/Main.scala
+++ b/indexer/file_finder/src/main/scala/weco/storage_service/indexer/file_finder/Main.scala
@@ -15,33 +15,34 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContextExecutor
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val executionContext: ExecutionContextExecutor =
-      actorSystem.dispatcher
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    implicit val sender: SNSMessageSender =
-      SNSBuilder.buildSNSMessageSender(
-        config,
-        subject = "Sent from the file finder"
+      implicit val sender: SNSMessageSender =
+        SNSBuilder.buildSNSMessageSender(
+          config,
+          subject = "Sent from the file finder"
+        )
+
+      val bagTrackerClient = new PekkoBagTrackerClient(
+        trackerHost = config.requireString("bags.tracker.host")
       )
 
-    val bagTrackerClient = new PekkoBagTrackerClient(
-      trackerHost = config.requireString("bags.tracker.host")
-    )
-
-    new FileFinderWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      bagTrackerClient = bagTrackerClient,
-      messageSender = sender
-    )
+      new FileFinderWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        bagTrackerClient = bagTrackerClient,
+        messageSender = sender
+      )
   }
 }

--- a/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/FileIndexer.scala
+++ b/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/FileIndexer.scala
@@ -9,8 +9,7 @@ import weco.storage_service.indexer.files.models.IndexedFile
 import scala.concurrent.ExecutionContext
 
 class FileIndexer(val client: ElasticClient, val index: Index)(
-  implicit
-  val ec: ExecutionContext,
+  implicit val ec: ExecutionContext,
   val encoder: Encoder[IndexedFile]
 ) extends Indexer[FileContext, IndexedFile] {
   override def id(file: FileContext): String = file.location.toString

--- a/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/FileIndexerWorker.scala
+++ b/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/FileIndexerWorker.scala
@@ -16,8 +16,7 @@ class FileIndexerWorker(
   config: PekkoSQSWorkerConfig,
   val indexer: Indexer[FileContext, IndexedFile]
 )(
-  implicit
-  val actorSystem: ActorSystem,
+  implicit val actorSystem: ActorSystem,
   val sqsAsync: SqsAsyncClient,
   val metrics: Metrics[Future],
   val decoder: Decoder[FileContext]

--- a/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/Main.scala
+++ b/indexer/file_indexer/src/main/scala/weco/storage_service/indexer/files/Main.scala
@@ -16,41 +16,42 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContextExecutor
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val executionContext: ExecutionContextExecutor =
-      actorSystem.dispatcher
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val index = Index(name = config.requireString("es.files.index-name"))
-    info(s"Writing files to index $index")
+      val index = Index(name = config.requireString("es.files.index-name"))
+      info(s"Writing files to index $index")
 
-    info(s"Creating the Elasticsearch index mapping")
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
+      info(s"Creating the Elasticsearch index mapping")
+      val elasticClient = ElasticBuilder.buildElasticClient(config)
 
-    val indexCreator = new ElasticsearchIndexCreator(
-      elasticClient = elasticClient,
-      index = index,
-      config = FilesIndexConfig.config
-    )
+      val indexCreator = new ElasticsearchIndexCreator(
+        elasticClient = elasticClient,
+        index = index,
+        config = FilesIndexConfig.config
+      )
 
-    indexCreator.create
+      indexCreator.create
 
-    val ingestIndexer = new FileIndexer(
-      client = elasticClient,
-      index = index
-    )
+      val ingestIndexer = new FileIndexer(
+        client = elasticClient,
+        index = index
+      )
 
-    new FileIndexerWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      indexer = ingestIndexer
-    )
+      new FileIndexerWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        indexer = ingestIndexer
+      )
   }
 }

--- a/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/IngestIndexer.scala
+++ b/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/IngestIndexer.scala
@@ -9,8 +9,7 @@ import weco.storage_service.indexer.ingests.models.IndexedIngest
 import scala.concurrent.ExecutionContext
 
 class IngestIndexer(val client: ElasticClient, val index: Index)(
-  implicit
-  val ec: ExecutionContext,
+  implicit val ec: ExecutionContext,
   val encoder: Encoder[IndexedIngest]
 ) extends Indexer[Ingest, IndexedIngest] {
 

--- a/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/IngestsIndexerWorker.scala
+++ b/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/IngestsIndexerWorker.scala
@@ -15,8 +15,7 @@ class IngestsIndexerWorker(
   config: PekkoSQSWorkerConfig,
   val indexer: Indexer[Ingest, IndexedIngest]
 )(
-  implicit
-  val actorSystem: ActorSystem,
+  implicit val actorSystem: ActorSystem,
   val sqsAsync: SqsAsyncClient,
   val metrics: Metrics[Future],
   val decoder: Decoder[Ingest]

--- a/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/Main.scala
+++ b/indexer/ingests_indexer/src/main/scala/weco/storage_service/indexer/ingests/Main.scala
@@ -16,41 +16,42 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContextExecutor
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val executionContext: ExecutionContextExecutor =
-      actorSystem.dispatcher
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val index = Index(name = config.requireString("es.ingests.index-name"))
-    info(s"Writing ingests to index $index")
+      val index = Index(name = config.requireString("es.ingests.index-name"))
+      info(s"Writing ingests to index $index")
 
-    info(s"Creating the Elasticsearch index mapping")
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
+      info(s"Creating the Elasticsearch index mapping")
+      val elasticClient = ElasticBuilder.buildElasticClient(config)
 
-    val indexCreator = new ElasticsearchIndexCreator(
-      elasticClient = elasticClient,
-      index = index,
-      config = IngestsIndexConfig.config
-    )
+      val indexCreator = new ElasticsearchIndexCreator(
+        elasticClient = elasticClient,
+        index = index,
+        config = IngestsIndexConfig.config
+      )
 
-    indexCreator.create
+      indexCreator.create
 
-    val ingestIndexer = new IngestIndexer(
-      client = elasticClient,
-      index = index
-    )
+      val ingestIndexer = new IngestIndexer(
+        client = elasticClient,
+        index = index
+      )
 
-    new IngestsIndexerWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      indexer = ingestIndexer
-    )
+      new IngestsIndexerWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        indexer = ingestIndexer
+      )
   }
 }

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/IngestsApi.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/IngestsApi.scala
@@ -13,13 +13,15 @@ trait IngestsApi[UnpackerDestination]
   val ingests: Route = concat(
     pathPrefix("ingests") {
       post {
-        entity(as[RequestDisplayIngest]) { ingest =>
-          withFuture { createIngest(ingest) }
+        entity(as[RequestDisplayIngest]) {
+          ingest =>
+            withFuture { createIngest(ingest) }
         }
-      } ~ path(JavaUUID) { id: UUID =>
-        get {
-          withFuture { lookupIngest(id) }
-        }
+      } ~ path(JavaUUID) {
+        id: UUID =>
+          get {
+            withFuture { lookupIngest(id) }
+          }
       }
     },
     pathPrefix("management") {

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/Main.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/Main.scala
@@ -21,51 +21,52 @@ import weco.http.monitoring.HttpMetrics
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    val httpServerConfigMain = HTTPServerBuilder.buildHTTPServerConfig(config)
+      val httpServerConfigMain = HTTPServerBuilder.buildHTTPServerConfig(config)
 
-    val ingestTrackerHost = Uri(
-      config.requireString("ingests.tracker.host")
-    )
-
-    val ingestCreatorInstance = new IngestCreator(
-      ingestTrackerClient = new PekkoIngestTrackerClient(ingestTrackerHost),
-      unpackerMessageSender = SNSBuilder.buildSNSMessageSender(
-        config,
-        namespace = "unpacker",
-        subject = "Sent from the ingests API"
+      val ingestTrackerHost = Uri(
+        config.requireString("ingests.tracker.host")
       )
-    )
 
-    val client = new PekkoIngestTrackerClient(ingestTrackerHost)
+      val ingestCreatorInstance = new IngestCreator(
+        ingestTrackerClient = new PekkoIngestTrackerClient(ingestTrackerHost),
+        unpackerMessageSender = SNSBuilder.buildSNSMessageSender(
+          config,
+          namespace = "unpacker",
+          subject = "Sent from the ingests API"
+        )
+      )
 
-    val router = new IngestsApi[SNSConfig] {
-      override val ingestTrackerClient: IngestTrackerClient = client
+      val client = new PekkoIngestTrackerClient(ingestTrackerHost)
 
-      override val ingestCreator = ingestCreatorInstance
+      val router = new IngestsApi[SNSConfig] {
+        override val ingestTrackerClient: IngestTrackerClient = client
 
-      override val httpServerConfig: HTTPServerConfig = httpServerConfigMain
+        override val ingestCreator = ingestCreatorInstance
 
-      override implicit val ec: ExecutionContext = actorSystem.dispatcher
-    }
+        override val httpServerConfig: HTTPServerConfig = httpServerConfigMain
 
-    val appName = "IngestsApi"
+        override implicit val ec: ExecutionContext = actorSystem.dispatcher
+      }
 
-    val httpMetrics = new HttpMetrics(
-      name = appName,
-      metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
-    )
+      val appName = "IngestsApi"
 
-    new WellcomeHttpApp(
-      routes = router.ingests,
-      httpMetrics = httpMetrics,
-      httpServerConfig = httpServerConfigMain,
-      appName = appName
-    )
+      val httpMetrics = new HttpMetrics(
+        name = appName,
+        metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
+      )
+
+      new WellcomeHttpApp(
+        routes = router.ingests,
+        httpMetrics = httpMetrics,
+        httpServerConfig = httpServerConfigMain,
+        appName = appName
+      )
   }
 }

--- a/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
+++ b/ingests/ingests_api/src/main/scala/weco/storage_service/ingests_api/responses/CreateIngest.scala
@@ -47,7 +47,7 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
     } else if (!StorageProvider.allowedValues.contains(providerId)) {
       createBadRequestResponse(
         s"""Unrecognised value at .sourceLocation.provider.id: got "$providerId", valid values are: ${StorageProvider.recognisedValues
-          .mkString(", ")}."""
+            .mkString(", ")}."""
       )
     }
     // In theory we might support unpacking bags uploaded to a different location
@@ -69,7 +69,8 @@ trait CreateIngest[UnpackerDestination] extends FutureDirectives with Logging {
     )
 
   private def convertToBadRequestResponse(
-    invalidArg: IllegalArgumentException): Future[Route] = {
+    invalidArg: IllegalArgumentException
+  ): Future[Route] = {
     def originalMessage = invalidArg.getMessage
     def prefix = "requirement failed: External identifier"
     def newMessage =

--- a/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/Main.scala
+++ b/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/Main.scala
@@ -15,41 +15,42 @@ import weco.storage.typesafe.DynamoBuilder
 import weco.typesafe.WellcomeTypesafeApp
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val dynamoClient: DynamoDbClient =
-      DynamoDbClient.builder().build()
+      implicit val dynamoClient: DynamoDbClient =
+        DynamoDbClient.builder().build()
 
-    val callbackNotificationService: CallbackNotificationService[SNSConfig] =
-      new CallbackNotificationService(
-        messageSender = SNSBuilder.buildSNSMessageSender(
-          config,
-          namespace = "callbackNotifications",
-          subject = "Sent from the ingests service"
+      val callbackNotificationService: CallbackNotificationService[SNSConfig] =
+        new CallbackNotificationService(
+          messageSender = SNSBuilder.buildSNSMessageSender(
+            config,
+            namespace = "callbackNotifications",
+            subject = "Sent from the ingests service"
+          )
         )
+
+      val updatedIngestsMessageSender: SNSMessageSender =
+        SNSBuilder.buildSNSMessageSender(
+          config,
+          namespace = "updatedIngests",
+          subject = "Updated ingests sent by the ingests monitor"
+        )
+
+      val messagingService = new MessagingService(
+        callbackNotificationService,
+        updatedIngestsMessageSender
       )
 
-    val updatedIngestsMessageSender: SNSMessageSender =
-      SNSBuilder.buildSNSMessageSender(
-        config,
-        namespace = "updatedIngests",
-        subject = "Updated ingests sent by the ingests monitor"
+      val ingestTracker: IngestTracker = new DynamoIngestTracker(
+        config = DynamoBuilder.buildDynamoConfig(config)
       )
 
-    val messagingService = new MessagingService(
-      callbackNotificationService,
-      updatedIngestsMessageSender
-    )
-
-    val ingestTracker: IngestTracker = new DynamoIngestTracker(
-      config = DynamoBuilder.buildDynamoConfig(config)
-    )
-
-    new IngestsTrackerApi[SNSConfig, SNSConfig](
-      ingestTracker,
-      messagingService
-    )()
+      new IngestsTrackerApi[SNSConfig, SNSConfig](
+        ingestTracker,
+        messagingService
+      )()
   }
 }

--- a/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/client/IngestTrackerClient.scala
+++ b/ingests/ingests_tracker/src/main/scala/weco/storage_service/ingests_tracker/client/IngestTrackerClient.scala
@@ -99,8 +99,7 @@ trait IngestTrackerClient extends Logging {
 }
 
 class PekkoIngestTrackerClient(trackerHost: Uri)(
-  implicit
-  as: ActorSystem,
+  implicit as: ActorSystem,
   val mat: Materializer,
   val ec: ExecutionContext
 ) extends IngestTrackerClient {

--- a/ingests/ingests_worker/src/main/scala/weco/storage_service/ingests_worker/Main.scala
+++ b/ingests/ingests_worker/src/main/scala/weco/storage_service/ingests_worker/Main.scala
@@ -15,25 +15,26 @@ import weco.typesafe.config.builders.EnrichConfig._
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val ingestTrackerHost = Uri(
-      config.requireString("ingests.tracker.host")
-    )
+      val ingestTrackerHost = Uri(
+        config.requireString("ingests.tracker.host")
+      )
 
-    new IngestsWorkerService(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      ingestTrackerClient = new PekkoIngestTrackerClient(ingestTrackerHost)
-    )
+      new IngestsWorkerService(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        ingestTrackerClient = new PekkoIngestTrackerClient(ingestTrackerHost)
+      )
   }
 }

--- a/notifier/src/main/scala/weco/storage_service/notifier/Main.scala
+++ b/notifier/src/main/scala/weco/storage_service/notifier/Main.scala
@@ -16,29 +16,30 @@ import weco.typesafe.WellcomeTypesafeApp
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val callbackUrlService = new CallbackUrlService(
-      client = new PekkoHttpClient()
-    )
-
-    new NotifierWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      callbackUrlService = callbackUrlService,
-      messageSender = SNSBuilder.buildSNSMessageSender(
-        config,
-        subject = "Sent from the notifier"
+      val callbackUrlService = new CallbackUrlService(
+        client = new PekkoHttpClient()
       )
-    )
+
+      new NotifierWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        callbackUrlService = callbackUrlService,
+        messageSender = SNSBuilder.buildSNSMessageSender(
+          config,
+          subject = "Sent from the notifier"
+        )
+      )
   }
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -2,9 +2,25 @@ import sbt.Keys._
 import sbt._
 
 object Common {
+  private val codeArtifactToken = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
+
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.16",
     organization := "weco",
+    externalResolvers := {
+      val codeArtifact = codeArtifactToken.map(_ =>
+        "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
+      ).toSeq
+      Seq(Resolver.defaultLocal) ++ codeArtifact ++ Seq(Resolver.DefaultMavenRepository)
+    },
+    credentials ++= codeArtifactToken.map(token =>
+      Credentials(
+        "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
+        "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",
+        "aws",
+        token
+      )
+    ).toSeq,
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -4,6 +4,11 @@ import sbt._
 object Common {
   private val codeArtifactToken = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
 
+  {
+    val mode = if (codeArtifactToken.isDefined) "CodeArtifact → Maven Central" else "Maven Central only"
+    println(s"[info] Dependency resolution: $mode")
+  }
+
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.16",
     organization := "weco",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,14 @@
 
-{
-  val mode = if (sys.env.get("CODEARTIFACT_AUTH_TOKEN").exists(_.nonEmpty))
-    "CodeArtifact → Maven Central"
-  else
-    "Maven Central only"
-  println(s"[info] Plugin resolution: $mode")
+resolvers ++= {
+  val token = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
+  if (token.isDefined) {
+    println("[info] Plugin resolution: CodeArtifact → Maven Central")
+    Seq("CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/")
+  } else {
+    println("[info] Plugin resolution: Maven Central only")
+    Seq.empty
+  }
 }
-
-resolvers ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
-  "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
-).toSeq
 
 credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>
   Credentials(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,14 @@
 
+sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).foreach { token =>
+  resolvers += "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
+  credentials += Credentials(
+    "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
+    "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",
+    "aws",
+    token
+  )
+}
+
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,16 @@
 
-sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).foreach { token =>
-  resolvers += "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
-  credentials += Credentials(
+resolvers ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
+  "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
+).toSeq
+
+credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>
+  Credentials(
     "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
     "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",
     "aws",
     token
   )
-}
+).toSeq
 
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
 
+// Note this are provided by the base image in CI so they don't need to be pulled each run
+// If you change these, make sure to update the base image as well (see the platform-infrastructure repository)
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,12 @@
 
+{
+  val mode = if (sys.env.get("CODEARTIFACT_AUTH_TOKEN").exists(_.nonEmpty))
+    "CodeArtifact → Maven Central"
+  else
+    "Maven Central only"
+  println(s"[info] Plugin resolution: $mode")
+}
+
 resolvers ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
   "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
 ).toSeq

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,24 +1,4 @@
 
-resolvers ++= {
-  val token = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
-  if (token.isDefined) {
-    println("[info] Plugin resolution: CodeArtifact + Maven Central")
-    Seq("CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/")
-  } else {
-    println("[info] Plugin resolution: Maven Central only")
-    Seq.empty
-  }
-}
-
-credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>
-  Credentials(
-    "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
-    "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",
-    "aws",
-    token
-  )
-).toSeq
-
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 resolvers ++= {
   val token = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
   if (token.isDefined) {
-    println("[info] Plugin resolution: CodeArtifact → Maven Central")
+    println("[info] Plugin resolution: CodeArtifact + Maven Central")
     Seq("CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/")
   } else {
     println("[info] Plugin resolution: Maven Central only")

--- a/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/Main.scala
+++ b/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/Main.scala
@@ -33,42 +33,44 @@ import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { config: Config =>
-    implicit val actorSystem: ActorSystem =
-      ActorSystem("main-actor-system")
+  runWithConfig {
+    config: Config =>
+      implicit val actorSystem: ActorSystem =
+        ActorSystem("main-actor-system")
 
-    implicit val ec: ExecutionContext =
-      actorSystem.dispatcher
+      implicit val ec: ExecutionContext =
+        actorSystem.dispatcher
 
-    implicit val metrics: CloudWatchMetrics =
-      CloudWatchBuilder.buildCloudWatchMetrics(config)
+      implicit val metrics: CloudWatchMetrics =
+        CloudWatchBuilder.buildCloudWatchMetrics(config)
 
-    implicit val sqsClient: SqsAsyncClient =
-      SqsAsyncClient.builder().build()
+      implicit val sqsClient: SqsAsyncClient =
+        SqsAsyncClient.builder().build()
 
-    val dynamoConfig: DynamoConfig =
-      DynamoBuilder.buildDynamoConfig(config, namespace = "replicas")
+      val dynamoConfig: DynamoConfig =
+        DynamoBuilder.buildDynamoConfig(config, namespace = "replicas")
 
-    implicit val dynamoClient: DynamoDbClient =
-      DynamoDbClient.builder().build()
+      implicit val dynamoClient: DynamoDbClient =
+        DynamoDbClient.builder().build()
 
-    val dynamoVersionedStore =
-      new DynamoSingleVersionStore[ReplicaPath, AggregatorInternalRecord](
-        dynamoConfig
+      val dynamoVersionedStore =
+        new DynamoSingleVersionStore[ReplicaPath, AggregatorInternalRecord](
+          dynamoConfig
+        )
+
+      val operationName =
+        OperationNameBuilder.getName(config)
+
+      new ReplicaAggregatorWorker(
+        config = PekkoSQSWorkerConfigBuilder.build(config),
+        replicaAggregator = new ReplicaAggregator(dynamoVersionedStore),
+        replicaCounter = new ReplicaCounter(
+          expectedReplicaCount =
+            config.requireInt("aggregator.expected_replica_count")
+        ),
+        ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
+        outgoingPublisher =
+          OutgoingPublisherBuilder.build(config, operationName)
       )
-
-    val operationName =
-      OperationNameBuilder.getName(config)
-
-    new ReplicaAggregatorWorker(
-      config = PekkoSQSWorkerConfigBuilder.build(config),
-      replicaAggregator = new ReplicaAggregator(dynamoVersionedStore),
-      replicaCounter = new ReplicaCounter(
-        expectedReplicaCount =
-          config.requireInt("aggregator.expected_replica_count")
-      ),
-      ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
-      outgoingPublisher = OutgoingPublisherBuilder.build(config, operationName)
-    )
   }
 }

--- a/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -6,8 +6,8 @@ import scala.util.Try
 
 /** This records all the replicas that the aggregator knows about.
   *
-  * The location may be None if the aggregator receives notice of
-  * a secondary replica first.
+  * The location may be None if the aggregator receives notice of a secondary
+  * replica first.
   */
 case class AggregatorInternalRecord(
   location: Option[PrimaryReplicaLocation],
@@ -70,7 +70,7 @@ object AggregatorInternalRecord {
     primaryLocation: PrimaryReplicaLocation
   ): Try[AggregatorInternalRecord] = Try {
     record.location match {
-      case None                                          => record.copy(location = Some(primaryLocation))
+      case None => record.copy(location = Some(primaryLocation))
       case Some(location) if location == primaryLocation => record
       case Some(location) =>
         throw new Exception(

--- a/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/weco/storage_service/replica_aggregator/services/ReplicaCounter.scala
@@ -17,7 +17,6 @@ case class NotEnoughReplicas(
   *
   *   - there's a primary replica
   *   - there are at least `expectedReplicas` overall
-  *
   */
 class ReplicaCounter(val expectedReplicaCount: Int) {
   def countReplicas(


### PR DESCRIPTION
## What does this change?

Configures sbt to resolve project dependencies through an AWS CodeArtifact Maven mirror when a `CODEARTIFACT_AUTH_TOKEN` environment variable is present. This reduces direct traffic to Maven Central and avoids HTTP 429 (rate limiting) errors that have been causing CI build failures when multiple Buildkite jobs run in parallel.

**Changes:**

- **`project/Common.scala`** — When `CODEARTIFACT_AUTH_TOKEN` is set, overrides the default resolver chain to: local → CodeArtifact → Maven Central. Adds credentials for the CodeArtifact repo. When the env var is absent, behaviour is unchanged (Maven Central only).
- **`builds/run_sbt_task_in_docker.sh`** — Passes the `CODEARTIFACT_AUTH_TOKEN` env var into the sbt Docker container.
- **`project/plugins.sbt`** — Updates `sbt-scalafmt` from `com.lucidchart:1.16` to `org.scalameta:2.5.2` (aligning with catalogue-pipeline). Adds comments noting plugins are pre-cached in the base image.

Note: CodeArtifact cannot proxy Ivy-style artifact paths used by sbt plugins, so plugin resolution still goes directly to Maven Central. To mitigate this, the sbt_wrapper base image is being updated to pre-cache common plugins (see linked platform-infrastructure PR).

### Works with

- wellcomecollection/buildkite-infrastructure#33 — Adds CodeArtifact permissions and auth token for CI runners
- wellcomecollection/platform-infrastructure#489 — Updates sbt_wrapper image to pre-cache plugins and make sbt version configurable

## How to test

1. Locally without the env var — builds should work exactly as before (Maven Central only):
   ```bash
   sbt compile
   ```
2. Locally with the env var — dependencies resolve via CodeArtifact:
   ```bash
   export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
     --domain wellcomecollection-maven-mirror --domain-owner 760097843905 \
     --region eu-west-1 --query authorizationToken --profile platform-developer --output text)
   sbt compile
   ```
   You should see `[info] Dependency resolution: CodeArtifact → Maven Central` in the output.
3. In CI — once the linked buildkite-infrastructure and platform-infrastructure PRs are merged, the token will be available automatically.

## How can we measure success?

- CI builds on the `scala` queue stop failing with `HTTP/1.1 429 Too Many Requests` errors from Maven Central.
- `sbt compile` and `sbt test` continue to pass in CI.

## Have we considered potential risks?

- **CodeArtifact outage**: If CodeArtifact is unavailable, sbt will fall through to Maven Central (it's in the resolver chain). Builds may be slower but won't fail.
- **Token expiry**: CodeArtifact tokens expire after 12 hours. The Buildkite environment hook generates a fresh token per build, so this shouldn't be an issue.
- **No env var set**: When `CODEARTIFACT_AUTH_TOKEN` is absent or empty, the code paths are completely skipped — zero behaviour change from `main`.
