### PR TITLE
stack_staging: upgrade AWS provider to 5.100, matching stack_prod

### DIFF
--- a/terraform/stack_staging/.terraform.lock.hcl
+++ b/terraform/stack_staging/.terraform.lock.hcl
@@ -2,23 +2,26 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.35.0"
+  version     = "5.100.0"
+  constraints = "~> 5.0"
   hashes = [
-    "h1:MKNFmhsOIirK7Qzr6TWkVaBcVGN81lCU0BPiaPOeQ8s=",
-    "zh:3a2a6f40db82d30ea8c5e3e251ca5e16b08e520570336e7e342be823df67e945",
-    "zh:420a23b69b412438a15b8b2e2c9aac2cf2e4976f990f117e4bf8f630692d3949",
-    "zh:4d8b887f6a71b38cff77ad14af9279528433e279eed702d96b81ea48e16e779c",
-    "zh:4edd41f8e1c7d29931608a7b01a7ae3d89d6f95ef5502cf8200f228a27917c40",
-    "zh:6337544e2ded5cf37b55a70aa6ce81c07fd444a2644ff3c5aad1d34680051bdc",
-    "zh:668faa3faaf2e0758bf319ea40d2304340f4a2dc2cd24460ddfa6ab66f71b802",
-    "zh:79ddc6d7c90e59fdf4a51e6ea822ba9495b1873d6a9d70daf2eeaf6fc4eb6ff3",
-    "zh:885822027faf1aa57787f980ead7c26e7d0e55b4040d926b65709b764f804513",
-    "zh:8c50a8f397b871388ff2e048f5eb280af107faa2e8926694f1ffd9f32a7a7cdf",
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2f5d2553df5573a060641f18ee7585587047c25ba73fd80617f59b5893d22b4",
-    "zh:c43833ae2a152213ee92eb5be7653f9493779eddbe0ce403ea49b5f1d87fd766",
-    "zh:dab01527a3a55b4f0f958af6f46313d775e27f9ad9d10bedbbfea4a35a06dc5f",
-    "zh:ed49c65620ec42718d681a7fc00c166c295ff2795db6cede2c690b83f9fb3e65",
-    "zh:f0a358c0ae1087c466d0fbcc3b4da886f33f881a145c3836ec43149878b86a1a",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }

--- a/terraform/stack_staging/terraform.tf
+++ b/terraform/stack_staging/terraform.tf
@@ -1,4 +1,11 @@
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
   backend "s3" {
     role_arn = "arn:aws:iam::975596993436:role/storage-developer"
 

--- a/terraform/stack_staging/terraform.tf
+++ b/terraform/stack_staging/terraform.tf
@@ -7,7 +7,9 @@ terraform {
   }
 
   backend "s3" {
-    role_arn = "arn:aws:iam::975596993436:role/storage-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::975596993436:role/storage-developer"
+    }
 
     bucket         = "wellcomecollection-storage-infra"
     key            = "terraform/storage-service/stack_staging.tfstate"
@@ -20,10 +22,12 @@ data "terraform_remote_state" "accounts_storage" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/aws-account-infrastructure/storage.tfstate"
-    region   = "eu-west-1"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/aws-account-infrastructure/storage.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -35,10 +39,12 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/monitoring.tfstate"
-    region   = "eu-west-1"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -46,7 +52,9 @@ data "terraform_remote_state" "app_clients" {
   backend = "s3"
 
   config = {
-    role_arn       = "arn:aws:iam::975596993436:role/storage-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::975596993436:role/storage-read_only"
+    }
     bucket         = "wellcomecollection-storage-infra"
     key            = "terraform/storage-service/app_clients.tfstate"
     dynamodb_table = "terraform-locktable"
@@ -58,10 +66,12 @@ data "terraform_remote_state" "archivematica_infra" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::299497370133:role/workflow-read_only"
-    bucket   = "wellcomecollection-workflow-infra"
-    key      = "terraform/archivematica-infra/critical_staging.tfstate"
-    region   = "eu-west-1"
+    assume_role = {
+      role_arn = "arn:aws:iam::299497370133:role/workflow-read_only"
+    }
+    bucket = "wellcomecollection-workflow-infra"
+    key    = "terraform/archivematica-infra/critical_staging.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -69,9 +79,11 @@ data "terraform_remote_state" "critical_staging" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::975596993436:role/storage-read_only"
-    bucket   = "wellcomecollection-storage-infra"
-    key      = "terraform/storage-service/critical_staging.tfstate"
-    region   = "eu-west-1"
+    assume_role = {
+      role_arn = "arn:aws:iam::975596993436:role/storage-read_only"
+    }
+    bucket = "wellcomecollection-storage-infra"
+    key    = "terraform/storage-service/critical_staging.tfstate"
+    region = "eu-west-1"
   }
 }


### PR DESCRIPTION
## What does this change?

stack_staging keeps its own lock file, so the provider upgrade in #1193 only cleared prod. Staging was still on hashicorp/aws 5.35.0 from January 2024, where a full plan proposes replacing around 150 inline IAM role policies: they were created in 2020 with an auto-recorded `name_prefix` that the config never sets, and old 5.x versions read that as drift. That makes any whole-stack apply unsafe. This is the follow-up flagged on #1193.

The lock moves to 5.100.0 with hashes for darwin_arm64, darwin_amd64 and linux_amd64, and the root gains a `~> 5.0` `required_providers` pin, since nothing else constrained the provider here.

## How to test

With terraform 1.6.5 and provider 5.100.0, a full `terraform plan` in `stack_staging` shows the replicator memory change from #1193 that has not been applied to staging yet (three task definition replacements, three service updates), plus two in-place lifecycle normalisations where the newer provider drops an empty `filter` block. No IAM policy churn.

## How can we measure success?

Staging can be applied as a whole stack again rather than resource by resource, and its plan matches prod's.

## Have we considered potential risks?

This has not been applied to staging yet, and applying it will also roll out the replicator memory increase from #1193. That is a rolling replacement of three services; in-flight messages return to the queue and the replicators are idempotent. The provider jump is the larger risk, which is why the full plan was read rather than a targeted one.
