### PR TITLE
Protect ECS tasks from scale-in while they process a message

### DIFF
--- a/common/src/main/scala/weco/messaging/worker/TaskScaleInProtection.scala
+++ b/common/src/main/scala/weco/messaging/worker/TaskScaleInProtection.scala
@@ -1,0 +1,99 @@
+package weco.messaging.worker
+
+import grizzled.slf4j.Logging
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.time.Duration
+
+/** Marks the running ECS task as protected from autoscaling scale-in while it
+  * has messages in flight, so a worker can't be killed mid-work.
+  *
+  * See
+  * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-scale-in-protection.html
+  */
+trait TaskScaleInProtection {
+  def acquire(): Unit
+  def release(): Unit
+}
+
+object NoOpTaskScaleInProtection extends TaskScaleInProtection {
+  override def acquire(): Unit = ()
+  override def release(): Unit = ()
+}
+
+class EcsTaskScaleInProtection(agentUri: String, expiresInMinutes: Int)
+    extends TaskScaleInProtection
+    with Logging {
+
+  private var inFlight = 0
+
+  // Only call the agent on 0<->1 transitions, to stay well inside the
+  // UpdateTaskProtection rate limits on busy queues.
+  override def acquire(): Unit = synchronized {
+    inFlight += 1
+    if (inFlight == 1) {
+      setProtection(enabled = true)
+    }
+  }
+
+  override def release(): Unit = synchronized {
+    inFlight -= 1
+    if (inFlight == 0) {
+      setProtection(enabled = false)
+    }
+  }
+
+  private lazy val client =
+    HttpClient
+      .newBuilder()
+      .connectTimeout(Duration.ofSeconds(2))
+      .build()
+
+  // Failures are logged and swallowed: losing protection is survivable,
+  // failing the message is not.
+  protected def setProtection(enabled: Boolean): Unit =
+    try {
+      val body =
+        if (enabled)
+          s"""{"ProtectionEnabled":true,"ExpiresInMinutes":$expiresInMinutes}"""
+        else
+          """{"ProtectionEnabled":false}"""
+
+      val request =
+        HttpRequest
+          .newBuilder()
+          .uri(URI.create(s"$agentUri/task-protection/v1/state"))
+          .timeout(Duration.ofSeconds(5))
+          .header("Content-Type", "application/json")
+          .PUT(HttpRequest.BodyPublishers.ofString(body))
+          .build()
+
+      val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+      if (response.statusCode() != 200) {
+        warn(
+          s"Failed to set task scale-in protection (enabled=$enabled): HTTP ${response
+              .statusCode()} ${response.body()}"
+        )
+      }
+    } catch {
+      case e: Exception =>
+        warn(s"Failed to set task scale-in protection (enabled=$enabled)", e)
+    }
+}
+
+object TaskScaleInProtection {
+  // Backstop expiry if a task dies without releasing; must outlast our
+  // slowest work, which is bag replication (5 hour visibility timeout).
+  private val expiresInMinutes = 330
+
+  /** Protection against the real ECS agent if we're running in ECS, otherwise
+    * (local, CI) a no-op.
+    */
+  lazy val default: TaskScaleInProtection =
+    sys.env.get("ECS_AGENT_URI") match {
+      case Some(uri) => new EcsTaskScaleInProtection(uri, expiresInMinutes)
+      case None      => NoOpTaskScaleInProtection
+    }
+}

--- a/common/src/main/scala/weco/messaging/worker/Worker.scala
+++ b/common/src/main/scala/weco/messaging/worker/Worker.scala
@@ -24,10 +24,15 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
   protected def isRetryable(t: Throwable): Boolean =
     false
 
+  protected val taskProtection: TaskScaleInProtection =
+    TaskScaleInProtection.default
+
   def process(message: Message): Future[Action] = {
     val startTime = Instant.now()
 
-    for {
+    taskProtection.acquire()
+
+    val processed = for {
       result <- parseMessage(message) match {
         case Failure(e) => Future.successful(TerminalFailure[Summary](e))
 
@@ -42,6 +47,10 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
 
       action = chooseAction(result)
     } yield action(message)
+
+    // Released before the action is applied downstream; workers are
+    // idempotent, so a scale-in in that window only costs a redelivery.
+    processed.andThen { case _ => taskProtection.release() }
   }
 
   private def chooseAction(result: Result[_]): Message => Action =

--- a/common/src/test/scala/weco/messaging/worker/TaskScaleInProtectionTest.scala
+++ b/common/src/test/scala/weco/messaging/worker/TaskScaleInProtectionTest.scala
@@ -1,0 +1,44 @@
+package weco.messaging.worker
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+
+class TaskScaleInProtectionTest extends AnyFunSpec with Matchers {
+
+  class RecordingProtection
+      extends EcsTaskScaleInProtection(
+        "http://localhost",
+        expiresInMinutes = 1
+      ) {
+    val calls: mutable.Buffer[Boolean] = mutable.Buffer.empty
+
+    override protected def setProtection(enabled: Boolean): Unit =
+      calls += enabled
+  }
+
+  it("protects on the first acquire and clears on the last release") {
+    val protection = new RecordingProtection()
+
+    protection.acquire()
+    protection.acquire()
+    protection.calls shouldBe Seq(true)
+
+    protection.release()
+    protection.calls shouldBe Seq(true)
+
+    protection.release()
+    protection.calls shouldBe Seq(true, false)
+  }
+
+  it("re-protects when work starts again after going idle") {
+    val protection = new RecordingProtection()
+
+    protection.acquire()
+    protection.release()
+    protection.acquire()
+
+    protection.calls shouldBe Seq(true, false, true)
+  }
+}

--- a/common/src/test/scala/weco/messaging/worker/WorkerTest.scala
+++ b/common/src/test/scala/weco/messaging/worker/WorkerTest.scala
@@ -27,20 +27,21 @@ class WorkerTest
     )
 
     val process = worker.process(message)
-    whenReady(process) { _ =>
-      worker.callCounter.calledCount shouldBe 1
+    whenReady(process) {
+      _ =>
+        worker.callCounter.calledCount shouldBe 1
 
-      assertMetricCount(
-        metrics = metrics,
-        metricName = s"$namespace/Successful",
-        expectedCount = 1
-      )
+        assertMetricCount(
+          metrics = metrics,
+          metricName = s"$namespace/Successful",
+          expectedCount = 1
+        )
 
-      assertMetricDurations(
-        metrics = metrics,
-        metricName = s"$namespace/Duration",
-        expectedNumberDurations = 1
-      )
+        assertMetricDurations(
+          metrics = metrics,
+          metricName = s"$namespace/Duration",
+          expectedNumberDurations = 1
+        )
     }
   }
 
@@ -55,20 +56,21 @@ class WorkerTest
     )
 
     val process = worker.process(message)
-    whenReady(process) { _ =>
-      worker.callCounter.calledCount shouldBe 0
+    whenReady(process) {
+      _ =>
+        worker.callCounter.calledCount shouldBe 0
 
-      assertMetricCount(
-        metrics = metrics,
-        metricName = s"$namespace/TerminalFailure",
-        expectedCount = 1
-      )
+        assertMetricCount(
+          metrics = metrics,
+          metricName = s"$namespace/TerminalFailure",
+          expectedCount = 1
+        )
 
-      assertMetricDurations(
-        metrics = metrics,
-        metricName = s"$namespace/Duration",
-        expectedNumberDurations = 1
-      )
+        assertMetricDurations(
+          metrics = metrics,
+          metricName = s"$namespace/Duration",
+          expectedNumberDurations = 1
+        )
     }
   }
 
@@ -84,12 +86,13 @@ class WorkerTest
 
     val process = worker.process(message)
 
-    whenReady(process) { _ =>
-      worker.callCounter.calledCount shouldBe 1
+    whenReady(process) {
+      _ =>
+        worker.callCounter.calledCount shouldBe 1
 
-      metrics.incrementedCounts shouldBe empty
+        metrics.incrementedCounts shouldBe empty
 
-      metrics.recordedValues shouldBe empty
+        metrics.recordedValues shouldBe empty
     }
   }
 
@@ -104,20 +107,21 @@ class WorkerTest
     )
 
     val process = worker.process(message)
-    whenReady(process) { _ =>
-      worker.callCounter.calledCount shouldBe 1
+    whenReady(process) {
+      _ =>
+        worker.callCounter.calledCount shouldBe 1
 
-      assertMetricCount(
-        metrics = metrics,
-        metricName = s"$namespace/TerminalFailure",
-        expectedCount = 1
-      )
+        assertMetricCount(
+          metrics = metrics,
+          metricName = s"$namespace/TerminalFailure",
+          expectedCount = 1
+        )
 
-      assertMetricDurations(
-        metrics = metrics,
-        metricName = s"$namespace/Duration",
-        expectedNumberDurations = 1
-      )
+        assertMetricDurations(
+          metrics = metrics,
+          metricName = s"$namespace/Duration",
+          expectedNumberDurations = 1
+        )
     }
   }
 
@@ -132,20 +136,69 @@ class WorkerTest
     )
 
     val process = worker.process(message)
-    whenReady(process) { _ =>
-      worker.callCounter.calledCount shouldBe 1
+    whenReady(process) {
+      _ =>
+        worker.callCounter.calledCount shouldBe 1
 
-      assertMetricCount(
-        metrics = metrics,
-        metricName = s"$namespace/RetryableFailure",
-        expectedCount = 1
-      )
+        assertMetricCount(
+          metrics = metrics,
+          metricName = s"$namespace/RetryableFailure",
+          expectedCount = 1
+        )
 
-      assertMetricDurations(
-        metrics = metrics,
-        metricName = s"$namespace/Duration",
-        expectedNumberDurations = 1
-      )
+        assertMetricDurations(
+          metrics = metrics,
+          metricName = s"$namespace/Duration",
+          expectedNumberDurations = 1
+        )
     }
+  }
+
+  it("holds scale-in protection for the duration of processing") {
+    implicit val metrics = new MemoryMetrics()
+
+    val protection = new CountingTaskProtection()
+
+    val worker = new MyWorker(
+      metricsNamespace = s"ns-${randomAlphanumeric()}",
+      testProcess = successful,
+      parseMessage = parseMessage(shouldFail = false)
+    ) {
+      override protected val taskProtection: TaskScaleInProtection = protection
+    }
+
+    whenReady(worker.process(message)) {
+      _ =>
+        protection.acquired shouldBe 1
+        protection.released shouldBe 1
+    }
+  }
+
+  it("releases scale-in protection when processing fails") {
+    implicit val metrics = new MemoryMetrics()
+
+    val protection = new CountingTaskProtection()
+
+    val worker = new MyWorker(
+      metricsNamespace = s"ns-${randomAlphanumeric()}",
+      testProcess = terminalFailure,
+      parseMessage = parseMessage(shouldFail = true)
+    ) {
+      override protected val taskProtection: TaskScaleInProtection = protection
+    }
+
+    whenReady(worker.process(message)) {
+      _ =>
+        protection.acquired shouldBe 1
+        protection.released shouldBe 1
+    }
+  }
+
+  class CountingTaskProtection extends TaskScaleInProtection {
+    var acquired = 0
+    var released = 0
+
+    override def acquire(): Unit = acquired += 1
+    override def release(): Unit = released += 1
   }
 }

--- a/terraform/modules/service/base/iam.tf
+++ b/terraform/modules/service/base/iam.tf
@@ -14,3 +14,22 @@ resource "aws_iam_role_policy" "bags_api_metrics" {
   role   = module.task_definition.task_role_name
   policy = data.aws_iam_policy_document.cloudwatch_putmetrics.json
 }
+
+# Lets a worker mark its task as protected while it holds a message,
+# so autoscaling scale-in can't kill it mid-work.
+data "aws_iam_policy_document" "ecs_task_protection" {
+  statement {
+    actions = [
+      "ecs:UpdateTaskProtection",
+    ]
+
+    resources = [
+      "${replace(var.cluster_arn, ":cluster/", ":task/")}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_task_protection" {
+  role   = module.task_definition.task_role_name
+  policy = data.aws_iam_policy_document.ecs_task_protection.json
+}


### PR DESCRIPTION
## What does this change?

Queue-driven scale-down can currently kill a task in the middle of its work. In-flight messages make the queue look empty, the low alarm scales the service in, and ECS is free to pick the busy task. Nothing is logged, and the message only comes back when the visibility timeout expires. Ingest `711eef99-8d63-4f3f-907a-6dcdc405d26d` has paid for this twice, at 5 hours a time, replicating the same bag to Azure (wellcomecollection/platform#6517).

The shared `Worker` now takes ECS task scale-in protection when a message starts processing and drops it when the last in-flight message finishes, so ECS will not choose a working task. This applies to every queue-driven worker in the storage service, not only the replicator. Task roles gain `ecs:UpdateTaskProtection` scoped to the cluster's tasks.

The replifier's existing 15 minute scaling cooldown was aimed at the same problem but only delays the decision, it does not tell ECS which task is busy. It is left in place.

<details><summary>Risk-relevant design choices</summary>

- The agent is only called on idle-to-busy and busy-to-idle transitions, which keeps a busy queue well inside the `UpdateTaskProtection` rate limits.
- Protection is requested with a 330 minute backstop expiry so it outlasts the replicator's 5 hour visibility timeout if a task dies without releasing.
- Calls go to the ECS container agent endpoint over `java.net.http`, so there are no new dependencies. With no `ECS_AGENT_URI` in the environment (tests, local runs) it is a no-op.
- Failures are logged and swallowed. Losing protection is survivable, failing a message is not.

</details>

## How to test

`sbt "project common" test` covers the new behaviour: `WorkerTest` asserts protection is held for the duration of processing and released when processing fails, and `TaskScaleInProtectionTest` covers the reference counting across idle and busy transitions. `terraform validate` passes in `stack_prod`.

Apply the IAM change before deploying the app so the permission is in place, though either order is safe.

## How can we measure success?

No repeat of the incident: replications complete rather than reappearing after a 5 hour visibility timeout, and `storage-prod_bag_replicator_*_dlq_not_empty` stays quiet. If the agent calls are going wrong we should see "Failed to set task scale-in protection" warnings in the service logs.

## Have we considered potential risks?

Protection is released just before the SQS delete action is applied downstream, so there is a small window where a scale-in could still take the task. Workers are idempotent, so the cost there is a redelivery rather than lost or duplicated work.

If the IAM policy is missing or the agent is unreachable, every call fails, gets logged, and we are back to today's behaviour rather than anything worse.
